### PR TITLE
Add more info when changing aws region

### DIFF
--- a/docs/07-deployments/04-deploying-to-aws.md
+++ b/docs/07-deployments/04-deploying-to-aws.md
@@ -163,7 +163,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
 
 :::
 

--- a/versioned_docs/version-0.9.10/04-deployments/01-deploying-to-aws.md
+++ b/versioned_docs/version-0.9.10/04-deployments/01-deploying-to-aws.md
@@ -77,7 +77,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file.
 
 :::
 

--- a/versioned_docs/version-0.9.11/04-deployments/01-deploying-to-aws.md
+++ b/versioned_docs/version-0.9.11/04-deployments/01-deploying-to-aws.md
@@ -77,7 +77,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file.
 
 :::
 

--- a/versioned_docs/version-0.9.20/05-deployments/01-deploying-to-aws.md
+++ b/versioned_docs/version-0.9.20/05-deployments/01-deploying-to-aws.md
@@ -77,7 +77,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file.
 
 :::
 

--- a/versioned_docs/version-0.9.21/05-deployments/01-deploying-to-aws.md
+++ b/versioned_docs/version-0.9.21/05-deployments/01-deploying-to-aws.md
@@ -77,7 +77,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file.
 
 :::
 

--- a/versioned_docs/version-0.9.22/05-deployments/01-deploying-to-aws.md
+++ b/versioned_docs/version-0.9.22/05-deployments/01-deploying-to-aws.md
@@ -77,7 +77,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
 
 :::
 

--- a/versioned_docs/version-0.9.8/04-deployments/01-deploying-to-aws.md
+++ b/versioned_docs/version-0.9.8/04-deployments/01-deploying-to-aws.md
@@ -77,7 +77,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file.
 
 :::
 

--- a/versioned_docs/version-0.9.9/04-deployments/01-deploying-to-aws.md
+++ b/versioned_docs/version-0.9.9/04-deployments/01-deploying-to-aws.md
@@ -77,7 +77,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file.
 
 :::
 

--- a/versioned_docs/version-1.0.0/05-deployments/01-deploying-to-aws.md
+++ b/versioned_docs/version-1.0.0/05-deployments/01-deploying-to-aws.md
@@ -77,7 +77,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
 
 :::
 

--- a/versioned_docs/version-1.1.0/05-deployments/04-deploying-to-aws.md
+++ b/versioned_docs/version-1.1.0/05-deployments/04-deploying-to-aws.md
@@ -77,7 +77,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
 
 :::
 

--- a/versioned_docs/version-1.1.1/06-deployments/04-deploying-to-aws.md
+++ b/versioned_docs/version-1.1.1/06-deployments/04-deploying-to-aws.md
@@ -77,7 +77,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
 
 :::
 

--- a/versioned_docs/version-1.2.0/06-deployments/04-deploying-to-aws.md
+++ b/versioned_docs/version-1.2.0/06-deployments/04-deploying-to-aws.md
@@ -77,7 +77,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
 
 :::
 

--- a/versioned_docs/version-2.0.0/06-deployments/04-deploying-to-aws.md
+++ b/versioned_docs/version-2.0.0/06-deployments/04-deploying-to-aws.md
@@ -83,7 +83,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
 
 :::
 

--- a/versioned_docs/version-2.1.0/07-deployments/04-deploying-to-aws.md
+++ b/versioned_docs/version-2.1.0/07-deployments/04-deploying-to-aws.md
@@ -163,7 +163,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
 
 :::
 

--- a/versioned_docs/version-2.2.0/07-deployments/04-deploying-to-aws.md
+++ b/versioned_docs/version-2.2.0/07-deployments/04-deploying-to-aws.md
@@ -163,7 +163,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
 
 :::
 

--- a/versioned_docs/version-2.3.0/07-deployments/04-deploying-to-aws.md
+++ b/versioned_docs/version-2.3.0/07-deployments/04-deploying-to-aws.md
@@ -163,7 +163,7 @@ You acquired a hosted zone id and two certificate ARNs from AWS in the previous 
 
 :::info
 
-If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `instance_ami` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
+If you deploy your servers in a region other than Oregon (us-west-2), you will need to update the `aws_region`, `instance_ami` and in some cases `instance_type` variable. Instructions are in the configuration file. In addition, you will also need to update the region in your Github deployment file located in `.github/workflows/deployment-aws.yml`.
 
 :::
 


### PR DESCRIPTION
Wasted an hour because I didn't see that there is `aws_region` field. 

It might take sense to you, but to a newcomer, I think it's weird that docs are talking about changing `ami_instance` and never mention the `aws_region` field.