### PR TITLE
fix: Grammar on get started with tests page.

### DIFF
--- a/docs/06-concepts/18-testing/01-get-started.md
+++ b/docs/06-concepts/18-testing/01-get-started.md
@@ -4,7 +4,7 @@ Serverpod provides simple but feature rich test tools to make testing your backe
 
 :::warning
 
-The test tools are an experimental feature. Experimental features should not be used in production environments, as their stability is uncertain and they may receive breaking changes in upcoming releases.
+The test tools is an experimental feature. Experimental features should not be used in production environments, as their stability is uncertain and they may receive breaking changes in upcoming releases.
 
 :::
 


### PR DESCRIPTION
I'm pretty sure this should be 'is', as 'test tools' is singular (it's just one feature).