### PR TITLE
fix: Remove the unreferenced List of Employee from the get-started doc

### DIFF
--- a/docs/01-get-started.md
+++ b/docs/01-get-started.md
@@ -176,7 +176,6 @@ class: Company
 fields:
   name: String
   foundedDate: DateTime?
-  employees: List<Employee>
 ```
 
 Supported types are `bool`, `int`, `double`, `String`, `DateTime`, `ByteData`, and other serializable classes. You can also use `List`s and `Map`s of the supported types, just make sure to specify the types. Null safety is supported. The keys of `Map` must be non-nullable `String`s. Once your classes are generated, you can use them as parameters or return types to endpoint methods.

--- a/versioned_docs/version-1.1.1/01-get-started.md
+++ b/versioned_docs/version-1.1.1/01-get-started.md
@@ -118,7 +118,6 @@ class: Company
 fields:
   name: String
   foundedDate: DateTime?
-  employees: List<Employee>
 ```
 
 Supported types are `bool`, `int`, `double`, `String`, `DateTime`, `ByteData`, and other serializable classes. You can also use `List`s and `Map`s of the supported types, just make sure to specify the types. Null safety is supported. The keys of `Map` must be non-nullable `String`s. Once your classes are generated, you can use them as parameters or return types to endpoint methods.

--- a/versioned_docs/version-1.2.0/01-get-started.md
+++ b/versioned_docs/version-1.2.0/01-get-started.md
@@ -124,7 +124,6 @@ class: Company
 fields:
   name: String
   foundedDate: DateTime?
-  employees: List<Employee>
 ```
 
 Supported types are `bool`, `int`, `double`, `String`, `DateTime`, `ByteData`, and other serializable classes. You can also use `List`s and `Map`s of the supported types, just make sure to specify the types. Null safety is supported. The keys of `Map` must be non-nullable `String`s. Once your classes are generated, you can use them as parameters or return types to endpoint methods.

--- a/versioned_docs/version-2.0.0/01-get-started.md
+++ b/versioned_docs/version-2.0.0/01-get-started.md
@@ -140,7 +140,6 @@ class: Company
 fields:
   name: String
   foundedDate: DateTime?
-  employees: List<Employee>
 ```
 
 Supported types are `bool`, `int`, `double`, `String`, `DateTime`, `ByteData`, and other serializable classes. You can also use `List`s and `Map`s of the supported types, just make sure to specify the types. Null safety is supported. The keys of `Map` must be non-nullable `String`s. Once your classes are generated, you can use them as parameters or return types to endpoint methods.

--- a/versioned_docs/version-2.1.0/01-get-started.md
+++ b/versioned_docs/version-2.1.0/01-get-started.md
@@ -176,7 +176,6 @@ class: Company
 fields:
   name: String
   foundedDate: DateTime?
-  employees: List<Employee>
 ```
 
 Supported types are `bool`, `int`, `double`, `String`, `DateTime`, `ByteData`, and other serializable classes. You can also use `List`s and `Map`s of the supported types, just make sure to specify the types. Null safety is supported. The keys of `Map` must be non-nullable `String`s. Once your classes are generated, you can use them as parameters or return types to endpoint methods.


### PR DESCRIPTION
Because there is an `employees` field with type `List<Employee>` in the company definition, running `serverpod generate`serverpod generate fails with `The field has an invalid datatype "Employee".` error. 

Later in the docs in the [Object database mapping](https://docs.serverpod.dev/get-started#object-database-mapping) section, there is no employees field, so I'm guessing it's okay to remove it. 