### PR TITLE
docs: Expand custom serialization section with examples.

### DIFF
--- a/docs/05-concepts/01-working-with-endpoints.md
+++ b/docs/05-concepts/01-working-with-endpoints.md
@@ -1,4 +1,5 @@
 # Working with endpoints
+
 Endpoints are the connection points to the server from the client. With Serverpod, you add methods to your endpoint, and your client code will be generated to make the method call. For the code to be generated, you need to place your endpoint in the endpoints directory of your server. Your endpoint should extend the `Endpoint` class. For methods to be generated, they need to return a typed `Future`, and its first argument should be a `Session` object. The `Session` object holds information about the call being made and provides access to the database.
 
 ```dart
@@ -31,7 +32,20 @@ var client = Client('http://localhost:8080/')
   ..connectivityMonitor = FlutterConnectivityMonitor();
 ```
 
-If you run the app in an Android emulator, change the address to `10.0.2.2` as this is the IP address of the host machine.
+If you run the app in an Android emulator, change the address to `10.0.2.2` as this is the IP address of the host machine. To access the server from a different device on the same network (such as a physical phone) replace `localhost` with the local ip address. You can find the local ip by running `ifconfig` (Linux/MacOS) or `ipconfig` (Windows).
+
+Make sure to also update the `publicHost` in the development config to make sure the server always servers the client with the correct path to assets etc.
+
+```yaml
+# your_project_server/config/development.yaml
+
+apiServer:
+  port: 8080
+  publicHost: localhost # Change this line
+  publicPort: 8080
+  publicScheme: http
+...
+```
 
 :::info
 
@@ -40,9 +54,11 @@ You can pass the `--watch` flag to `serverpod generate` to watch for changed fil
 :::
 
 ## Passing parameters
+
 There are some limitations to how endpoint methods can be implemented. Parameters and return types can be of type `bool`, `int`, `double`, `String`, `DateTime`, `ByteData`, or generated serializable objects (see next section). A typed `Future` should always be returned. Null safety is supported. When passing a `DateTime` it is always converted to UTC.
 
 You can also pass `List` and `Map` as parameters, but they need to be strictly typed with one of the types mentioned above. For `Map`, the keys must be non-nullable strings. E.g., `Map<String, int?>` is valid, but `Map<int, String>` is not.
 
 ## Return types
+
 The return type must be a typed Future. Supported return types are the same as for parameters.

--- a/docs/05-concepts/02-protocol.md
+++ b/docs/05-concepts/02-protocol.md
@@ -1,6 +1,6 @@
 # Working with protocols
 
-Protocols are the YAML files used to define serializable classes in Serverpod. They are used to generate Dart code for the server and client, and, if a database table is defined, to generate database code for the server.
+Protocols are the YAML files used to define serializable classes in Serverpod. They are used to generate Dart code for the server and client, and, if a database table is defined, to generate database code for the server. The yaml-files are located in the `protocol` directory in your server project.
 
 The files are analyzed by the Serverpod CLI when generating the project and creating migrations.
 
@@ -15,6 +15,8 @@ fields:
   foundedDate: DateTime?
   employees: List<Employee>
 ```
+
+Supported types are `bool`, `int`, `double`, `String`, `DateTime`, `ByteData`, and other serializable classes. You can also use `List`s and `Map`s of the supported types, just make sure to specify the types. Null safety is supported. The keys of `Map` must be non-nullable `String`s. Once your classes are generated, you can use them as parameters or return types to endpoint methods.
 
 ### Limiting visibility of a generated class
 

--- a/docs/05-concepts/02-protocol.md
+++ b/docs/05-concepts/02-protocol.md
@@ -1,6 +1,6 @@
 # Working with protocols
 
-Protocols are the YAML files used to define serializable classes in Serverpod. They are used to generate Dart code for the server and client, and, if a database table is defined, to generate database code for the server. The yaml-files are located in the `protocol` directory in your server project.
+Protocols are the YAML files used to define serializable classes in Serverpod. They are used to generate Dart code for the server and client, and, if a database table is defined, to generate database code for the server. The yaml-files are located in the `lib/src/protocol` directory in your server project.
 
 The files are analyzed by the Serverpod CLI when generating the project and creating migrations.
 


### PR DESCRIPTION
- Remove duplicated content.
- Add detailed info on how custom serializable objects work.

Resolves documentation comment on: https://github.com/serverpod/serverpod/issues/858

I have opted to not write about the fact that you are able to write `project:src/path/to/file.dart` in the generator.yaml file. While this is possible should we encourage people to copy-paste code between two projects manually?