### PR TITLE
fix: Streams documented with new auth object in session.

### DIFF
--- a/docs/05-concepts/14-streams.md
+++ b/docs/05-concepts/14-streams.md
@@ -33,8 +33,10 @@ In most cases, it's easiest to subscribe to a message channel in the `streamOpen
 ```dart
 @override
 Future<void> streamOpened(StreamingSession session) async {
+  final authenticationInfo = await session.authenticated;
+  final userId = userAuthenticatedInfo?.userId;
   session.messages.addListener(
-    'user_${await session.auth.authenticatedUserId}',
+    'user_$userId',
     (message) {
       sendStreamMessage(session, message);
     },

--- a/versioned_docs/version-2.0.0/05-concepts/14-streams.md
+++ b/versioned_docs/version-2.0.0/05-concepts/14-streams.md
@@ -33,8 +33,10 @@ In most cases, it's easiest to subscribe to a message channel in the `streamOpen
 ```dart
 @override
 Future<void> streamOpened(StreamingSession session) async {
+  final authenticationInfo = await session.authenticated;
+  final userId = userAuthenticatedInfo?.userId;
   session.messages.addListener(
-    'user_${await session.auth.authenticatedUserId}',
+    'user_$userId',
     (message) {
       sendStreamMessage(session, message);
     },


### PR DESCRIPTION
Closes: https://github.com/serverpod/serverpod_docs/issues/115