### PR TITLE
fix: add test tools experimental flag to the experimental page

### DIFF
--- a/docs/06-concepts/18-testing/01-get-started.md
+++ b/docs/06-concepts/18-testing/01-get-started.md
@@ -2,6 +2,12 @@
 
 Serverpod provides simple but feature rich test tools to make testing your backend a breeze.
 
+:::warning
+
+The test tools are an experimental feature. Experimental features should not be used in production environments, as their stability is uncertain and they may receive breaking changes in upcoming releases.
+
+:::
+
 :::info
 
 For Serverpod Mini projects, everything related to the database in this guide can be ignored.

--- a/docs/06-concepts/19-experimental.md
+++ b/docs/06-concepts/19-experimental.md
@@ -18,6 +18,7 @@ The current options you can pass are:
 |:-----|:---|
 | **all** | Enables all available experimental features. |
 | **inheritance** | Allows using the `extends` keyword in your model files to create class hierarchies.|
+| **testTools** | Generates the Serverpod test tools, see the [testing get started page](testing/get-started) for more information.|
 
 ## Inheritance
 


### PR DESCRIPTION
## Description
- The test tools experimental flag was missing from the experimental flags page.