### PR TITLE
docs: add all needed host aliases

### DIFF
--- a/docs/10-contribute.md
+++ b/docs/10-contribute.md
@@ -39,10 +39,12 @@ Tests may not yet work if running on a Windows machine. Mac or Linux is recommen
 
 Running single individual tests is useful when you are working on a specific feature. To do it, you will need to manually start the test server, then run the integration tests from the `serverpod` package.
 
-1. Add an entry for the test server at the end of your `/etc/hosts file`.
+1. Add entries for the test server, postgres and redis at the end of your `/etc/hosts file`.
 
     ```text
     127.0.0.1 serverpod_test_server
+    127.0.0.1 postgres
+    127.0.0.1 redis
     ```
 
 2. Start the Docker container for the test server.

--- a/versioned_docs/version-1.0.0/07-contribute.md
+++ b/versioned_docs/version-1.0.0/07-contribute.md
@@ -25,9 +25,11 @@ Tests may not yet work if running on a Windows machine. Mac is recommended for S
 ### Running individual tests
 Running single individual tests is useful when you are working on a specific feature. To do it, you will need to manually start the test server, then run the integration tests from the `serverpod` package.
 
-1. Add an entry for the test server at the end of your `/etc/hosts file`.
+1. Add entries for the test server, postgres and redis at the end of your `/etc/hosts file`.
 ```
 127.0.0.1 serverpod_test_server
+127.0.0.1 postgres
+127.0.0.1 redis
 ```
 2. Start the Docker container for the test server.
 ```bash

--- a/versioned_docs/version-1.1.0/08-contribute.md
+++ b/versioned_docs/version-1.1.0/08-contribute.md
@@ -38,9 +38,11 @@ Tests may not yet work if running on a Windows machine. Mac or Linux is recommen
 ### Running individual tests locally
 Running single individual tests is useful when you are working on a specific feature. To do it, you will need to manually start the test server, then run the integration tests from the `serverpod` package.
 
-1. Add an entry for the test server at the end of your `/etc/hosts file`.
+1. Add entries for the test server, postgres and redis at the end of your `/etc/hosts file`.
 ```
 127.0.0.1 serverpod_test_server
+127.0.0.1 postgres
+127.0.0.1 redis
 ```
 2. Start the Docker container for the test server.
 ```bash

--- a/versioned_docs/version-1.1.1/09-contribute.md
+++ b/versioned_docs/version-1.1.1/09-contribute.md
@@ -31,9 +31,11 @@ Tests may not yet work if running on a Windows machine. Mac or Linux is recommen
 ### Running individual tests
 Running single individual tests is useful when you are working on a specific feature. To do it, you will need to manually start the test server, then run the integration tests from the `serverpod` package.
 
-1. Add an entry for the test server at the end of your `/etc/hosts file`.
+1. Add entries for the test server, postgres and redis at the end of your `/etc/hosts file`.
 ```
 127.0.0.1 serverpod_test_server
+127.0.0.1 postgres
+127.0.0.1 redis
 ```
 2. Start the Docker container for the test server.
 ```bash

--- a/versioned_docs/version-1.2.0/11-contribute.md
+++ b/versioned_docs/version-1.2.0/11-contribute.md
@@ -31,9 +31,11 @@ Tests may not yet work if running on a Windows machine. Mac or Linux is recommen
 ### Running individual tests
 Running single individual tests is useful when you are working on a specific feature. To do it, you will need to manually start the test server, then run the integration tests from the `serverpod` package.
 
-1. Add an entry for the test server at the end of your `/etc/hosts file`.
+1. Add entries for the test server, postgres and redis at the end of your `/etc/hosts file`.
 ```
 127.0.0.1 serverpod_test_server
+127.0.0.1 postgres
+127.0.0.1 redis
 ```
 2. Start the Docker container for the test server.
 ```bash

--- a/versioned_docs/version-2.0.0/11-contribute.md
+++ b/versioned_docs/version-2.0.0/11-contribute.md
@@ -36,10 +36,12 @@ Tests may not yet work if running on a Windows machine. Mac or Linux is recommen
 
 Running single individual tests is useful when you are working on a specific feature. To do it, you will need to manually start the test server, then run the integration tests from the `serverpod` package.
 
-1. Add an entry for the test server at the end of your `/etc/hosts file`.
+1. Add entries for the test server, postgres and redis at the end of your `/etc/hosts file`.
 
     ```text
     127.0.0.1 serverpod_test_server
+    127.0.0.1 postgres
+    127.0.0.1 redis
     ```
 
 2. Start the Docker container for the test server.


### PR DESCRIPTION
- Adds additional aliases that are needed to run integration tests locally