### PR TITLE
Update documentation about password length

### DIFF
--- a/versioned_docs/version-1.2.0/05-concepts/10-authentication/04-providers/01-email.md
+++ b/versioned_docs/version-1.2.0/05-concepts/10-authentication/04-providers/01-email.md
@@ -127,6 +127,10 @@ After the password has been reset you have to call the `signIn` method to log in
 
 Serverpod provides some additional configurable options to provide extra layers of security for stored password hashes.
 
+:::info
+By default, the minimum password length is set to 8 characters. If you wish to modify this requirement, you can utilize the properties within AuthConfig.
+:::
+
 ### Peppering
 
 For an additional layer of security, it is possible to configure a password hash pepper. A pepper is a server-side secret that is added, along with a unique salt, to a password before it is hashed and stored. The pepper makes it harder for an attacker to crack password hashes if they have only gained access to the database.


### PR DESCRIPTION
Today, I encountered some issues while troubleshooting the creation of a simple authentication flow. I utilized my own UI for the process and attempted to use `authController.createAccountRequest` to generate the account request, but unfortunately, it consistently failed.

Currently, there are no explicit error messages indicating the root cause of the failure; the method simply returns false. Consequently, I've first updated the documentation to reflect this challenge. Tomorrow, I plan to implement modifications to enhance error visibility during these steps.

I noticed that the sign-in method includes a logging mechanism for errors. Considering this, I'm considering creating a pull request (PR) to implement similar error logging in other methods within `server_pod_auth_email`.