### PR TITLE
fix: correct typo in the custom provider guide

### DIFF
--- a/docs/05-concepts/10-authentication/04-providers/06-custom-providers.md
+++ b/docs/05-concepts/10-authentication/04-providers/06-custom-providers.md
@@ -120,7 +120,7 @@ var serverResponse = await caller.myAuthentication.login(username, password);
 
 if (serverResponse.success) {
     // Store the user info in the session manager.
-    AuthenticationResponse sessionManager = await SessionManager.instance;
+    SessionManager sessionManager = await SessionManager.instance;
     await sessionManager.registerSignedInUser(
         serverResponse.userInfo!,
         serverResponse.keyId!,

--- a/versioned_docs/version-1.2.0/05-concepts/10-authentication/04-providers/06-custom-providers.md
+++ b/versioned_docs/version-1.2.0/05-concepts/10-authentication/04-providers/06-custom-providers.md
@@ -120,7 +120,7 @@ var serverResponse = await caller.myAuthentication.login(username, password);
 
 if (serverResponse.success) {
     // Store the user info in the session manager.
-    AuthenticationResponse sessionManager = await SessionManager.instance;
+    SessionManager sessionManager = await SessionManager.instance;
     await sessionManager.registerSignedInUser(
         serverResponse.userInfo!,
         serverResponse.keyId!,


### PR DESCRIPTION
Fixes a small typo (incorrect type assigned to `sessionManager`) in the custom provider guide.