### PR TITLE
fix: Correct typo in shared dependency

### DIFF
--- a/docs/06-concepts/03-serialization.md
+++ b/docs/06-concepts/03-serialization.md
@@ -50,7 +50,7 @@ Then you need to update both your `my_project_server/pubspec.yaml` and `my_proje
 ```yaml
 dependencies:
   ...
-  my_project_client:
+  my_project_shared:
     path: ../my_project_shared
   ...
 ```

--- a/versioned_docs/version-1.2.0/05-concepts/03-serialization.md
+++ b/versioned_docs/version-1.2.0/05-concepts/03-serialization.md
@@ -58,7 +58,7 @@ Then you need to update both your `my_project_server/pubspec.yaml` and `my_proje
 ```yaml
 dependencies:
   ...
-  my_project_client:
+  my_project_shared:
     path: ../my_project_shared
   ...
 ```

--- a/versioned_docs/version-2.0.0/05-concepts/03-serialization.md
+++ b/versioned_docs/version-2.0.0/05-concepts/03-serialization.md
@@ -50,7 +50,7 @@ Then you need to update both your `my_project_server/pubspec.yaml` and `my_proje
 ```yaml
 dependencies:
   ...
-  my_project_client:
+  my_project_shared:
     path: ../my_project_shared
   ...
 ```


### PR DESCRIPTION
## Changes
- The dependency name of the shared code should be `<projectname>_shared` 