### PR TITLE
ci: Introduce ci build for docs.

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,22 @@
+name: Docusaurus build
+on:
+    push:
+        branches:
+            - main
+    pull_request: 
+        branches: 
+            - main
+jobs:
+    test-build:
+        name: Test build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: 18
+                  cache: npm
+            - name: Install dependencies
+              run: npm ci 
+            - name: Build
+              run: npm run build

--- a/docs/07-cli.md
+++ b/docs/07-cli.md
@@ -18,7 +18,7 @@ $ serverpod <command> [arguments]
 
 - **[create](get-started)**: Establishes a new Serverpod project. When employing this command, designate the project name, ensuring it's in lowercase and devoid of special characters.
 
-- **[generate](concepts/models)**: Converts YAML files into appropriate code for the server and associated clients.
+- **[generate](concepts/model)**: Converts YAML files into appropriate code for the server and associated clients.
 
 - **[language-server](lsp)**: Activates the Serverpod LSP server, which interfaces via JSON-RPC-2. This is tailored for compatibility with a client integrated within an IDE.
 

--- a/docs/07-cli.md
+++ b/docs/07-cli.md
@@ -18,7 +18,7 @@ $ serverpod <command> [arguments]
 
 - **[create](get-started)**: Establishes a new Serverpod project. When employing this command, designate the project name, ensuring it's in lowercase and devoid of special characters.
 
-- **[generate](concepts/model)**: Converts YAML files into appropriate code for the server and associated clients.
+- **[generate](concepts/models)**: Converts YAML files into appropriate code for the server and associated clients.
 
 - **[language-server](lsp)**: Activates the Serverpod LSP server, which interfaces via JSON-RPC-2. This is tailored for compatibility with a client integrated within an IDE.
 


### PR DESCRIPTION
Does a simple build of the docs to ensure that it can be published once merged to main.

Also introduces a build on main once it is merged.

Guide followed: https://docusaurus.io/docs/deployment#triggering-deployment-with-github-actions