### PR TITLE
fix: Apply 1.2 documentation fixes.

### DIFF
--- a/docs/05-concepts/06-database/02-models.md
+++ b/docs/05-concepts/06-database/02-models.md
@@ -46,7 +46,7 @@ This creates a database relation between two tables and always keeps the data in
 class: Company
 table: company
 fields:
-  address: Address, relation
+  address: Address?, relation
 ```
 
 For a complete guide on how to work with relations see the [relation section](relations/one-to-one).

--- a/docs/05-concepts/06-database/03-relations/02-one-to-many.md
+++ b/docs/05-concepts/06-database/03-relations/02-one-to-many.md
@@ -18,7 +18,7 @@ class: Company
 table: company
 fields:
   name: String
-  employees: List<Employee>, relation
+  employees: List<Employee>?, relation
 
 # employee.yaml
 class: Employee
@@ -85,7 +85,7 @@ class: Company
 table: company
 fields:
   name: String
-  employees: List<Employee>, relation(name=company_employees)
+  employees: List<Employee>?, relation(name=company_employees)
 
 # employee.yaml
 class: Employee
@@ -103,7 +103,7 @@ class: Company
 table: company
 fields:
   name: String
-  employees: List<Employee>, relation(name=company_employees)
+  employees: List<Employee>?, relation(name=company_employees)
 
 # employee.yaml
 class: Employee

--- a/versioned_docs/version-1.2.0/01-get-started.md
+++ b/versioned_docs/version-1.2.0/01-get-started.md
@@ -73,12 +73,12 @@ These are the most important directories:
 
 - `config`: These are the configuration files for your Serverpod. These include a `password.yaml` file with your passwords and configurations for running your server in development, staging, and production. By default, everything is correctly configured to run your server locally.
 - `lib/src/endpoints`: This is where you place your server's endpoints. When you add methods to an endpoint, Serverpod will generate the corresponding methods in your client.
-- `lib/src/model`: The model definition files are placed here. The files define the classes you can pass through your API and how they relate to your database. Serverpod generates serializable objects from the model definitions.
+- `lib/src/models`: The model definition files are placed here. The files define the classes you can pass through your API and how they relate to your database. Serverpod generates serializable objects from the model definitions.
 
-Both the `endpoints` and `model` directories contain sample files that give a quick idea of how they work. So this a great place to start learning.
+Both the `endpoints` and `models` directories contain sample files that give a quick idea of how they work. So this a great place to start learning.
 
 ### Generating code
-Whenever you change your code in either the `endpoints` or `model` directory, you will need to regenerate the classes managed by Serverpod. Do this by running `serverpod generate`.
+Whenever you change your code in either the `endpoints` or `models` directory, you will need to regenerate the classes managed by Serverpod. Do this by running `serverpod generate`.
 
 ```bash
 $ cd mypod/mypod_server
@@ -115,7 +115,7 @@ To learn more about endpoints, see the [Working with endpoints](concepts/working
 ### Serializing data
 Serverpod makes it easy to generate serializable classes that can be passed between server and client or used to communicate with the database.
 
-The structure for your serialized classes is defined in yaml-files in the `lib/src/model` directory. Run `serverpod generate` in the home directory of the server to build the Dart code for the classes and make them accessible to both the server and client.
+The structure for your serialized classes is defined in yaml-files in the `lib/src/models` directory. Run `serverpod generate` in the home directory of the server to build the Dart code for the classes and make them accessible to both the server and client.
 
 Here is a simple example of a yaml-file defining a serializable class:
 
@@ -212,7 +212,7 @@ myCompany = await Company.db.insertRow(session, myCompany);
 The method returns the inserted object with its `id` field set from the database.
 
 ### Reading from database
-Retrieving a single row from the database can be done by calling the static `db.findById` method and providing the `id` of the row.
+Retrieving a single row from the database can done by calling the static `db.findById` method and providing the `id` of the row.
 
 ```dart
 var myCompany = await Company.db.findById(session, companyId);
@@ -237,6 +237,6 @@ Working with a database is an extensive subject. Learn more in the [Database](co
 :::
 
 ## Where to go next
-You should now have a basic understanding of how Serverpod works. The different topics are described in more details in the _Concepts_ section of the documentation. If you are unfamiliar with server-side development, a good starting place for learning is to do the [Build your first app](tutorials/first-app) tutorial. There are also many good video tutorials linked in the _Tutorials_ section.
+You should now have a basic understanding of how Serverpod works. The different topics are described in more detail in the _Concepts_ section of the documentation. If you are unfamiliar with server-side development, a good staring place for learning is to do the [Build your first app](tutorials/first-app) tutorial. There are also many good video tutorials linked in the _Tutorials_ section.
 
 If you get stuck, never be afraid to ask questions in our [community on Github](https://github.com/serverpod/serverpod/discussions). The Serverpod team is very active there, and many questions are also answered by other developers in the community.

--- a/versioned_docs/version-1.2.0/03-tutorials/01-first-app.mdx
+++ b/versioned_docs/version-1.2.0/03-tutorials/01-first-app.mdx
@@ -50,7 +50,7 @@ Make sure you have Docker running on your machine before executing these command
 
 Serverpod comes with a convenient way to create serializable objects with the help of code generation. These objects can easily be sent back and forth between the server and the client. This is managed by defining our objects in a YAML file which the code generator then parses and generates the necessary code for.
 
-To define the structure of our Note object, we will create a YAML file called `note.yaml` inside the `lib/src/model` directory in your Serverpod project (`notes_server`). Add the following content in `note.yaml`:
+To define the structure of our Note object, we will create a YAML file called `note.yaml` inside the `lib/src/models` directory in your Serverpod project (`notes_server`). Add the following content in `note.yaml`:
 
 ```yaml
 ### Holds a note with a text written by the user.

--- a/versioned_docs/version-1.2.0/05-concepts/02-models.md
+++ b/versioned_docs/version-1.2.0/05-concepts/02-models.md
@@ -16,7 +16,7 @@ fields:
   employees: List<Employee>
 ```
 
-Supported types are `bool`, `int`, `double`, `String`, `UuidValue`, `Duration`, `DateTime`, `ByteData`, and other serializable classes, exceptions and enums. You can also use `List`s and `Map`s of the supported types, just make sure to specify the types. Null safety is supported. The keys of `Map` must be non-nullable `String`s. Once your classes are generated, you can use them as parameters or return types to endpoint methods.
+Supported types are [bool](https://api.dart.dev/dart-core/bool-class.html), [int](https://api.dart.dev/dart-core/int-class.html), [double](https://api.dart.dev/dart-core/double-class.html), [String](https://api.dart.dev/dart-core/String-class.html), [Duration](https://api.dart.dev/dart-core/Duration-class.html), [DateTime](https://api.dart.dev/dart-core/DateTime-class.html), [ByteData](https://api.dart.dev/dart-typed_data/ByteData-class.html), [UuidValue](https://pub.dev/documentation/uuid/latest/uuid_value/UuidValue-class.html), and other serializable [classes](#class), [exceptions](#exception) and [enums](#enum). You can also use [List](https://api.dart.dev/dart-core/List-class.html)s and [Map](https://api.dart.dev/dart-core/Map-class.html)s of the supported types, just make sure to specify the types. Null safety is supported. Once your classes are generated, you can use them as parameters or return types to endpoint methods.
 
 ### Limiting visibility of a generated class
 

--- a/versioned_docs/version-1.2.0/05-concepts/06-database/02-models.md
+++ b/versioned_docs/version-1.2.0/05-concepts/06-database/02-models.md
@@ -29,7 +29,7 @@ fields:
 All fields are persisted by default and have an implicit `persist` set on each field.
 
 ### Data representation
-Storing a field with a primitive / core dart type will be handled as the their respective type. But if you use a complex type, such as another model, a `List` or a `Map` these will be stored as a `json` object in the database.
+Storing a field with a primitive / core dart type will be handled as its respective type. However, if you use a complex type, such as another model, a `List`, or a `Map`, these will be stored as a `json` object in the database.
 
 ```yaml
 class: Company
@@ -46,7 +46,7 @@ This creates a database relation between two tables and always keeps the data in
 class: Company
 table: company
 fields:
-  address: Address, relation
+  address: Address?, relation
 ```
 
 For a complete guide on how to work with relations see the [relation section](relations/one-to-one).

--- a/versioned_docs/version-1.2.0/05-concepts/06-database/03-relations/02-one-to-many.md
+++ b/versioned_docs/version-1.2.0/05-concepts/06-database/03-relations/02-one-to-many.md
@@ -18,7 +18,7 @@ class: Company
 table: company
 fields:
   name: String
-  employees: List<Employee>, relation
+  employees: List<Employee>?, relation
 
 # employee.yaml
 class: Employee
@@ -85,7 +85,7 @@ class: Company
 table: company
 fields:
   name: String
-  employees: List<Employee>, relation(name=company_employees)
+  employees: List<Employee>?, relation(name=company_employees)
 
 # employee.yaml
 class: Employee
@@ -103,7 +103,7 @@ class: Company
 table: company
 fields:
   name: String
-  employees: List<Employee>, relation(name=company_employees)
+  employees: List<Employee>?, relation(name=company_employees)
 
 # employee.yaml
 class: Employee

--- a/versioned_docs/version-1.2.0/05-concepts/06-database/05-crud.md
+++ b/versioned_docs/version-1.2.0/05-concepts/06-database/05-crud.md
@@ -13,7 +13,7 @@ fields:
 
 :::note
 
-You can also access the database methods through the session object under the field `dbNext`. However, this is typically only recommended if you want to want to do custom queries where you explicitly type out your SQL queries. The `db` field on `Session` contains legacy methods that are included for compatibility. In version 2 of Serverpod, the old legacy methods will be removed and `db` will be replaced by `dbNext`.
+You can also access the database methods through the session object under the field `dbNext`. However, this is typically only recommended if you want to do custom queries where you explicitly type out your SQL queries. The `db` field on `Session` contains legacy methods that are included for compatibility. In version 2 of Serverpod, the old legacy methods will be removed and `db` will be replaced by `dbNext`.
 
 :::
 


### PR DESCRIPTION
## Changes
- Updates documentation to always use nullable object field relation in examples.
- Updates the deployed 1.2 documentation version with all fixes.

Closes: https://github.com/serverpod/serverpod/issues/1863

