### PR TITLE
Fix small mistake in 01-one-to-one.md

### DIFF
--- a/versioned_docs/version-1.2.0/05-concepts/06-database/03-relations/01-one-to-one.md
+++ b/versioned_docs/version-1.2.0/05-concepts/06-database/03-relations/01-one-to-one.md
@@ -62,7 +62,7 @@ The object field, in this case `address`, must always be nullable (as indicated 
 
 An object relation field gives a big advantage when fetching data. Utilizing [relational queries](../relation-queries) enables filtering based on relation attributes or optionally including the related data in the result.
 
-No `parent` keyword is needed here because the relational table is inferred from the type on the field.
+No `parent` keyword is not needed here because the relational table is inferred from the type on the field.
 
 ### Optional relation
 


### PR DESCRIPTION
I believe this is a small mistake in docs. It's talking about an object field that does **not** need a parent keyword, and the example doesn't have a parent keyword.