### PR TITLE
clarify language in info block on findFirstRow

### DIFF
--- a/docs/06-concepts/06-database/05-crud.md
+++ b/docs/06-concepts/06-database/05-crud.md
@@ -71,7 +71,7 @@ var company = await Company.db.findFirstRow(
 This operation returns the first model matching the filtering criteria or `null`. See [filter](filter) and [sort](sort) for all filter operations.
 
 :::info
-Note that ordering of the entries is important here as it will return the fist row returned by the database query.
+If you include an `orderBy`, it will be evaluated before the list is reduced. In this case, `findFirstRow()` will return the first entry from the sorted list.
 :::
 
 ### Finding multiple rows


### PR DESCRIPTION
per discussion [#2814](https://github.com/serverpod/serverpod/discussions/2814#discussioncomment-10864209)
orderBy is exceucted before the list is cut down
