### PR TITLE
feat: Add test tools docs

### DIFF
--- a/docs/06-concepts/18-testing/01-get-started.md
+++ b/docs/06-concepts/18-testing/01-get-started.md
@@ -135,4 +135,10 @@ docker-compose up --build --detach
 
 By default this starts up both the `development` and `test` profiles. To only start one profile, simply add `--profile test` to the command.
 
-Now the test is ready to be run!
+Now the test is ready to be run:
+
+```bash
+dart test integration_test
+```
+
+Happy testing!

--- a/docs/06-concepts/18-testing/01-get-started.md
+++ b/docs/06-concepts/18-testing/01-get-started.md
@@ -2,10 +2,16 @@
 
 Serverpod provides simple but feature rich test tools to make testing your backend a breeze.
 
+:::info
+
+For Serverpod Mini projects, everything related to the database in this guide can be ignored.
+
+:::
+
 <details>
 <summary> Have an existing project? Follow these steps first!</summary>
 <p>
-For existing projects, a few extra things need to be done:
+For existing non-Mini projects, a few extra things need to be done:
 1. Add the `server_test_tools_path` key to `config/generator.yaml`. Without this key, the test tools file is not generated. The default location for the generated file is `integration_test/test_tools/serverpod_test_tools.dart`, but this can be set to any path (though should be outside of `lib` as per Dart's test conventions).
 
 2. New projects now come with a test profile in `docker-compose.yaml`. This is not strictly mandatory, but is recommended to ensure that the testing state is never polluted. Add the snippet below to the `docker-compose.yaml` file in the server directory:
@@ -157,7 +163,7 @@ That's it, the project setup should be ready to start using the test tools!
 </p>
 </details>
 
-Go to the server directory and generate the test tools by running `serverpod generate`. The default location for the generated file is `integration_test/test_tools/serverpod_test_tools.dart`. The folder name `integration_test` is chosen to differentiate from unit tests (see the [best practises section](best-practises#unit-integration) for more information on this).
+Go to the server directory and generate the test tools by running `serverpod generate --experimental-features testTools`. The default location for the generated file is `integration_test/test_tools/serverpod_test_tools.dart`. The folder name `integration_test` is chosen to differentiate from unit tests (see the [best practises section](best-practises#unit-integration) for more information on this).
 
 The generated file exports a `withServerpod` helper that enables you to call your endpoints directly like regular functions:
 

--- a/docs/06-concepts/18-testing/01-get-started.md
+++ b/docs/06-concepts/18-testing/01-get-started.md
@@ -118,7 +118,7 @@ A few things to note from the above example:
 
 - The test tools should be imported from the generated test tools file and not the `serverpod_test` package.
 - The `withServerpod` callback takes two parameters: `sessionBuilder` and `endpoints`.
-  - `sessionBuilder` is used to build a `session` object that represents the state of the world for your endpoints and is used to set up scenarios.
+  - `sessionBuilder` is used to build a `session` object that represents the state of the world during an endpoint call and is used to set up scenarios.
   - `endpoints` contains all your Serverpod endpoints and lets you call them.
 
 :::info

--- a/docs/06-concepts/18-testing/01-get-started.md
+++ b/docs/06-concepts/18-testing/01-get-started.md
@@ -37,6 +37,68 @@ redis_test:
     - test
 ```
 
+<details>
+<summary>Or copy the complete file here.</summary>
+<p>
+
+```yaml
+services:
+  # Development services
+  postgres:
+    image: postgres:16.3
+    ports:
+      - '8090:5432'
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: projectname
+      POSTGRES_PASSWORD: "<insert database development password>"
+    volumes:
+      - projectname_data:/var/lib/postgresql/data
+    profiles:
+      - '' # Default profile
+      - dev
+  redis:
+    image: redis:6.2.6
+    ports:
+      - '8091:6379'
+    command: redis-server --requirepass "<insert redis development password>"
+    environment:
+      - REDIS_REPLICATION_MODE=master
+    profiles:
+      - '' # Default profile
+      - dev
+
+  # Test services
+  postgres_test:
+    image: postgres:16.3
+    ports:
+      - '9090:5432'
+    environment:
+      POSTGRES_USER: postgres_test
+      POSTGRES_DB: projectname_test
+      POSTGRES_PASSWORD: "<insert database test password>"
+    volumes:
+      - projectname_data:/var/lib/postgresql/data
+    profiles:
+      - '' # Default profile
+      - test
+  redis_test:
+    image: redis:6.2.6
+    ports:
+      - '9091:6379'
+    command: redis-server --requirepass "<insert redis test password>"
+    environment:
+      - REDIS_REPLICATION_MODE=master
+    profiles:
+      - '' # Default profile
+      - test
+
+volumes:
+  projectname_data:
+```
+
+</p>
+</details>
 3. Create a `test.yaml` file and add it to the `config` directory:
 
 ```yaml

--- a/docs/06-concepts/18-testing/01-get-started.md
+++ b/docs/06-concepts/18-testing/01-get-started.md
@@ -163,7 +163,7 @@ That's it, the project setup should be ready to start using the test tools!
 </p>
 </details>
 
-Go to the server directory and generate the test tools by running `serverpod generate --experimental-features testTools`. The default location for the generated file is `integration_test/test_tools/serverpod_test_tools.dart`. The folder name `integration_test` is chosen to differentiate from unit tests (see the [best practises section](best-practises#unit-integration) for more information on this).
+Go to the server directory and generate the test tools by running `serverpod generate --experimental-features testTools`. The default location for the generated file is `integration_test/test_tools/serverpod_test_tools.dart`. The folder name `integration_test` is chosen to differentiate from unit tests (see the [best practises section](best-practises#unit-and-integration-tests) for more information on this).
 
 The generated file exports a `withServerpod` helper that enables you to call your endpoints directly like regular functions:
 

--- a/docs/06-concepts/18-testing/01-get-started.md
+++ b/docs/06-concepts/18-testing/01-get-started.md
@@ -1,0 +1,138 @@
+# Get started
+
+Serverpod provides simple but feature rich test tools to make testing your backend a breeze.
+
+<details>
+<summary> Have an existing project? Follow these steps first!</summary>
+<p>
+For existing projects, a few extra things need to be done:
+1. Add the `server_test_tools_path` key to `config/generator.yaml`. Without this key, the test tools file is not generated. The default location for the generated file is `integration_test/test_tools/serverpod_test_tools.dart`, but this can be set to any path (though should be outside of `lib` as per Dart's test conventions).
+
+2. New projects now come with a test profile in `docker-compose.yaml`. This is not strictly mandatory, but is recommended to ensure that the testing state is never polluted. Add the snippet below to the `docker-compose.yaml` file in the server directory:
+
+```yaml
+# Test services
+postgres_test:
+  image: postgres:16.3
+  ports:
+    - '9090:5432'
+  environment:
+    POSTGRES_USER: postgres_test
+    POSTGRES_DB: projectname_test
+    POSTGRES_PASSWORD: "<insert database test password>"
+  volumes:
+    - projectname_data:/var/lib/postgresql/data
+  profiles:
+    - '' # Default profile
+    - test
+redis_test:
+  image: redis:6.2.6
+  ports:
+    - '9091:6379'
+  command: redis-server --requirepass "<insert redis test password>"
+  environment:
+    - REDIS_REPLICATION_MODE=master
+  profiles:
+    - '' # Default profile
+    - test
+```
+
+3. Create a `test.yaml` file and add it to the `config` directory:
+
+```yaml
+# This is the configuration file for your local test environment. By
+# default, it runs a single server on port 8090. To set up your server, you will
+# need to add the name of the database you are connecting to and the user name.
+# The password for the database is stored in the config/passwords.yaml.
+#
+# When running your server locally, the server ports are the same as the public
+# facing ports.
+
+# Configuration for the main API test server.
+apiServer:
+  port: 9080
+  publicHost: localhost
+  publicPort: 9080
+  publicScheme: http
+
+# Configuration for the Insights test server.
+insightsServer:
+  port: 9081
+  publicHost: localhost
+  publicPort: 9081
+  publicScheme: http
+
+# Configuration for the web test server.
+webServer:
+  port: 9082
+  publicHost: localhost
+  publicPort: 9082
+  publicScheme: http
+
+# This is the database setup for your test server.
+database:
+  host: localhost
+  port: 9090
+  name: projectname_test
+  user: postgres
+
+# This is the setup for your Redis test instance.
+redis:
+  enabled: false
+  host: localhost
+  port: 9091
+```
+
+4. Add this entry to `config/passwords.yaml`
+
+```yaml
+test:
+  database: '<insert database test password>'
+  redis: '<insert redis test password>'
+```
+
+That's it, the project setup should be ready to start using the test tools!
+</p>
+</details>
+
+Go to the server directory and generate the test tools by running `serverpod generate`. The default location for the generated file is `integration_test/test_tools/serverpod_test_tools.dart`.
+
+The generated file exports a `withServerpod` helper that enables you to call your endpoints directly like regular functions:
+
+```dart
+// Import the generated file, it contains everything you need.
+import 'test_tools/serverpod_test_tools.dart';
+
+void main() {
+  withServerpod('Given Example endpoint', (sessionBuilder, endpoints) {
+    test('when calling `hello` then should return greeting', () async {
+      final greeting =
+          await endpoints.example.hello(sessionBuilder, 'Michael');
+      expect(greeting, 'Hello, Michael!');
+    });
+  });
+}
+```
+
+A few things to note from the above example:
+
+- The test tools should be imported from the generated test tools file and not the `serverpod_test` package.
+- The `withServerpod` callback takes two parameters: `sessionBuilder` and `endpoints`.
+  - `sessionBuilder` is used to build a `session` object that represents the state of the world for your endpoints and is used to set up scenarios.
+  - `endpoints` contains all your Serverpod endpoints and lets you call them.
+
+:::info
+
+The location of the test tools can be changed by changing the  `server_test_tools_path` key in `config/generator.yaml`. If you remove the `server_test_tools_path` key, the test tools will stop being generated.
+
+:::
+
+Before you can run the test you also need to start the Postgres and Redis:
+
+```bash
+docker-compose up --build --detach
+```
+
+By default this starts up both the `development` and `test` profiles. To only start one profile, simply add `--profile test` to the command.
+
+Now the test is ready to be run!

--- a/docs/06-concepts/18-testing/01-get-started.md
+++ b/docs/06-concepts/18-testing/01-get-started.md
@@ -95,7 +95,7 @@ That's it, the project setup should be ready to start using the test tools!
 </p>
 </details>
 
-Go to the server directory and generate the test tools by running `serverpod generate`. The default location for the generated file is `integration_test/test_tools/serverpod_test_tools.dart`.
+Go to the server directory and generate the test tools by running `serverpod generate`. The default location for the generated file is `integration_test/test_tools/serverpod_test_tools.dart`. The folder name `integration_test` is chosen to differentiate from unit tests (see the [best practises section](best-practises#unit-integration) for more information on this).
 
 The generated file exports a `withServerpod` helper that enables you to call your endpoints directly like regular functions:
 
@@ -118,16 +118,16 @@ A few things to note from the above example:
 
 - The test tools should be imported from the generated test tools file and not the `serverpod_test` package.
 - The `withServerpod` callback takes two parameters: `sessionBuilder` and `endpoints`.
-  - `sessionBuilder` is used to build a `session` object that represents the state of the world during an endpoint call and is used to set up scenarios.
+  - `sessionBuilder` is used to build a `session` object that represents the server state during an endpoint call and is used to set up scenarios.
   - `endpoints` contains all your Serverpod endpoints and lets you call them.
 
-:::info
+:::tip
 
 The location of the test tools can be changed by changing the  `server_test_tools_path` key in `config/generator.yaml`. If you remove the `server_test_tools_path` key, the test tools will stop being generated.
 
 :::
 
-Before you can run the test you also need to start the Postgres and Redis:
+Before the test can be run the Postgres and Redis also have to be started:
 
 ```bash
 docker-compose up --build --detach

--- a/docs/06-concepts/18-testing/02-the-basics.md
+++ b/docs/06-concepts/18-testing/02-the-basics.md
@@ -2,7 +2,7 @@
 
 ## Using `sessionBuilder` to set up a test scenario
 
-The `withServerpod` helper provides a `sessionBuilder` that helps with setting up different scenarios for tests. To modify the session builder's properties, call its `copyWith` method. The copyWith method takes the following named parameters:
+The `withServerpod` helper provides a `sessionBuilder` that helps with setting up different scenarios for tests. To modify the session builder's properties, call its `copyWith` method. It takes the following named parameters:
 
 |Property|Type|Default|Description|
 |:-----|:-----|:---:|:-----|

--- a/docs/06-concepts/18-testing/02-the-basics.md
+++ b/docs/06-concepts/18-testing/02-the-basics.md
@@ -219,7 +219,7 @@ Wether pending migrations should be applied when starting Serverpod. Defaults to
 
 ## Test exceptions
 
-The following exceptions are exported from the generated test tools file and can be thrown in various scenarios, see below.
+The following exceptions are exported from the generated test tools file and can be thrown by the test tools in various scenarios, see below.
 
 |Exception|Description|
 |:-----|:-----|

--- a/docs/06-concepts/18-testing/02-the-basics.md
+++ b/docs/06-concepts/18-testing/02-the-basics.md
@@ -44,8 +44,7 @@ abstract class AuthenticationOverride {
 Pass it to the `sessionBuilder.copyWith` to simulate different scenarios. Below follows an example for each case:
 
 ```dart
-withServerpod('Given AuthenticatedExample endpoint',
-    (sessionBuilder, endpoints) {
+withServerpod('Given AuthenticatedExample endpoint', (sessionBuilder, endpoints) {
   // Corresponds to an actual user id
   const int userId = 1234;
 
@@ -90,27 +89,18 @@ By default `withServerpod` does all database operations inside a transaction tha
 :::
 
 ```dart
-withServerpod('Given Products endpoint when authenticated',
-    (sessionBuilder, endpoints) {
-  const int userId = 1234;
-  var authenticatedSession = sessionBuilder
-      .copyWith(
-        authentication: AuthenticationOverride.authenticationInfo(
-          userId,
-          {Scope('user')},
-        ),
-      )
-      .build();
+withServerpod('Given Products endpoint', (sessionBuilder, endpoints) {
+  var session = sessionBuilder.build();
 
   setUp(() async {
-    await Product.db.insert(authenticatedSession, [
-      Product(name: 'Apple', price: 10),
-      Product(name: 'Banana', price: 10)
+    await Product.db.insert(session, [
+    Product(name: 'Apple', price: 10),
+    Product(name: 'Banana', price: 10)
     ]);
   });
 
   test('then calling `all` should return all products', () async {
-    final products = await endpoints.products.all(authenticatedSession);
+    final products = await endpoints.products.all(sessionBuilder);
     expect(products, hasLength(2));
     expect(products.map((p) => p.name), contains(['Apple', 'Banana']));
   });
@@ -125,7 +115,7 @@ It is possible to override the default run mode by setting the `runMode` setting
 
 ```dart
 withServerpod(
-  'Given Products endpoint when authenticated',
+  'Given Products endpoint',
   (sessionBuilder, endpoints) {
     /* test code */
   },
@@ -137,14 +127,12 @@ withServerpod(
 
 The following optional configuration options are available to pass as a second argument to `withServerpod`:
 
-```dart
-{
-  RollbackDatabase? rollbackDatabase = RollbackDatabase.afterEach,
-  String? runMode = ServerpodRunmode.test,
-  bool? enableSessionLogging = false,
-  bool? applyMigrations = true,
-}
-```
+|Property|Type|Default|
+|:-----|:-----|:---:|
+|`rollbackDatabase`|`RollbackDatabase?`|`RollbackDatabase.afterEach`|
+|`runMode`|`String?`|`ServerpodRunmode.test`|
+|`enableSessionLogging`|`bool?`|`false`|
+|`applyMigrations`|`bool?`|`true`|
 
 ### `rollbackDatabase` {#rollback-database-configuration}
 
@@ -225,45 +213,12 @@ Wether pending migrations should be applied when starting Serverpod. Defaults to
 
 The following exceptions are exported from the generated test tools file and can be thrown in various scenarios, see below.
 
-### `ServerpodUnauthenticatedException`
-
-```dart
-/// The user was not authenticated.
-class ServerpodUnauthenticatedException implements Exception {
-  ServerpodUnauthenticatedException();
-}
-
-```
-
-### `ServerpodInsufficientAccessException`
-
-```dart
-/// The authentication key provided did not have sufficient access.
-class ServerpodInsufficientAccessException implements Exception {
-  ServerpodInsufficientAccessException();
-}
-```
-
-### `InvalidConfigurationException`
-
-```dart
-/// Thrown when an invalid configuration state is found.
-class InvalidConfigurationException implements Exception {
-  final String message;
-  InvalidConfigurationException(this.message);
-}
-```
-
-### `ConnectionClosedException`
-
-```dart
-/// Thrown if a stream connection is closed with an error.
-/// For example, if the user authentication was revoked.
-class ConnectionClosedException implements Exception {
-  const ConnectionClosedException();
-}
-
-```
+|Exception|Description|
+|:-----|:-----|
+|`ServerpodUnauthenticatedException`|Thrown during an endpoint method call when the user was not authenticated.|
+|`ServerpodInsufficientAccessException`|Thrown during an endpoint method call when the authentication key provided did not have sufficient access.|
+|`ConnectionClosedException`|Thrown during an endpoint method call if a stream connection was closed with an error. For example, if the user authentication was revoked.|
+|`InvalidConfigurationException`|Thrown when an invalid configuration state is found.|
 
 ## Test helpers
 

--- a/docs/06-concepts/18-testing/02-the-basics.md
+++ b/docs/06-concepts/18-testing/02-the-basics.md
@@ -1,6 +1,6 @@
 # The basics
 
-## Using `sessionBuilder` to set up a test scenario
+## Set up a test scenario
 
 The `withServerpod` helper provides a `sessionBuilder` that helps with setting up different scenarios for tests. To modify the session builder's properties, call its `copyWith` method. It takes the following named parameters:
 
@@ -11,7 +11,7 @@ The `withServerpod` helper provides a `sessionBuilder` that helps with setting u
 
 The `copyWith` method creates a new unique session builder with the provided properties. This can then be used in endpoint calls (see section [Setting authenticated state](#setting-authenticated-state) for an example).
 
-To build out a `Session` (to use for [database calls](#seeding-the-database) or [pass on to functions](advanced-examples##business-logic-depends-on-session)), simply call the `build` method:
+To build out a `Session` (to use for [database calls](#seeding-the-database) or [pass on to functions](advanced-examples#test-business-logic-that-depends-on-session)), simply call the `build` method:
 
 ```dart
 Session session = sessionBuilder.build();
@@ -19,7 +19,7 @@ Session session = sessionBuilder.build();
 
 Given the properties set on the session builder through the `copyWith` method, this returns a Serverpod `Session` that has the corresponding state.
 
-### Setting authenticated state {#setting-authenticated-state}
+### Setting authenticated state
 
 To control the authenticated state of the session, the `AuthenticationOverride` class can be used.
 
@@ -76,7 +76,7 @@ withServerpod('Given AuthenticatedExample endpoint', (sessionBuilder, endpoints)
 });
 ```
 
-### Seeding the database {#seeding-the-database}
+### Seeding the database
 
 To seed the database before tests, `build` a `session` and pass it to the database call just as in production code.
 
@@ -245,4 +245,4 @@ var stream = endpoints.someEndoint.generatorFunction(session);
 await flushEventQueue();
 ```
 
-See also [this complete example](advanced-examples#multiple-users-with-stream).
+See also [this complete example](advanced-examples#multiple-users-interacting-with-a-shared-stream).

--- a/docs/06-concepts/18-testing/02-the-basics.md
+++ b/docs/06-concepts/18-testing/02-the-basics.md
@@ -2,46 +2,44 @@
 
 ## Using `sessionBuilder` to set up a test scenario
 
-The `withServerpod` helper provides a `sessionBuilder` object that helps with setting up different scenarios for tests. It looks like the following:
+The `withServerpod` helper provides a `sessionBuilder` that helps with setting up different scenarios for tests. To modify the session builder's properties, call its `copyWith` method. The copyWith method takes the following named parameters:
+
+|Property|Type|Default|Description|
+|:-----|:-----|:---:|:-----|
+|`authentication`|`AuthenticationOverride?`|`AuthenticationOverride.unauthenticated()`|See section [Setting authenticated state](#setting-authenticated-state).|
+|`enableLogging`|`bool?`|`false`|Wether logging is turned on for the session.|
+
+The `copyWith` method creates a new unique session builder with the provided properties. This can then be used in endpoint calls (see section [Setting authenticated state](#setting-authenticated-state) for an example).
+
+To build out a `Session` (to use for [database calls](#seeding-the-database) or [pass on to functions](advanced-examples##business-logic-depends-on-session)), simply call the `build` method:
 
 ```dart
-/// A test specific builder to create a [Session] that for instance can be used to call database methods.
-/// The builder can also be passed to endpoint calls. The builder will create a new session for each call.
-abstract class TestSessionBuilder {
-  /// Given the properties set on the session through the `copyWith` method,
-  /// this returns a serverpod [Session] that has the configured state.
-  Session build();
-
-  /// Creates a new unique session with the provided properties.
-  /// This is useful for setting up different session states in the tests
-  /// or simulating multiple users.
-  TestSessionBuilder copyWith({
-    AuthenticationOverride? authentication,
-    bool? enableLogging,
-  });
-}
+Session session = sessionBuilder.build();
 ```
 
-To create a new state, simply call `copyWith` with the new properties and use the new session builder in the endpoint call.
+Given the properties set on the session builder through the `copyWith` method, this returns a Serverpod `Session` that has the corresponding state.
 
-### Setting authenticated state
+### Setting authenticated state {#setting-authenticated-state}
 
-To control the authenticated state of the session, the `AuthenticationOverride` class can be used:
+To control the authenticated state of the session, the `AuthenticationOverride` class can be used.
+
+To create an unauthenticated override (this is the default value for new sessions), call `AuthenticationOverride unauthenticated()`:
 
 ```dart
-/// An override for the authentication state in a test session.
-abstract class AuthenticationOverride {
-  /// Sets the session to be authenticated with the provided userId and scope.
-  static AuthenticationOverride authenticationInfo(
-          int userId, Set<Scope> scopes,
-          {String? authId});
-
-  /// Sets the session to be unauthenticated. This is the default.
-  static AuthenticationOverride unauthenticated();
-}
+static AuthenticationOverride unauthenticated();
 ```
 
-Pass it to the `sessionBuilder.copyWith` to simulate different scenarios. Below follows an example for each case:
+To create an authenticated override, call `AuthenticationOverride.authenticationInfo(...)`:
+
+```dart
+static AuthenticationOverride authenticationInfo(
+  int userId,
+  Set<Scope> scopes, {
+  String? authId,
+})
+```
+
+Pass these to `sessionBuilder.copyWith` to simulate different scenarios. Below follows an example for each case:
 
 ```dart
 withServerpod('Given AuthenticatedExample endpoint', (sessionBuilder, endpoints) {
@@ -78,9 +76,9 @@ withServerpod('Given AuthenticatedExample endpoint', (sessionBuilder, endpoints)
 });
 ```
 
-### Seeding the database
+### Seeding the database {#seeding-the-database}
 
-To seed the database before tests, simply `build` a `session` and pass to the database call exactly the same as in production code.
+To seed the database before tests, `build` a `session` and pass it to the database call just as in production code.
 
 :::info
 

--- a/docs/06-concepts/18-testing/02-the-basics.md
+++ b/docs/06-concepts/18-testing/02-the-basics.md
@@ -197,6 +197,14 @@ withServerpod(
 );
 ```
 
+Additionally, when setting `rollbackDatabase.disabled`, it may also be needed to pass the `--concurrency=1` flag to the dart test runner. Otherwise multiple tests might pollute each others database state:
+
+```bash
+dart test integration_test --concurrency=1
+```
+
+For the other cases this is not an issue, as each `withServerpod` has its own transaction and will therefore be isolated.
+
 ### `runMode`
 
 The run mode that Serverpod should be running in. Defaults to `test`.

--- a/docs/06-concepts/18-testing/03-advanced-examples.md
+++ b/docs/06-concepts/18-testing/03-advanced-examples.md
@@ -1,6 +1,6 @@
 # Advanced examples
 
-## Test business logic that depends on `session`
+## Test business logic that depends on `Session`
 
 It is common to break out business logic into modules and keep it separate from the endpoints. If such a module depends on a `Session` object (e.g to interact with the database), then the `withServerpod` helper can still be used and the second `endpoint` argument can simply be ignored:
 
@@ -34,7 +34,7 @@ withServerpod('Given decreasing product quantity when quantity is zero', (
 });
 ```
 
-## Multiple users interacting with a shared stream
+## Multiple users interacting with a shared stream {#multiple-users-with-stream}
 
 For cases where there are multiple users reading from or writing to a stream, such as real-time communication, it can be helpful to validate this behavior in tests.
 

--- a/docs/06-concepts/18-testing/03-advanced-examples.md
+++ b/docs/06-concepts/18-testing/03-advanced-examples.md
@@ -1,6 +1,6 @@
 # Advanced examples
 
-## Test business logic that depends on `Session` {#business-logic-depends-on-session}
+## Test business logic that depends on `Session`
 
 It is common to break out business logic into modules and keep it separate from the endpoints. If such a module depends on a `Session` object (e.g to interact with the database), then the `withServerpod` helper can still be used and the second `endpoint` argument can simply be ignored:
 
@@ -34,7 +34,7 @@ withServerpod('Given decreasing product quantity when quantity is zero', (
 });
 ```
 
-## Multiple users interacting with a shared stream {#multiple-users-with-stream}
+## Multiple users interacting with a shared stream
 
 For cases where there are multiple users reading from or writing to a stream, such as real-time communication, it can be helpful to validate this behavior in tests.
 

--- a/docs/06-concepts/18-testing/03-advanced-examples.md
+++ b/docs/06-concepts/18-testing/03-advanced-examples.md
@@ -1,0 +1,98 @@
+# Advanced examples
+
+## Test business logic that depends on `session`
+
+It is common to break out business logic into modules and keep it separate from the endpoints. If such a module depends on a `Session` object (e.g to interact with the database), then the `withServerpod` helper can still be used and the second `endpoint` argument can simply be ignored:
+
+```dart
+withServerpod('Given decreasing product quantity when quantity is zero', (
+  sessionBuilder,
+  _ /* Ignore */,
+) {
+  var session = sessionBuilder.build();
+
+  setUp(() async {
+    await Product.db.insertRow(session, [
+      Product(
+        id: 123,
+        name: 'Apple',
+        quantity: 0,
+      ),
+    ]);
+  });
+
+  test('then should throw `InvalidOperationException`',
+      () async {
+    var future = ProductsBusinessLogic.updateQuantity(
+      session,
+      id: 123,
+      decrease: 1,
+    );
+
+    await expectLater(future, throwsA(isA<InvalidOperationException>()));
+  });
+});
+```
+
+## Multiple users interacting with a shared stream
+
+For cases where there are multiple users reading from or writing to a stream, such as real-time communication, it can be helpful to validate this behavior in tests.
+
+Given the following simplified endpoint:
+
+```dart
+class CommunicationExampleEndpoint {
+  static const sharedStreamName = 'shared-stream';
+  Future<void> postNumberToSharedStream(Session session, int number) async {
+    await session.messages
+        .postMessage(sharedStreamName, SimpleData(num: number));
+  }
+
+  Stream<int> listenForNumbersOnSharedStream(Session session) async* {
+    var sharedStream =
+        session.messages.createStream<SimpleData>(sharedStreamName);
+
+    await for (var message in sharedStream) {
+      yield message.num;
+    }
+  }
+}
+```
+
+Then a test to verify this behavior can be written as below. Note the call to the `flushEventQueue` helper (exported by the test tools), which ensures that `listenForNumbersOnSharedStream` executes up to its first `yield` statement before continuing with the test. This guarantees that the stream was registered by Serverpod before messages are posted to it.
+
+```dart
+withServerpod('Given CommunicationExampleEndpoint', (sessionBuilder, endpoints) {
+  const int userId1 = 1;
+  const int userId2 = 2;
+
+  test(
+      'when calling postNumberToSharedStream and listenForNumbersOnSharedStream '
+      'with different sessions then number should be echoed',
+      () async {
+    var userSession1 = sessionBuilder.copyWith(
+      authentication: AuthenticationOverride.authenticationInfo(
+        userId1,
+        {},
+      ),
+    );
+    var userSession2 = sessionBuilder.copyWith(
+      authentication: AuthenticationOverride.authenticationInfo(
+        userId2,
+        {},
+      ),
+    );
+
+    var stream =
+        endpoints.testTools.listenForNumbersOnSharedStream(userSession1);
+    // Wait for `listenForNumbersOnSharedStream` to execute up to its 
+    // `yield` statement before continuing
+    await flushEventQueue(); 
+
+    await endpoints.testTools.postNumberToSharedStream(userSession2, 111);
+    await endpoints.testTools.postNumberToSharedStream(userSession2, 222);
+
+    await expectLater(stream.take(2), emitsInOrder([111, 222]));
+  });
+});
+```

--- a/docs/06-concepts/18-testing/03-advanced-examples.md
+++ b/docs/06-concepts/18-testing/03-advanced-examples.md
@@ -1,6 +1,6 @@
 # Advanced examples
 
-## Test business logic that depends on `Session`
+## Test business logic that depends on `Session` {#business-logic-depends-on-session}
 
 It is common to break out business logic into modules and keep it separate from the endpoints. If such a module depends on a `Session` object (e.g to interact with the database), then the `withServerpod` helper can still be used and the second `endpoint` argument can simply be ignored:
 

--- a/docs/06-concepts/18-testing/03-advanced-examples.md
+++ b/docs/06-concepts/18-testing/03-advanced-examples.md
@@ -7,7 +7,7 @@ It is common to break out business logic into modules and keep it separate from 
 ```dart
 withServerpod('Given decreasing product quantity when quantity is zero', (
   sessionBuilder,
-  _ /* Ignore */,
+  _,
 ) {
   var session = sessionBuilder.build();
 

--- a/docs/06-concepts/18-testing/04-best-practises.md
+++ b/docs/06-concepts/18-testing/04-best-practises.md
@@ -1,3 +1,8 @@
+---
+# Don't display do's and don'ts in the table of contents
+toc_max_heading_level: 2
+---
+
 # Best practises
 
 ## Imports
@@ -104,7 +109,7 @@ void main() {
 }
 ```
 
-## Unit and integration tests {#unit-integration}
+## Unit and integration tests
 
 It is significantly easier to navigate a project if the different types of tests are clearly separated.
 

--- a/docs/06-concepts/18-testing/04-best-practises.md
+++ b/docs/06-concepts/18-testing/04-best-practises.md
@@ -2,6 +2,8 @@
 
 ## Imports
 
+While it's possible to import types and test helpers from the `serverpod_test`, it's completely redundant. The generated file exports everything that is needed. Adding an additional import is just unnecessary noise and will likely also be flagged as duplicated imports by the Dart linter.
+
 ### Don't
 
 ```dart
@@ -104,9 +106,11 @@ void main() {
 
 ## Unit and integration tests {#unit-integration}
 
+It is significantly easier to navigate a project if the different types of tests are clearly separated.
+
 ### Don't
 
-❌ Mix different types of tests together. It is significantly easier to navigate a project if the different types of tests are grouped.
+❌ Mix different types of tests together.
 
 ### Do
 

--- a/docs/06-concepts/18-testing/04-best-practises.md
+++ b/docs/06-concepts/18-testing/04-best-practises.md
@@ -20,7 +20,7 @@ import 'serverpod_test_tools.dart'; ✅
 
 ### Database clean up
 
-Unless configured otherwise, by default `withServerpod` does all database operations inside a transaction that is rolled back after each `test`.
+Unless configured otherwise, by default `withServerpod` does all database operations inside a transaction that is rolled back after each `test` (see [the configuration options](the-basics#rollback-database-configuration) for more info on this behavior).
 
 ### Don't
 
@@ -101,3 +101,16 @@ void main() {
   });
 }
 ```
+
+## Unit and integration tests {#unit-integration}
+
+### Don't
+
+❌ Mix different types of tests together. It is significantly easier to navigate a project if the different types of tests are grouped.
+
+### Do
+
+✅ Have a clear structure for the different types of test. Serverpod recommends the following two folders in the `server`:
+
+- `test`: Unit tests.
+- `integration_test`: Tests for endpoints or business logic modules using the `withServerpod` helper.

--- a/docs/06-concepts/18-testing/_category_.json
+++ b/docs/06-concepts/18-testing/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Testing",
+  "collapsed": true
+}


### PR DESCRIPTION
## Descrption / reasoning
The idea is to divide into different pages that has different focus areas. Currently I have the following in mind:
- **Get started**: Easily digested get started info, minimum for getting the simplest test to run
- **The basics**: Additional documentation you will absolutely need to know within "the first hour" of writing tests
- **Advanced exmples**: More complex test setup examples. Can still be common cases but not something you necessarily need to write a first test suite.
- **Best practises**: Inspired by Cypress' (e2e web test framework) [best practices page](https://docs.cypress.io/guides/references/best-practices), as inevitably there will always be cases where a user can do a thing in multiple ways. I've found the Cypress page to be tremendously helpful over the years. It also helps to educate and onboard team members who are new to a framework to quickly get into the "philosophy" of the tool.
<img width="280" alt="image" src="https://github.com/user-attachments/assets/fe3d32ad-4527-42d9-8bed-7d78bd757d54">

❓ TODO / Question for reviewer:
- Consider what more best practises to add. Maybe some general testing principles that applied outside of Serverpod as well?