### PR TITLE
fix: Document free endpoint defintion placement.

### DIFF
--- a/docs/01-get-started.md
+++ b/docs/01-get-started.md
@@ -121,7 +121,7 @@ At first glance, the complexity of the server may seem daunting, but there are o
 These are the most important directories:
 
 - `config`: These are the configuration files for your Serverpod. These include a `password.yaml` file with your passwords and configurations for running your server in development, staging, and production. By default, everything is correctly configured to run your server locally.
-- `lib/src/endpoints`: This is where you place your server's endpoints. When you add methods to an endpoint, Serverpod will generate the corresponding methods in your client.
+- `lib/src/endpoints`: This is the default location for your server's endpoints. When you add methods to an endpoint, Serverpod will generate the corresponding methods in your client.
 - `lib/src/models`: The model definition files are placed here. The files define the classes you can pass through your API and how they relate to your database. Serverpod generates serializable objects from the model definitions.
 
 Both the `endpoints` and `models` directories contain sample files that give a quick idea of how they work. So this a great place to start learning.

--- a/docs/06-concepts/01-working-with-endpoints.md
+++ b/docs/06-concepts/01-working-with-endpoints.md
@@ -1,6 +1,6 @@
 # Working with endpoints
 
-Endpoints are the connection points to the server from the client. With Serverpod, you add methods to your endpoint, and your client code will be generated to make the method call. For the code to be generated, you need to place your endpoint in the endpoints directory of your server. Your endpoint should extend the `Endpoint` class. For methods to be generated, they need to return a typed `Future`, and its first argument should be a `Session` object. The `Session` object holds information about the call being made and provides access to the database.
+Endpoints are the connection points to the server from the client. With Serverpod, you add methods to your endpoint, and your client code will be generated to make the method call. For the code to be generated, you need to place the endpoint file anywhere under the **lib** directory of your server. Your endpoint should extend the `Endpoint` class. For methods to be generated, they need to return a typed `Future`, and its first argument should be a `Session` object. The `Session` object holds information about the call being made and provides access to the database.
 
 ```dart
 import 'package:serverpod/serverpod.dart';

--- a/docs/06-concepts/01-working-with-endpoints.md
+++ b/docs/06-concepts/01-working-with-endpoints.md
@@ -72,3 +72,21 @@ maxRequestSize: 1048576
 ## Return types
 
 The return type must be a typed Future. Supported return types are the same as for parameters.
+
+## Ignore endpoint definition
+
+If you want the code generator to ignore an endpoint definition, you can annotate the class with `@ignoreEndpoint`, imported from `serverpod_shared/annotations.dart`.  This can be useful if you want to keep the definition in your codebase without generating server or client bindings for it.
+
+```dart
+import 'package:serverpod/serverpod.dart';
+import 'package:serverpod_shared/annotations.dart';
+
+@ignoreEndpoint
+class ExampleEndpoint extends Endpoint {
+  Future<String> hello(Session session, String name) async {
+    return 'Hello $name';
+  }
+}
+```
+
+The above code will not generate any server or client bindings for the example endpoint.


### PR DESCRIPTION
Closes: [#3052](https://github.com/serverpod/serverpod/issues/3052)

Updates the documentation to reflect that endpoints can now be placed anywhere in the **lib** directory.
I didn't add any information for the tutorials since these are case examples.

Do we think this is enough, or does it need to be clarified more?

**Changes in get started**
<img width="867" alt="Screenshot 2024-12-13 at 13 28 36" src="https://github.com/user-attachments/assets/8172844d-bd07-469c-9f37-6b2df159ca3e" />

**Changes in working with endpoints**

<img width="865" alt="Screenshot 2024-12-13 at 13 29 23" src="https://github.com/user-attachments/assets/766538e7-82d9-4808-917f-f9f0f1ee762d" />

--------------------------------------

<img width="883" alt="Screenshot 2024-12-13 at 13 29 35" src="https://github.com/user-attachments/assets/33602d9b-a6b3-4942-bfda-3c7f90a8ef04" />
