### PR TITLE
fix: Change incorrect casing `iLike` to `ilike`.

### DIFF
--- a/docs/06-concepts/06-database/06-filter.md
+++ b/docs/06-concepts/06-database/06-filter.md
@@ -148,19 +148,19 @@ await User.db.find(
 
 In the example we fetch all users with a name that does not start with B.
 
-### iLike
+### ilike
 
-iLike works the same as `like` but is case-insensitive.
+`ilike` works the same as `like` but is case-insensitive.
 
 ```dart
 await User.db.find(
-  where: (t) => t.name.iLike('a%')
+  where: (t) => t.name.ilike('a%')
 );
 ```
 
 In the example we fetch all users with a name that starts with a or A.
 
-There is a negated version of iLike that can be used to exclude rows from the result.
+There is a negated version of `ilike` that can be used to exclude rows from the result.
 
 ```dart
 await User.db.find(

--- a/docs/06-concepts/06-database/07-relation-queries.md
+++ b/docs/06-concepts/06-database/07-relation-queries.md
@@ -125,7 +125,7 @@ var user = await Company.db.findById(
   employeeId,
   include: Company.include(
     employees: Employee.includeList(
-      where: (t) => t.name.iLike('a%')
+      where: (t) => t.name.ilike('a%')
     ),
   ),
 );

--- a/versioned_docs/version-1.2.0/05-concepts/06-database/06-filter.md
+++ b/versioned_docs/version-1.2.0/05-concepts/06-database/06-filter.md
@@ -145,19 +145,19 @@ await User.db.find(
 In the example we fetch all users with a name that does not start with B.
 
 
-### iLike
+### ilike
 
-iLike works the same as `like` but is case-insensitive.
+`ilike` works the same as `like` but is case-insensitive.
 
 ```dart
 await User.db.find(
-  where: (t) => t.name.iLike('a%')
+  where: (t) => t.name.ilike('a%')
 );
 ```
 
 In the example we fetch all users with a name that starts with a or A.
 
-There is a negated version of iLike that can be used to exclude rows from the result.
+There is a negated version of `ilike` that can be used to exclude rows from the result.
 
 ```dart
 await User.db.find(

--- a/versioned_docs/version-1.2.0/05-concepts/06-database/07-relation-queries.md
+++ b/versioned_docs/version-1.2.0/05-concepts/06-database/07-relation-queries.md
@@ -125,7 +125,7 @@ var user = await Company.db.findById(
   employeeId,
   include: Company.include(
     employees: Employee.includeList(
-      where: (t) => t.name.iLike('a%')
+      where: (t) => t.name.ilike('a%')
     ),
   ),
 );`

--- a/versioned_docs/version-2.0.0/05-concepts/06-database/06-filter.md
+++ b/versioned_docs/version-2.0.0/05-concepts/06-database/06-filter.md
@@ -148,19 +148,19 @@ await User.db.find(
 
 In the example we fetch all users with a name that does not start with B.
 
-### iLike
+### ilike
 
-iLike works the same as `like` but is case-insensitive.
+`ilike` works the same as `like` but is case-insensitive.
 
 ```dart
 await User.db.find(
-  where: (t) => t.name.iLike('a%')
+  where: (t) => t.name.ilike('a%')
 );
 ```
 
 In the example we fetch all users with a name that starts with a or A.
 
-There is a negated version of iLike that can be used to exclude rows from the result.
+There is a negated version of `ilike` that can be used to exclude rows from the result.
 
 ```dart
 await User.db.find(

--- a/versioned_docs/version-2.0.0/05-concepts/06-database/07-relation-queries.md
+++ b/versioned_docs/version-2.0.0/05-concepts/06-database/07-relation-queries.md
@@ -125,7 +125,7 @@ var user = await Company.db.findById(
   employeeId,
   include: Company.include(
     employees: Employee.includeList(
-      where: (t) => t.name.iLike('a%')
+      where: (t) => t.name.ilike('a%')
     ),
   ),
 );`

--- a/versioned_docs/version-2.1.0/06-concepts/06-database/06-filter.md
+++ b/versioned_docs/version-2.1.0/06-concepts/06-database/06-filter.md
@@ -148,19 +148,19 @@ await User.db.find(
 
 In the example we fetch all users with a name that does not start with B.
 
-### iLike
+### ilike
 
-iLike works the same as `like` but is case-insensitive.
+`ilike` works the same as `like` but is case-insensitive.
 
 ```dart
 await User.db.find(
-  where: (t) => t.name.iLike('a%')
+  where: (t) => t.name.ilike('a%')
 );
 ```
 
 In the example we fetch all users with a name that starts with a or A.
 
-There is a negated version of iLike that can be used to exclude rows from the result.
+There is a negated version of `ilike` that can be used to exclude rows from the result.
 
 ```dart
 await User.db.find(

--- a/versioned_docs/version-2.1.0/06-concepts/06-database/07-relation-queries.md
+++ b/versioned_docs/version-2.1.0/06-concepts/06-database/07-relation-queries.md
@@ -125,7 +125,7 @@ var user = await Company.db.findById(
   employeeId,
   include: Company.include(
     employees: Employee.includeList(
-      where: (t) => t.name.iLike('a%')
+      where: (t) => t.name.ilike('a%')
     ),
   ),
 );`


### PR DESCRIPTION
## Description
- [This PR aligned](https://github.com/serverpod/serverpod_docs/commit/ea118fbc641e2fc9c25e1c98ec169cb63d6ee0b7) the docs so that `iLike` was used everywhere (it was mixed in the docs before this PR).
- However, the correct casing is actually `ilike`, which this PR addresses.

## Changes
- Changes `iLike` to `ilike` 
- Adds code highlighting to `ilike`