### PR TITLE
ci: Copy CNAME on docs deploy.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,7 @@ jobs:
               git config --global user.email "serverpod_docs@serverpod.dev"
               git config --global user.name "serverpod_docs"
               rm -rf target/docs/*
+              cp target/CNAME target/docs
               cp -r src/build/* target/docs
               cd target
               git add .


### PR DESCRIPTION
When the deploy repo was initialized there probably was a manual step that involved copying over the CNAME file to the docs repo.

Since we now clear out the docs repo between deploys the CNAME file was accidentally removed.

We now always copy over the CNAME file in the deploy pipeline.