### PR TITLE
fix: concepts->authentication typo

### DIFF
--- a/versioned_docs/version-1.0.0/04-concepts/07-authentication.md
+++ b/versioned_docs/version-1.0.0/04-concepts/07-authentication.md
@@ -8,7 +8,7 @@ The `Session` object provides information about the current user. A unique `user
 ```dart
 Future<void> myMethod(Session session) async {
   var userId = await session.auth.authenticatedUserId;
-  var isSignedIn = userId == null;
+  var isSignedIn = userId != null;
   ...
 }
 ```


### PR DESCRIPTION
Hi, thanks for creating Serverpod! I was looking through the documentation, and this seems like a typo.