### PR TITLE
chore: add groups for docusaurus and react dependencies.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
       interval: "daily"
     versioning-strategy: "auto"
     open-pull-requests-limit: 5
+    groups:
+      docusaurus:
+        patterns:
+          - "docusaurus/*"
+      react:
+        patterns:
+          - "*react*"


### PR DESCRIPTION
Creates two new dependency groups that ensure that all react dependencies are bumped together and all docusarus dependencies are bumped together.