### PR TITLE
fix: Update deprecated connectWebSocket to openStreamingConnection

### DIFF
--- a/docs/05-concepts/11-streams.md
+++ b/docs/05-concepts/11-streams.md
@@ -65,7 +65,7 @@ For a real-world example, check out [Pixorama](https://pixorama.live). It's a mu
 Before you can access streams in your client, you need to connect to the server's web socket. You do this by calling connectWebSocket on your client.
 
 ```dart
-await client.connectWebSocket();
+await client.openStreamingConnection();
 
 ```
 


### PR DESCRIPTION
As from v0.9.15 the `connectWebSocket` method has been deprecated in favour of `openStreamingConnection` but the docs still show the old method.