### PR TITLE
add missing equals sign to bash command

### DIFF
--- a/docs/06-concepts/18-testing/01-get-started.md
+++ b/docs/06-concepts/18-testing/01-get-started.md
@@ -196,7 +196,7 @@ That's it, the project setup should be ready to start using the test tools!
 Go to the server directory and generate the test tools:
 
  ```bash
- serverpod generate --experimental-features testTools
+ serverpod generate --experimental-features=testTools
  ```
 
 The default location for the generated file is `test/integration/test_tools/serverpod_test_tools.dart`. The folder name `test/integration` is chosen to differentiate from unit tests (see the [best practises section](best-practises#unit-and-integration-tests) for more information on this).


### PR DESCRIPTION
Found a missing `=` in the bash command 