### PR TITLE
fix: Use new order by syntax for documentation.

### DIFF
--- a/docs/03-tutorials/01-first-app.mdx
+++ b/docs/03-tutorials/01-first-app.mdx
@@ -196,12 +196,12 @@ Future<List<Note>> getAllNotes(Session session) async {
   // and not in the order they were updated.
   return await Note.db.find(
     session,
-    orderBy: Note.t.id,
+    orderBy: (t) => t.id,
   );
 }
 ```
 
-In the code above, we use the `Note.db.find` method to retrieve all the notes from the database. By specifying `orderBy: Note.t.id`, we ensure that the notes are always returned in the same order based on the id column.
+In the code above, we use the `Note.db.find` method to retrieve all the notes from the database. By specifying `orderBy: (t) => t.id`, we ensure that the notes are always returned in the same order based on the id column.
 
 Putting it all together you end up with a `notes_endpoint.dart` file that looks like this:
 
@@ -216,7 +216,7 @@ class NotesEndpoint extends Endpoint {
     // and not in the order they were updated.
     return await Note.db.find(
       session,
-      orderBy: Note.t.id,
+      orderBy: (t) => t.id,
     );
   }
 

--- a/docs/05-concepts/06-database/07-relation-queries.md
+++ b/docs/05-concepts/06-database/07-relation-queries.md
@@ -138,7 +138,7 @@ var user = await Company.db.findById(
   employeeId,
   include: Company.include(
     employees: Employee.includeList(
-      orderBy: Employee.t.name,
+      orderBy: (t) => t.name,
     ),
   ),
 );

--- a/docs/05-concepts/06-database/09-pagination.md
+++ b/docs/05-concepts/06-database/09-pagination.md
@@ -40,7 +40,7 @@ int companiesPerPage = 10;
 
 var companies = await Company.db.find(
   session,
-  orderBy: Company.t.id,
+  orderBy: (t) => t.id,
   limit: companiesPerPage,
   offset: (page - 1) * companiesPerPage,
 );
@@ -73,7 +73,7 @@ int recordsPerPage = 10;
 
 var companies = await Company.db.find(
   session,
-  orderBy: Company.t.id,
+  orderBy: (t) => t.id,
   limit: recordsPerPage,
 );
 ```
@@ -87,7 +87,7 @@ int cursor = lastCompanyIdFromPreviousPage; // This is typically sent by the cli
 var companies = await Company.db.find(
   session,
   where: Company.t.id > cursor,
-  orderBy: Company.t.id,
+  orderBy: (t) => t.id,
   limit: recordsPerPage,
 );
 ```


### PR DESCRIPTION
Resolve the last order by syntax issues with the documentation.