### PR TITLE
refactor: Rename protocol to model.

### DIFF
--- a/docs/01-get-started.md
+++ b/docs/01-get-started.md
@@ -45,7 +45,7 @@ If you need to stop the Docker containers at some point, just run `docker compos
 :::
 
 ### Running the demo app
-Start the default demo app by changing directory into the Flutter package that was created and running `flutter run`.
+Start the default demo app by changing the directory into the Flutter package that was created and running `flutter run`.
 
 ```bash
 $ cd mypod/mypod_flutter
@@ -67,12 +67,12 @@ These are the most important directories:
 
 - `config`: These are the configuration files for your Serverpod. These include a `password.yaml` file with your passwords and configurations for running your server in development, staging, and production. By default, everything is correctly configured to run your server locally.
 - `lib/src/endpoints`: This is where you place your server's endpoints. When you add methods to an endpoint, Serverpod will generate the corresponding methods in your client.
-- `lib/src/protocol`: The entity definition files are placed here. The files define the classes you can pass through your API and how they relate to your database. Serverpod generates serializable objects from the entity definitions.
+- `lib/src/model`: The model definition files are placed here. The files define the classes you can pass through your API and how they relate to your database. Serverpod generates serializable objects from the model definitions.
 
-Both the `endpoints` and `protocol` directories contain sample files that give a quick idea of how they work. So this a great place to start learning.
+Both the `endpoints` and `model` directories contain sample files that give a quick idea of how they work. So this a great place to start learning.
 
 ### Generating code
-Whenever you change your code in either the `endpoints` or `protocol` directory, you will need to regenerate the classes managed by Serverpod. Do this by running `serverpod generate`.
+Whenever you change your code in either the `endpoints` or `model` directory, you will need to regenerate the classes managed by Serverpod. Do this by running `serverpod generate`.
 
 ```bash
 $ cd mypod/mypod_server
@@ -109,7 +109,7 @@ To learn more about endpoints, see the [Working with endpoints](concepts/working
 ### Serializing data
 Serverpod makes it easy to generate serializable classes that can be passed between server and client or used to communicate with the database.
 
-The structure for your serialized classes is defined in yaml-files in the `lib/src/protocol` directory. Run `serverpod generate` in the home directory of the server to build the Dart code for the classes and make them accessible to both the server and client.
+The structure for your serialized classes is defined in yaml-files in the `lib/src/model` directory. Run `serverpod generate` in the home directory of the server to build the Dart code for the classes and make them accessible to both the server and client.
 
 Here is a simple example of a yaml-file defining a serializable class:
 
@@ -176,9 +176,8 @@ To learn more about database migrations, see the [Migrations](concepts/database/
 
 :::
 
-
 ### Object database mapping
-Add a `table` key to your protocol file to add a mapping to the database. The value specified after the key sets the database table name. Here is the `Company` class from earlier with a database table mapping to a table called `company`:
+Add a `table` key to your model file to add a mapping to the database. The value specified after the key sets the database table name. Here is the `Company` class from earlier with a database table mapping to a table called `company`:
 
 ```yaml
 class: Company

--- a/docs/02-capabilities.md
+++ b/docs/02-capabilities.md
@@ -5,7 +5,7 @@ Serverpod is a complete, competent backend for Flutter. For the glossy sales pit
 Every design decision in Serverpod aims to minimize the amount of code you need to write and make it as readable as possible. Apart from being just a server, Serverpod incorporates many common tasks that are otherwise cumbersome to implement or require external services.
 
 ## Code generation
-Serverpod automatically generates your protocol and client-side code by analyzing your server. Calling a remote endpoint is as easy as making a local method call.
+Serverpod automatically generates your model and client-side code by analyzing your server. Calling a remote endpoint is as easy as making a local method call.
 
 ## World-class logging
 Stop struggling. You no longer need to search through endless server logs. Pinpoint exceptions and slow database queries in an easy-to-use user interface with a single click. _The visual interface is coming soon._

--- a/docs/03-tutorials/01-first-app.mdx
+++ b/docs/03-tutorials/01-first-app.mdx
@@ -45,7 +45,7 @@ $ dart bin/main.dart
 
 Serverpod comes with a convenient way to create serializable objects with the help of code generation. These objects can easily be sent back and forth between the server and the client. This is managed by defining our objects in a YAML file which the code generator then parses and generates the necessary code for.
 
-To define the structure of our Note object, we will create a YAML file called `note.yaml`. Navigate to the `lib/src/protocol` folder in your Serverpod project (`notes_server`). Create the file and add the following content:
+To define the structure of our Note object, we will create a YAML file called `note.yaml`. Navigate to the `lib/src/model` folder in your Serverpod project (`notes_server`). Create the file and add the following content:
 
 ```yaml
 ### Holds a note with a text written by the user.

--- a/docs/05-concepts/02-model.md
+++ b/docs/05-concepts/02-model.md
@@ -1,10 +1,10 @@
-# Working with protocols
+# Working with models
 
-Protocols are the YAML files used to define serializable classes in Serverpod. They are used to generate Dart code for the server and client, and, if a database table is defined, to generate database code for the server. The yaml-files are located in the `lib/src/protocol` directory in your server project.
+Models are the YAML files used to define serializable classes in Serverpod. They are used to generate Dart code for the server and client, and, if a database table is defined, to generate database code for the server. The yaml-files are located in the `lib/src/model` directory in your server project.
 
 The files are analyzed by the Serverpod CLI when generating the project and creating migrations.
 
-Run `serverpod generate` to generate dart classes from the protocol files.
+Run `serverpod generate` to generate dart classes from the model files.
 
 ## Class
 
@@ -141,7 +141,7 @@ extension MyExtension on MyClass {
 |[**type (fields)**](#class)|Denotes the data type for a field.                                                                             |✅|✅||
 |[**scope**](#limiting-visibility-of-a-generated-class)|Denotes the scope for a field.                                                      |✅|||
 |[**persist**](database/models)|A boolean flag if the data should be stored in the database or not can be negated with `!persist` |✅|||
-|[**relation**](database/relations/one-to-one)|Sets a relation between protocol files, requires a table name to be set.           |✅|||
+|[**relation**](database/relations/one-to-one)|Sets a relation between model files, requires a table name to be set.           |✅|||
 |[**name**](database/relations/one-to-one#bidirectional-representation)|Give a name to a relation to pair them.                   |✅|||
 |[**parent**](database/relations/one-to-one#one-side-defined)|Sets the parent table on a relation.                                |✅|||
 |[**field**](database/relations/one-to-one#custom-foreign-key-field)|A manual specified foreign key field.                        |✅|||

--- a/docs/05-concepts/04-exceptions.md
+++ b/docs/05-concepts/04-exceptions.md
@@ -10,7 +10,7 @@ Use the Serverpod Insights app to view your logs. It will show any failed or slo
 :::
 
 ## Serializable exceptions
-Serverpod allows adding data to an exception you throw on the server and extracting that data in the client. This is useful for passing error messages back to the client when a call fails. You use the same yaml-files to define the serializable exceptions as you would with any serializable entity (see [serialization](serialization) for details). The only difference is that you use the keyword `exception` instead of `class`.
+Serverpod allows adding data to an exception you throw on the server and extracting that data in the client. This is useful for passing error messages back to the client when a call fails. You use the same yaml-files to define the serializable exceptions as you would with any serializable model (see [serialization](serialization) for details). The only difference is that you use the keyword `exception` instead of `class`.
 
 ```yaml
 exception: MyException

--- a/docs/05-concepts/06-database/02-models.md
+++ b/docs/05-concepts/06-database/02-models.md
@@ -9,7 +9,7 @@ fields:
   name: String
 ```
 
-When the `table` keyword is added to the entity, the `serverpod generate` command will generate new methods for [interacting](crud) with the database. The addition of the keyword will also be detected by the `serverpod migrate` command that will generate the necessary [migrations](migrations) needed to update the database.
+When the `table` keyword is added to the model, the `serverpod generate` command will generate new methods for [interacting](crud) with the database. The addition of the keyword will also be detected by the `serverpod migrate` command that will generate the necessary [migrations](migrations) needed to update the database.
 
 :::info
 

--- a/docs/05-concepts/06-database/03-relations/01-one-to-one.md
+++ b/docs/05-concepts/06-database/03-relations/01-one-to-one.md
@@ -1,6 +1,6 @@
 # One-to-one
 
-One-to-one (1:1) relationships represent a unique association between two entities, there is at most one entity that can be connected on either side of the relation. This means we have to set a **unique index** on the foreign key in the database. Without the unique index the relation would be considered a one-to-many (1:n) relation.
+One-to-one (1:1) relationships represent a unique association between two entities, there is at most one model that can be connected on either side of the relation. This means we have to set a **unique index** on the foreign key in the database. Without the unique index the relation would be considered a one-to-many (1:n) relation.
 
 ## Defining the Relationship 
 In the following examples we show how to configure a 1:1 relationship between  `User` and `Address`.
@@ -54,7 +54,7 @@ indexes:
     unique: true
 ```
 
-In this example, we define an object relation field by annotating the `address` field with the `relation` keyword where the type is another entity, `Address?`. 
+In this example, we define an object relation field by annotating the `address` field with the `relation` keyword where the type is another model, `Address?`. 
 
 Serverpod then automatically generates a foreign key field (as seen in the last example) named `addressId` in the `User` class. This auto-generated field is non-nullable by default and is by default always named from the object relation field with the suffix `Id`.
 

--- a/docs/05-concepts/06-database/03-relations/02-one-to-many.md
+++ b/docs/05-concepts/06-database/03-relations/02-one-to-many.md
@@ -2,7 +2,7 @@
 
 One-to-many (1:n) relationships describes a scenario where multiple records from one table can relate to a single record in another table. An example of this would the relationship between a company and its employees, where multiple employees can be employed at a single company.
 
-The Serverpod framework provides versatility in establishing these relations. Depending on the specific use case and clarity desired, you can define the entity relationship either from the 'many' side (like `Employee`) or the 'one' side (like `Company`).
+The Serverpod framework provides versatility in establishing these relations. Depending on the specific use case and clarity desired, you can define the model relationship either from the 'many' side (like `Employee`) or the 'one' side (like `Company`).
 
 ## Defining the Relationship
 

--- a/docs/05-concepts/06-database/03-relations/03-many-to-many.md
+++ b/docs/05-concepts/06-database/03-relations/03-many-to-many.md
@@ -2,13 +2,13 @@
 
 Many-to-many (n:m) relationships describes a scenario where multiple records from a table can relate to multiple records in another table. An example of this would be the relationship between students and courses, where a single student can enroll in multiple courses, and a single course can have multiple students.
 
-The Serverpod framework supports these complex relationships by explicitly creating a separate entity, often called a junction or bridge table, that records the relation.
+The Serverpod framework supports these complex relationships by explicitly creating a separate model, often called a junction or bridge table, that records the relation.
 
 ## Overview
 
 In the context of many-to-many relationships, neither table contains a direct reference to the other. Instead, a separate table holds the foreign keys of both tables. This setup allows for a flexible and normalized approach to represent n:m relationships.
 
-Modeling the relationship between `Student` and `Course`, we would create an `Enrollment` entity as a junction table to store the relationship explicitly.
+Modeling the relationship between `Student` and `Course`, we would create an `Enrollment` model as a junction table to store the relationship explicitly.
 
 ## Defining the Relationship
 

--- a/docs/05-concepts/06-database/08-sort.md
+++ b/docs/05-concepts/06-database/08-sort.md
@@ -39,7 +39,7 @@ In the example we fetch all companies and sort them by their name in descending 
 
 ## Sort on relations
 
-To sort based on a field from a related entity, use the chained field reference.
+To sort based on a field from a related model, use the chained field reference.
 
 ```dart
 var companies = await Company.db.find(

--- a/docs/05-concepts/09-modules.md
+++ b/docs/05-concepts/09-modules.md
@@ -35,7 +35,7 @@ modules:
     nickname: auth
 ```
 
-Finally, you need to run `pub get` and `serverpod generate` from your server's directory (e.g., `mypod_server`) to add the module to your protocol.
+Finally, you need to run `pub get` and `serverpod generate` from your server's directory (e.g., `mypod_server`) to add the module to your projects deserializer.
 
 ```bash
 $ dart pub get
@@ -64,7 +64,7 @@ dependencies:
 
 ## Referencing a module
 
-It can be useful to reference serializable objects in other modules from the yaml-files in your protocol directory. You do this by adding the module prefix, followed by the nickname of the package. For instance, this is how you reference a serializable class in the auth package.
+It can be useful to reference serializable objects in other modules from the yaml-files in your model directory. You do this by adding the module prefix, followed by the nickname of the package. For instance, this is how you reference a serializable class in the auth package.
 
 ```yaml
 class: MyClass

--- a/docs/05-concepts/13-scheduling.md
+++ b/docs/05-concepts/13-scheduling.md
@@ -4,7 +4,7 @@ With Serverpod you can schedule future work with the `future call` feature. Futu
 
 A future call is guaranteed to only execute once across all your instances that are running, but execution failures are not handled automatically. It is your responsibility to schedule a new future call if the work was not able to complete.
 
-Creating a future call is simple, extend the `FutureCall` class and override the `invoke` method. The method takes two params the first being the [`Session`](sessions) object and the second being an optional SerializableEntity ([See protocol](protocol)).
+Creating a future call is simple, extend the `FutureCall` class and override the `invoke` method. The method takes two params the first being the [`Session`](sessions) object and the second being an optional SerializableEntity ([See model](model)).
 
 :::info
 The future call feature is not enabled when running Serverpod in serverless mode.
@@ -13,9 +13,9 @@ The future call feature is not enabled when running Serverpod in serverless mode
 ```dart
 import 'package:serverpod/serverpod.dart';
 
-class ExampleFutureCall extends FutureCall<MyProtocolEntity> {
+class ExampleFutureCall extends FutureCall<MyModelEntity> {
   @override
-  Future<void> invoke(Session session, MyProtocolEntity? object) async {
+  Future<void> invoke(Session session, MyModelEntity? object) async {
     // Do something interesting in the future here.
   }
 }
@@ -62,7 +62,7 @@ await session.serverpod.futureCallAtTime(
 ```
 
 :::note
-`data` is an object created from a class defined in one of your yaml files and has to be the same as the one you expect to receive in the future call. in the `protocol` folder, `data` may also be null if you don't need it.
+`data` is an object created from a class defined in one of your yaml files and has to be the same as the one you expect to receive in the future call. in the `model` folder, `data` may also be null if you don't need it.
 :::
 
 When registering a future call it is also possible to give it an `identifier` so that it can be referenced later. The same identifier can be applied to multiple future calls.

--- a/docs/07-cli.md
+++ b/docs/07-cli.md
@@ -18,7 +18,7 @@ $ serverpod <command> [arguments]
 
 - **[create](get-started)**: Establishes a new Serverpod project. When employing this command, designate the project name, ensuring it's in lowercase and devoid of special characters.
 
-- **[generate](concepts/protocol)**: Converts YAML files into appropriate code for the server and associated clients.
+- **[generate](concepts/model)**: Converts YAML files into appropriate code for the server and associated clients.
 
 - **[language-server](lsp)**: Activates the Serverpod LSP server, which interfaces via JSON-RPC-2. This is tailored for compatibility with a client integrated within an IDE.
 

--- a/docs/12-upgrading/01-upgrade-to-one-point-two.md
+++ b/docs/12-upgrading/01-upgrade-to-one-point-two.md
@@ -69,7 +69,7 @@ Example.count(...);
 Example.db.count(...);
 ```
 
-## Protocol changes
+## Model changes
 
 The keyword `api` has been deprecated and replaced with the new keyword `!persist` as a drop-in replacement.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ sidebar_position: -1
 ---
 
 # Installing Serverpod
-Serverpod is an open-source, scalable app server written in Dart for the Flutter community. Serverpod automatically generates your protocol and client-side code by analyzing your server. Calling a remote endpoint is as easy as making a local method call.
+Serverpod is an open-source, scalable app server written in Dart for the Flutter community. Serverpod automatically generates your model and client-side code by analyzing your server. Calling a remote endpoint is as easy as making a local method call.
 
 <div style={{ position : 'relative', paddingBottom : '56.25%', height : '0' }}><iframe style={{ position : 'absolute', top : '0', left : '0', width : '100%', height : '100%' }} width="560" height="315" src="https://www.youtube-nocookie.com/embed/QN6juNWW3js" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
 


### PR DESCRIPTION
# Changes

All references to `protocol` and `entity` change to `model`. (Except, SerializebleEntity)