### PR TITLE
fix: add missing parameter, change incorrect member variable name

### DIFF
--- a/docs/05-concepts/06-database/05-crud.md
+++ b/docs/05-concepts/06-database/05-crud.md
@@ -98,7 +98,7 @@ To update a single row, use the `updateRow` method.
 ```dart
 var company = await Company.db.findById(session, companyId); // Fetched company has its id set 
 company.name = 'New name';
-var updatedCompany = await Company.db.updateRow(company);
+var updatedCompany = await Company.db.updateRow(session, company);
 ```
 
 The object that you update must have its `id` set to a non-`null` value and the id needs to exist on a row in the database. The `updateRow` method returns the updated object.

--- a/docs/05-concepts/10-authentication/03-working-with-users.md
+++ b/docs/05-concepts/10-authentication/03-working-with-users.md
@@ -3,7 +3,7 @@
 It's a common task to read or update user information on your server. You can always retrieve the id of a signed-in user through the session object.
 
 ```dart
-var userId = await session.auth.authorizedUserId;
+var userId = await session.auth.authenticatedUserId;
 ```
 
 If you sign in users through the auth module, you will be able to retrieve more information through the static methods of the `Users` class.

--- a/versioned_docs/version-1.0.0/04-concepts/07-authentication.md
+++ b/versioned_docs/version-1.0.0/04-concepts/07-authentication.md
@@ -248,7 +248,7 @@ Serverpod automatically merges accounts that are using the same email addresses,
 It's a common task to read or update user information on your server. You can always retrieve the id of a signed-in user through the session object.
 
 ```dart
-var userId = await session.auth.authorizedUserId;
+var userId = await session.auth.authenticatedUserId;
 ```
 
 If you sign in users through the auth module, you will be able to retrieve more information through the static methods of the `Users` class.

--- a/versioned_docs/version-1.1.0/04-concepts/09-authentication.md
+++ b/versioned_docs/version-1.1.0/04-concepts/09-authentication.md
@@ -251,7 +251,7 @@ Serverpod automatically merges accounts that are using the same email addresses,
 It's a common task to read or update user information on your server. You can always retrieve the id of a signed-in user through the session object.
 
 ```dart
-var userId = await session.auth.authorizedUserId;
+var userId = await session.auth.authenticatedUserId;
 ```
 
 If you sign in users through the auth module, you will be able to retrieve more information through the static methods of the `Users` class.

--- a/versioned_docs/version-1.1.1/05-concepts/09-authentication/03-working-with-users.md
+++ b/versioned_docs/version-1.1.1/05-concepts/09-authentication/03-working-with-users.md
@@ -3,7 +3,7 @@
 It's a common task to read or update user information on your server. You can always retrieve the id of a signed-in user through the session object.
 
 ```dart
-var userId = await session.auth.authorizedUserId;
+var userId = await session.auth.authenticatedUserId;
 ```
 
 If you sign in users through the auth module, you will be able to retrieve more information through the static methods of the `Users` class.

--- a/versioned_docs/version-1.2.0/05-concepts/06-database/05-crud.md
+++ b/versioned_docs/version-1.2.0/05-concepts/06-database/05-crud.md
@@ -98,7 +98,7 @@ To update a single row, use the `updateRow` method.
 ```dart
 var company = await Company.db.findById(session, companyId); // Fetched company has its id set 
 company.name = 'New name';
-var updatedCompany = await Company.db.updateRow(company);
+var updatedCompany = await Company.db.updateRow(session, company);
 ```
 
 The object that you update must have its `id` set to a non-`null` value and the id needs to exist on a row in the database. The `updateRow` method returns the updated object.

--- a/versioned_docs/version-1.2.0/05-concepts/10-authentication/03-working-with-users.md
+++ b/versioned_docs/version-1.2.0/05-concepts/10-authentication/03-working-with-users.md
@@ -3,7 +3,7 @@
 It's a common task to read or update user information on your server. You can always retrieve the id of a signed-in user through the session object.
 
 ```dart
-var userId = await session.auth.authorizedUserId;
+var userId = await session.auth.authenticatedUserId;
 ```
 
 If you sign in users through the auth module, you will be able to retrieve more information through the static methods of the `Users` class.


### PR DESCRIPTION
Fixes:
 - Missing `session` parameter in `updateRow` call
 - Unless I'm missing something, the member variable referenced in the docs, `authorizedUserId`, doesn't exist (anymore)?
   - I changed it to `authenticatedUserId` which is the existing one
   - Is this just a typo and should I change it in all versions of the docs? Or was this a breaking change at some point?