### PR TITLE
chore: Add issue template pointing towards serverpod.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Something missing or incorrect?
+    url: https://github.com/serverpod/serverpod/issues/new/choose
+    about: Please open an issue in the Serverpod repository for documentation corrections or suggestions.


### PR DESCRIPTION
Prevents issues from being created in the docs repository and refer them to the Serverpod repo.

Creating a new issue in this repository will now display this prompt

<img width="872" alt="Screenshot 2025-01-21 at 15 32 42" src="https://github.com/user-attachments/assets/01e9cdeb-dbbb-4b77-a0ed-b410e19e3549" />


Directing you to this page:

<img width="1461" alt="Screenshot 2025-01-21 at 15 33 23" src="https://github.com/user-attachments/assets/9b6e610e-69cf-488b-b656-b321608d30b5" />
