### PR TITLE
Limit clause update for db examples

### DIFF
--- a/docs/05-concepts/06-database/05-crud.md
+++ b/docs/05-concepts/06-database/05-crud.md
@@ -81,7 +81,7 @@ To find multiple rows, use the same principle as for finding a single row.
 var companies = await Company.db.find(
   session,
   where: (t) => t.id < 100,
-  limit 50,
+  limit: 50,
 );
 ```
 

--- a/versioned_docs/version-0.9.10/03-concepts/03-database-communication.md
+++ b/versioned_docs/version-0.9.10/03-concepts/03-database-communication.md
@@ -79,7 +79,7 @@ To find multiple rows, use the same principle as for finding a single row. Retur
 var companies = await Company.find(
   tCompany,
   where: (t) => t.id < 100,
-  limit 50,
+  limit: 50,
 );
 ```
 ### Updating a row

--- a/versioned_docs/version-0.9.11/03-concepts/03-database-communication.md
+++ b/versioned_docs/version-0.9.11/03-concepts/03-database-communication.md
@@ -85,7 +85,7 @@ To find multiple rows, use the same principle as for finding a single row. Retur
 var companies = await Company.find(
   tCompany,
   where: (t) => t.id < 100,
-  limit 50,
+  limit: 50,
 );
 ```
 ### Updating a row

--- a/versioned_docs/version-0.9.20/04-concepts/03-database-communication.md
+++ b/versioned_docs/version-0.9.20/04-concepts/03-database-communication.md
@@ -118,7 +118,7 @@ To find multiple rows, use the same principle as for finding a single row. Retur
 var companies = await Company.find(
   tCompany,
   where: (t) => t.id < 100,
-  limit 50,
+  limit: 50,
 );
 ```
 ### Updating a row

--- a/versioned_docs/version-0.9.21/04-concepts/03-database-communication.md
+++ b/versioned_docs/version-0.9.21/04-concepts/03-database-communication.md
@@ -118,7 +118,7 @@ To find multiple rows, use the same principle as for finding a single row. Retur
 var companies = await Company.find(
   tCompany,
   where: (t) => t.id < 100,
-  limit 50,
+  limit: 50,
 );
 ```
 ### Updating a row

--- a/versioned_docs/version-0.9.22/04-concepts/03-database-communication.md
+++ b/versioned_docs/version-0.9.22/04-concepts/03-database-communication.md
@@ -118,7 +118,7 @@ To find multiple rows, use the same principle as for finding a single row. Retur
 var companies = await Company.find(
   tCompany,
   where: (t) => t.id < 100,
-  limit 50,
+  limit: 50,
 );
 ```
 ### Updating a row

--- a/versioned_docs/version-0.9.5/02-concepts/03-database-communication.md
+++ b/versioned_docs/version-0.9.5/02-concepts/03-database-communication.md
@@ -79,7 +79,7 @@ To find multiple rows, use the same principle as for finding a single row. Retur
 var companies = await Company.find(
   tCompany,
   where: (t) => t.id < 100,
-  limit 50,
+  limit: 50,
 );
 ```
 ### Updating a row

--- a/versioned_docs/version-0.9.6/02-concepts/03-database-communication.md
+++ b/versioned_docs/version-0.9.6/02-concepts/03-database-communication.md
@@ -79,7 +79,7 @@ To find multiple rows, use the same principle as for finding a single row. Retur
 var companies = await Company.find(
   tCompany,
   where: (t) => t.id < 100,
-  limit 50,
+  limit: 50,
 );
 ```
 ### Updating a row

--- a/versioned_docs/version-0.9.7/03-concepts/03-database-communication.md
+++ b/versioned_docs/version-0.9.7/03-concepts/03-database-communication.md
@@ -79,7 +79,7 @@ To find multiple rows, use the same principle as for finding a single row. Retur
 var companies = await Company.find(
   tCompany,
   where: (t) => t.id < 100,
-  limit 50,
+  limit: 50,
 );
 ```
 ### Updating a row

--- a/versioned_docs/version-0.9.8/03-concepts/03-database-communication.md
+++ b/versioned_docs/version-0.9.8/03-concepts/03-database-communication.md
@@ -79,7 +79,7 @@ To find multiple rows, use the same principle as for finding a single row. Retur
 var companies = await Company.find(
   tCompany,
   where: (t) => t.id < 100,
-  limit 50,
+  limit: 50,
 );
 ```
 ### Updating a row

--- a/versioned_docs/version-0.9.9/03-concepts/03-database-communication.md
+++ b/versioned_docs/version-0.9.9/03-concepts/03-database-communication.md
@@ -79,7 +79,7 @@ To find multiple rows, use the same principle as for finding a single row. Retur
 var companies = await Company.find(
   tCompany,
   where: (t) => t.id < 100,
-  limit 50,
+  limit: 50,
 );
 ```
 ### Updating a row

--- a/versioned_docs/version-1.0.0/04-concepts/03-database-communication.md
+++ b/versioned_docs/version-1.0.0/04-concepts/03-database-communication.md
@@ -118,7 +118,7 @@ To find multiple rows, use the same principle as for finding a single row. Retur
 var companies = await Company.find(
   tCompany,
   where: (t) => t.id < 100,
-  limit 50,
+  limit: 50,
 );
 ```
 ### Updating a row

--- a/versioned_docs/version-1.1.0/04-concepts/05-database-communication.md
+++ b/versioned_docs/version-1.1.0/04-concepts/05-database-communication.md
@@ -118,7 +118,7 @@ To find multiple rows, use the same principle as for finding a single row. Retur
 var companies = await Company.find(
   tCompany,
   where: (t) => t.id < 100,
-  limit 50,
+  limit: 50,
 );
 ```
 ### Updating a row

--- a/versioned_docs/version-1.1.1/05-concepts/05-database-communication.md
+++ b/versioned_docs/version-1.1.1/05-concepts/05-database-communication.md
@@ -118,7 +118,7 @@ To find multiple rows, use the same principle as for finding a single row. Retur
 var companies = await Company.find(
   session,
   where: (t) => t.id < 100,
-  limit 50,
+  limit: 50,
 );
 ```
 ### Updating a row

--- a/versioned_docs/version-1.2.0/05-concepts/06-database/05-crud.md
+++ b/versioned_docs/version-1.2.0/05-concepts/06-database/05-crud.md
@@ -81,7 +81,7 @@ To find multiple rows, use the same principle as for finding a single row.
 var companies = await Company.db.find(
   session,
   where: (t) => t.id < 100,
-  limit 50,
+  limit: 50,
 );
 ```
 


### PR DESCRIPTION
Added a colon to the limit clause in the db examples to correct the typographical error.

Closes: https://github.com/serverpod/serverpod/issues/2158