### PR TITLE
fix: Fixes a typo that was fixed in the repo in 2.3.0

### DIFF
--- a/docs/07-deployments/04-deploying-to-aws.md
+++ b/docs/07-deployments/04-deploying-to-aws.md
@@ -146,7 +146,7 @@ ExecStart=/home/ec2-user/serverpod/active/mypod_server/deploy/aws/scripts/run_se
 Restart=always
 
 [Install]
-WantedBy=muti-user.target
+WantedBy=multi-user.target
 WantedBy=network-online.target
 EOF
 

--- a/versioned_docs/version-2.3.0/07-deployments/04-deploying-to-aws.md
+++ b/versioned_docs/version-2.3.0/07-deployments/04-deploying-to-aws.md
@@ -146,7 +146,7 @@ ExecStart=/home/ec2-user/serverpod/active/mypod_server/deploy/aws/scripts/run_se
 Restart=always
 
 [Install]
-WantedBy=muti-user.target
+WantedBy=multi-user.target
 WantedBy=network-online.target
 EOF
 

--- a/versioned_docs/version-2.4.0/07-deployments/04-deploying-to-aws.md
+++ b/versioned_docs/version-2.4.0/07-deployments/04-deploying-to-aws.md
@@ -146,7 +146,7 @@ ExecStart=/home/ec2-user/serverpod/active/mypod_server/deploy/aws/scripts/run_se
 Restart=always
 
 [Install]
-WantedBy=muti-user.target
+WantedBy=multi-user.target
 WantedBy=network-online.target
 EOF
 


### PR DESCRIPTION
This typo was fixed in this PR https://github.com/serverpod/serverpod/pull/2976 and shipped with 2.3.0.

This fixes the typo for the newer versions.

Noticed and originally fixed by @damolator in https://github.com/serverpod/serverpod_docs/pull/250