### PR TITLE
fix: add note about concurrency

### DIFF
--- a/docs/06-concepts/18-testing/01-get-started.md
+++ b/docs/06-concepts/18-testing/01-get-started.md
@@ -206,7 +206,13 @@ By default this starts up both the `development` and `test` profiles. To only st
 Now the test is ready to be run:
 
 ```bash
-dart test integration_test
+dart test integration_test --concurrency=1
 ```
+
+:::note
+
+The `--concurrency=1` flag has to be set to ensure only one Serverpod server is running at a time.
+
+:::
 
 Happy testing!

--- a/docs/06-concepts/18-testing/02-the-basics.md
+++ b/docs/06-concepts/18-testing/02-the-basics.md
@@ -195,14 +195,6 @@ withServerpod(
 );
 ```
 
-Additionally, when setting `rollbackDatabase.disabled`, it may also be needed to pass the `--concurrency=1` flag to the dart test runner. Otherwise multiple tests might pollute each others database state:
-
-```bash
-dart test integration_test --concurrency=1
-```
-
-For the other cases this is not an issue, as each `withServerpod` has its own transaction and will therefore be isolated.
-
 ### `runMode`
 
 The run mode that Serverpod should be running in. Defaults to `test`.


### PR DESCRIPTION
## Changes
The test tools has to be run with the `--concurrency=1` flag to avoid Serverpod server port collisions. This was missing in the initial version of the test docs.