### PR TITLE
Updated field reference mismatch from addressId to address in the - W…

### DIFF
--- a/docs/05-concepts/06-database/03-relations/01-one-to-one.md
+++ b/docs/05-concepts/06-database/03-relations/01-one-to-one.md
@@ -50,7 +50,7 @@ fields:
   address: Address?, relation // Object relation field
 indexes:
   user_address_unique_idx:
-    fields: addressId
+    fields: address
     unique: true
 ```
 


### PR DESCRIPTION
The current documentation for one to one relation when using an Object has a mismatch for the address field been indexed:

```yaml
# address.yaml
class: Address
table: address
fields:
  street: String

# user.yaml
class: User
table: user
fields:
  address: Address?, relation // Object relation field
indexes:
  user_address_unique_idx:
    fields: addressId //Wrong. There is no addressId field
    unique: true
```

Below is the correction made:

```yaml
# address.yaml
class: Address
table: address
fields:
  street: String

# user.yaml
class: User
table: user
fields:
  address: Address?, relation // Object relation field
indexes:
  user_address_unique_idx:
    fields: address  //Correct
    unique: true
```