### PR TITLE
fix: Add documentation for transaction isolation level.

### DIFF
--- a/docs/06-concepts/06-database/08-transactions.md
+++ b/docs/06-concepts/06-database/08-transactions.md
@@ -2,7 +2,7 @@
 
 The essential point of a database transaction is that it bundles multiple steps into a single, all-or-nothing operation. The intermediate states between the steps are not visible to other concurrent transactions, and if some failure occurs that prevents the transaction from completing, then none of the steps affect the database at all.
 
-Serverpod handles database transactions through the `session.db.transaction` method. The method takes a callback function that receives a transaction object. The transaction object is then passed to any database operation to be included in the same transaction.
+Serverpod handles database transactions through the `session.db.transaction` method. The method takes a callback function that receives a transaction object. 
 
 The transaction is committed when the callback function returns, and rolled back if an exception is thrown. Any return value of the callback function is returned by the `transaction` method.
 

--- a/docs/06-concepts/06-database/08-transactions.md
+++ b/docs/06-concepts/06-database/08-transactions.md
@@ -34,12 +34,10 @@ At the time of writing, the default isolation level for the PostgreSQL database 
 To set the isolation level, configure the `isolationLevel` property of the `TransactionSettings` object:
 
 ```dart
-var result = await session.db.transaction(
+await session.db.transaction(
   (transaction) async {
     await Company.db.insertRow(session, company, transaction: transaction);
     await Employee.db.insertRow(session, employee, transaction: transaction);
-    
-    return true;
   },
   settings: TransactionSettings(isolationLevel: IsolationLevel.serializable),
 );

--- a/docs/06-concepts/06-database/08-transactions.md
+++ b/docs/06-concepts/06-database/08-transactions.md
@@ -43,7 +43,7 @@ await session.db.transaction(
 );
 ```
 
-In the example we set the isolation level to `IsolationLevel.serializable`.
+In the example the isolation level is set to `IsolationLevel.serializable`.
 
 The available isolation levels are:
 

--- a/docs/06-concepts/06-database/08-transactions.md
+++ b/docs/06-concepts/06-database/08-transactions.md
@@ -2,7 +2,9 @@
 
 The essential point of a database transaction is that it bundles multiple steps into a single, all-or-nothing operation. The intermediate states between the steps are not visible to other concurrent transactions, and if some failure occurs that prevents the transaction from completing, then none of the steps affect the database at all.
 
-Serverpod handles database transactions through the `session.db.transaction` method. The transaction takes a method that performs any database queries or other operations and optionally returns a value.
+Serverpod handles database transactions through the `session.db.transaction` method. The method takes a callback function that receives a transaction object. The transaction object is then passed to any database operation to be included in the same transaction.
+
+The transaction is committed when the callback function returns, and rolled back if an exception is thrown. Any return value of the callback function is returned by the `transaction` method.
 
 Simply pass the transaction object to each database operation method to include them in the same atomic operation:
 

--- a/docs/06-concepts/06-database/08-transactions.md
+++ b/docs/06-concepts/06-database/08-transactions.md
@@ -47,7 +47,7 @@ In the example we set the isolation level to `IsolationLevel.serializable`.
 
 The available isolation levels are:
 
-| Isolation Level | Value                 | Description |
+| Isolation Level | Constant              | Description |
 |-----------------|-----------------------|-------------|
 | Read uncommitted | `IsolationLevel.readUncommitted` | Exhibits the same behavior as `IsolationLevel.readCommitted` in PostgresSQL |
 | Read committed | `IsolationLevel.readCommitted` | Each statement in the transaction sees a snapshot of the database as of the beginning of that statement. |


### PR DESCRIPTION
Closes: https://github.com/serverpod/serverpod/issues/3050

Adds documentation for transaction isolation level.

Also updates the description for transactions a bit to better reflect the current state of the code.

Image of the documentation:
<img width="934" alt="Screenshot 2024-12-12 at 16 05 47" src="https://github.com/user-attachments/assets/ccacc98c-1457-45c4-b130-8d569ff21146" />


After review:

<img width="878" alt="Screenshot 2024-12-13 at 09 36 37" src="https://github.com/user-attachments/assets/ccee91fc-02cc-481f-b565-41e5f74d8c40" />

