### PR TITLE
chore: fix grouping for docusaurus dependencies.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     groups:
       docusaurus:
         patterns:
-          - "docusaurus/*"
+          - "*docusaurus*"
       react:
         patterns:
           - "*react*"


### PR DESCRIPTION
Fixes an issue where docusaurus was not correctly grouped.