### PR TITLE
fix: Add links to supported datatypes.

### DIFF
--- a/docs/05-concepts/02-models.md
+++ b/docs/05-concepts/02-models.md
@@ -16,7 +16,7 @@ fields:
   employees: List<Employee>
 ```
 
-Supported types are `bool`, `int`, `double`, `String`, `UuidValue`, `Duration`, `DateTime`, `ByteData`, and other serializable classes, exceptions and enums. You can also use `List`s and `Map`s of the supported types, just make sure to specify the types. Null safety is supported. Once your classes are generated, you can use them as parameters or return types to endpoint methods.
+Supported types are [bool](https://api.dart.dev/dart-core/bool-class.html), [int](https://api.dart.dev/dart-core/int-class.html), [double](https://api.dart.dev/dart-core/double-class.html), [String](https://api.dart.dev/dart-core/String-class.html), [Duration](https://api.dart.dev/dart-core/Duration-class.html), [DateTime](https://api.dart.dev/dart-core/DateTime-class.html), [ByteData](https://api.dart.dev/dart-typed_data/ByteData-class.html), [UuidValue](https://pub.dev/documentation/uuid/latest/uuid_value/UuidValue-class.html), and other serializable [classes](#class), [exceptions](#exception) and [enums](#enum). You can also use [List](https://api.dart.dev/dart-core/List-class.html)s and [Map](https://api.dart.dev/dart-core/Map-class.html)s of the supported types, just make sure to specify the types. Null safety is supported. Once your classes are generated, you can use them as parameters or return types to endpoint methods.
 
 ### Limiting visibility of a generated class
 


### PR DESCRIPTION
<img width="973" alt="Screenshot 2024-01-24 at 13 28 15" src="https://github.com/serverpod/serverpod_docs/assets/7395515/b3a08eb9-52d9-442b-92e2-d341b7f28bca">
<img width="1094" alt="Screenshot 2024-01-24 at 13 28 43" src="https://github.com/serverpod/serverpod_docs/assets/7395515/862ef1e9-5adf-4ff3-9d83-e95408331385">

Add links to the supported datatypes that open the dart API reference.