### PR TITLE
docs: Add documentation for `Endpoint` inheritance

### DIFF
--- a/docs/06-concepts/01-working-with-endpoints.md
+++ b/docs/06-concepts/01-working-with-endpoints.md
@@ -199,7 +199,7 @@ Since `CalculatorEndpoint` is marked as `@ignoreEndpoint` it will not be exposed
 
 ### Overriding endpoint methods
 
-Suppose you had a `GreeterBaseEndpoint` whose behavior you want to adapt.
+It is possible to override methods of the super class. This can be useful when you want to modify the behavior of specific methods but preserve the rest.
 
 ```dart
 import 'package:serverpod/serverpod.dart';

--- a/docs/06-concepts/01-working-with-endpoints.md
+++ b/docs/06-concepts/01-working-with-endpoints.md
@@ -90,7 +90,7 @@ class ExampleEndpoint extends Endpoint {
 
 The above code will not generate any server or client bindings for the example endpoint.
 
-Alternatively you can disable single methods like in the example below, where `hello` is exposed to the client, but `goodbye` is not:
+Alternatively, you can disable single methods like in the example below, where `hello` is exposed to the client, but `goodbye` is not:
 
 ```dart
 import 'package:serverpod/serverpod.dart';
@@ -109,7 +109,7 @@ class ExampleEndpoint extends Endpoint {
 
 ## Endpoint inheritance
 
-It is possible to extend existing endpoints, from your own app or other modules, by subclassing them. In case the parent endpoint was marked as `abstract` or `@ignoreEndpoint`, no client code is generated for it, but a client will be generated for your subclass – as long as it does not opt-out by any of the aforementioned ways.
+It is possible to extend existing endpoints, from your own app or other modules, by subclassing them. If the parent endpoint was marked as `abstract` or `@ignoreEndpoint`, no client code is generated for it, but a client will be generated for your subclass – as long as it does not opt-out by any of the aforementioned ways.
 
 ```dart
 import 'package:serverpod/serverpod.dart';
@@ -153,14 +153,14 @@ class ExcitedGreeter extends GreeterBase {
 }
 ```
 
-In the above example `ExcitedGreeter` inherits from `GreeterBase`. Since the base class is marked as `abstract` no client was generated for it, but now all of its visible endpoint methods would be exposed through the sub-class `ExcitedGreeter`.
+In the above example, `ExcitedGreeter` inherits from `GreeterBase`. Since the base class is marked as `abstract`, no client was generated for it, but now all of its visible endpoint methods would be exposed through the sub-class `ExcitedGreeter`.
 
 The sub-class `ExcitedGreeter` is an example of all possible modifications to the abstract base class and contains the following changes:
 
 - `hello` is overriden and augments the super class' implementation with a trailing `!!!`
 - `goodbye` is now exposed through the sub-class, as it was not individually hidden and the sub-class does not further augment it
-- `wave`, which is explictly ignored in the base-class is still not exposed, as the sub-class did not opt into re-exposing it
-- `wavePerson` was explicitly overriden to be ignored. Don't worry about the `throw` in the method implementation, which is only needed to satisfy the compiler. In practice this method can not be called from the client anymore.
+- `wave`, which is explicitly ignored in the base-class, is still not exposed, as the sub-class did not opt into re-exposing it
+- `wavePerson` was explicitly overriden to be ignored. Don't worry about the `throw` in the method implementation, which is only needed to satisfy the compiler. In practice, this method can not be called from the client anymore.
 
 ### API versioning for breaking changes
 
@@ -189,12 +189,12 @@ class TeamV2Endpoint extends TeamEndpoint {
 }
 ```
 
-In the above example we created a new `TeamV2` endpoint which hides the `join` method and instead exposes a `joinWithCode` method, plus all the other inherited (and untouched) methods from the parent class.
+In the above example, we created a new `TeamV2` endpoint, which hides the `join` method and instead exposes a `joinWithCode` method, plus all the other inherited (and untouched) methods from the parent class.
 
 While we may have liked to re-use the `join` method name, Dart inheritance rules do not allow doing so.
 
-Then in your client you could move all usages from `client.team` to `client.teamV2`, and could eventually remove the old endpoint. Either by marking it with `@ignoreEndpoint` on the class or deleting it and moving the untouched method implementations you want to keep to the V2 endpoint class.
+In your client, you could then move all usages from `client.team` to `client.teamV2` and eventually remove the old endpoint. Either by marking it with `@ignoreEndpoint` on the class or deleting it and moving the untouched method implementations you want to keep to the V2 endpoint class.
 
 An alternative pattern to consider would be to move all the business logic for an endpoint into a helper class, and then call into that from the endpoint. In case you want to create a V2 version later, you might be able to reuse most of the underlying business logic through that helper class, and don't have to sub-class the old endpoint. This has the added benefit of the endpoint class clearly listing all exposed methods, and you don't have to wonder what you inherit from the base class.
 
-Either approach has its pros and cons, and it depends on the concrete circumstances to pick the one that is most useful. Both give you all the tools you need to extend and update your API while gracefully moving clients along, giving them time to update.
+Either approach has its pros and cons, and it depends on the concrete circumstances to pick the one that is most useful. Both give you all the tools you need to extend and update your API while moving clients along gracefully, giving them time to update.

--- a/docs/06-concepts/01-working-with-endpoints.md
+++ b/docs/06-concepts/01-working-with-endpoints.md
@@ -119,7 +119,7 @@ Endpoints can be based on other endpoints using inheritance, like `class ChildEn
 
 Currently, there are the following possibilities to extend another `Endpoint` class:
 
-### Inheriting from a concrete (visible) `Endpoint` class
+### Inheriting from an `Endpoint` class
 
 Suppose there is an existing `CalculatorEndpoint` (presumably defined in another package, otherwise the existing one could be adapted) which you want to extend with further functionality.
 
@@ -142,7 +142,7 @@ class MyCalculatorEndpoint extends CalculatorEndpoint {
 The generated client code will now be able to access both `CalculatorEndpoint` and `MyCalculatorEndpoint`.
 Whereas the `CalculatorEndpoint` only exposes the original `add` method, `MyCalculatorEndpoint` now exposes both the inherited `add` and its own `subtract` methods.
 
-### Inheriting from an `abstract` `Endpoint` class
+### Inheriting from an `Endpoint` class marked `abstract`
 
 Endpoints marked as `abstract` are not added to the server. But if they are subclassed, their methods will be exposed through the subclass.
 
@@ -177,7 +177,7 @@ class MyCalculatorEndpoint extends CalculatorEndpoint {
 
 In this case it will expose both an `add` and a `subtract` method.
 
-### Inheriting from an `@ignoreEndpoint` `Endpoint` class
+### Inheriting from an `Endpoint` class annotated with `@ignoreEndpoint`
 
 Suppose you had an `Endpoint` class marked with `@ignoreEndpoint` and a subclass that extends it:
 
@@ -251,7 +251,7 @@ Don't worry about the exception in the `subtract` implementation. That is only a
 
 Hiding endpoints from a super class is only appropriate in case the parent `class` is `abstract` or annotated with `@ignoreEndpoint`. Otherwise the method that should be hidden on the child would still be accessible via the parent class.
 
-### Unhiding endpoint methods with `@ignoreEndpoint`
+### Unhiding endpoint methods annotated with `@ignoreEndpoint` in the super class
 
 The reverse of the previous example would be a base endpoint that has a method marked with `@ignoreEndpoint`, which you now want to expose on the subclass.
 

--- a/docs/06-concepts/01-working-with-endpoints.md
+++ b/docs/06-concepts/01-working-with-endpoints.md
@@ -155,7 +155,7 @@ class ExcitedGreeter extends GreeterBase {
 
 In the above example `ExcitedGreeter` inherits from `GreeterBase`. Since the base class is marked as `abstract` no client was generated for it, but now all of its visible endpoint methods would be exposed through the sub-class `ExcitedGreeter`.
 
-The sub-class applies the following modifications though:
+The sub-class `ExcitedGreeter` is an example of all possible modifications to the abstract base class and contains the following changes:
 
 - `hello` is overriden and augments the super class' implementation with a trailing `!!!`
 - `goodbye` is now exposed through the sub-class, as it was not individually hidden and the sub-class does not further augment it

--- a/docs/06-concepts/01-working-with-endpoints.md
+++ b/docs/06-concepts/01-working-with-endpoints.md
@@ -164,7 +164,7 @@ The sub-class applies the following modifications though:
 
 ### API versioning for breaking changes
 
-Endpoint sub-class can be useful when having to do a breaking change on an endpoint, but you want to keep sharing most of it's implementation with the old endpoint.
+An endpoint sub-class can be useful when having to do a breaking change on an endpoint, but you need to keep supporting existing clients. Doing so also allows you to keep sharing most of its implementation with the old endpoint.
 
 Imagine you had a "team" management endpoint where before a user could join if they had an e-mail address ending in the expected domain, but now it should be opened up for anyone to join if they can provide an "invite code".
 

--- a/docs/06-concepts/01-working-with-endpoints.md
+++ b/docs/06-concepts/01-working-with-endpoints.md
@@ -115,13 +115,14 @@ In this case the `ExampleEndpoint` will only expose the `hello` method, whereas 
 
 ## Endpoint method inheritance
 
-Endpoints can be based on other endpoints using inheritance, like `class ChildEndpoint extends ParentEndpoint`. If the parent endpoint was marked as `abstract` or `@ignoreEndpoint`, no client code is generated for it, but a client will be generated for your subclass – as long as it does not opt out again.
+Endpoints can be based on other endpoints using inheritance, like `class ChildEndpoint extends ParentEndpoint`. If the parent endpoint was marked as `abstract` or `@ignoreEndpoint`, no client code is generated for it, but a client will be generated for your subclass – as long as it does not opt out again.  
+Inheritance gives you the possibility to modify the behavior of `Endpoint` classes defined in other Serverpod modules.
 
 Currently, there are the following possibilities to extend another `Endpoint` class:
 
 ### Inheriting from an `Endpoint` class
 
-Suppose there is an existing `CalculatorEndpoint` (presumably defined in another package, otherwise the existing one could be adapted) which you want to extend with further functionality.
+Given an existing `Endpoint` class, it is possible to extend or modify its behavior while retaining the already exposed methods.
 
 ```dart
 import 'package:serverpod/serverpod.dart';

--- a/docs/06-concepts/01-working-with-endpoints.md
+++ b/docs/06-concepts/01-working-with-endpoints.md
@@ -109,7 +109,7 @@ class ExampleEndpoint extends Endpoint {
 
 ## Endpoint inheritance
 
-It is possible to extend existing endpoints, from your own app or other modules, by subclassing them. If the parent endpoint was marked as `abstract` or `@ignoreEndpoint`, no client code is generated for it, but a client will be generated for your subclass – as long as it does not opt-out by any of the aforementioned ways.
+Extending existing endpoints from your own app or other modules is possible by subclassing them. If the parent endpoint was marked as `abstract` or `@ignoreEndpoint`, no client code is generated for it, but a client will be generated for your subclass – as long as it does not opt out by any of the aforementioned ways.
 
 ```dart
 import 'package:serverpod/serverpod.dart';
@@ -139,7 +139,7 @@ class ExcitedGreeter extends GreeterBase {
     return '${super.hello(session, name)}!!!';
   }
 
-  // to enable `wave`, which was marked with `@ignoreEndpoint` on the base class, you can override it on the sub-class and call the `super` implementation. This will create the method on the endpoint.
+  // To enable `wave`, which was marked with `@ignoreEndpoint` on the base class, you can override it on the sub-class and call the `super` implementation. This will create the method on the endpoint.
   // @override
   // Future<String> wave(Session session) async {
   //   return super.wave(session);
@@ -157,8 +157,8 @@ In the above example, `ExcitedGreeter` inherits from `GreeterBase`. Since the ba
 
 The sub-class `ExcitedGreeter` is an example of all possible modifications to the abstract base class and contains the following changes:
 
-- `hello` is overriden and augments the super class' implementation with a trailing `!!!`
-- `goodbye` is now exposed through the sub-class, as it was not individually hidden and the sub-class does not further augment it
+- `hello` is overridden and augments the super class' implementation with a trailing `!!!`
+- `goodbye` is now exposed through the sub-class, as it was not individually hidden, and the sub-class does not further augment it
 - `wave`, which is explicitly ignored in the base-class, is still not exposed, as the sub-class did not opt into re-exposing it
 - `wavePerson` was explicitly overriden to be ignored. Don't worry about the `throw` in the method implementation, which is only needed to satisfy the compiler. In practice, this method can not be called from the client anymore.
 
@@ -193,8 +193,8 @@ In the above example, we created a new `TeamV2` endpoint, which hides the `join`
 
 While we may have liked to re-use the `join` method name, Dart inheritance rules do not allow doing so.
 
-In your client, you could then move all usages from `client.team` to `client.teamV2` and eventually remove the old endpoint. Either by marking it with `@ignoreEndpoint` on the class or deleting it and moving the untouched method implementations you want to keep to the V2 endpoint class.
+In your client, you could then move all usages from `client.team` to `client.teamV2` and eventually remove the old endpoint. Either mark it with `@ignoreEndpoint` on the class or delete it and move the untouched method implementations you want to keep to the V2 endpoint class.
 
-An alternative pattern to consider would be to move all the business logic for an endpoint into a helper class, and then call into that from the endpoint. In case you want to create a V2 version later, you might be able to reuse most of the underlying business logic through that helper class, and don't have to sub-class the old endpoint. This has the added benefit of the endpoint class clearly listing all exposed methods, and you don't have to wonder what you inherit from the base class.
+An alternative pattern to consider would be to move all the business logic for an endpoint into a helper class and then call into that from the endpoint. In case you want to create a V2 version later, you might be able to reuse most of the underlying business logic through that helper class, and don't have to sub-class the old endpoint. This has the added benefit of the endpoint class clearly listing all exposed methods, and you don't have to wonder what you inherit from the base class.
 
-Either approach has its pros and cons, and it depends on the concrete circumstances to pick the one that is most useful. Both give you all the tools you need to extend and update your API while moving clients along gracefully, giving them time to update.
+Either approach has pros and cons, and it depends on the concrete circumstances to pick the most useful one. Both give you all the tools you need to extend and update your API while gracefully moving clients along and giving them time to update.

--- a/docs/06-concepts/01-working-with-endpoints.md
+++ b/docs/06-concepts/01-working-with-endpoints.md
@@ -139,7 +139,7 @@ class ExcitedGreeter extends GreeterBase {
     return '${super.hello(session, name)}!!!';
   }
 
-  // to expose `wave` on the sub-class, override it like this to drop the `@ignoreEndpoint` annotation
+  // to enable `wave`, which was marked with `@ignoreEndpoint` on the base class, you can override it on the sub-class and call the `super` implementation. This will create the method on the endpoint.
   // @override
   // Future<String> wave(Session session) async {
   //   return super.wave(session);

--- a/docs/06-concepts/01-working-with-endpoints.md
+++ b/docs/06-concepts/01-working-with-endpoints.md
@@ -109,9 +109,9 @@ class ExampleEndpoint extends Endpoint {
 
 ## Endpoint method inheritance
 
-Endpoints can be based on other endpoint using inheritance like `class ChildEndpoint extends ParentEndpoint`. If the parent endpoint was marked as `abstract` or `@ignoreEndpoint`, no client code is generated for it, but a client will be generated for your subclass – as long as it does not opt out again.
+Endpoints can be based on other endpoints using inheritance, like `class ChildEndpoint extends ParentEndpoint`. If the parent endpoint was marked as `abstract` or `@ignoreEndpoint`, no client code is generated for it, but a client will be generated for your subclass – as long as it does not opt out again.
 
-Currently there are the following possibilities to extend another `Endpoint` class:
+Currently, there are the following possibilities to extend another `Endpoint` class:
 
 ### Inheriting from a concrete (visible) endpoint
 
@@ -138,12 +138,12 @@ class MyCalculator extends Calculator {
 The generated code will now contain both a `Calculator` and `MyCalculator` client.  
 The `MyCalculator` endpoint will not expose both `add` and `subtract` methods.
 
-To prevent usage of the base `Calculator` endpoint it might be appropriate to hide it.
-If the base class was defined in another module like shown above, then this is currently not possible. But if it's part of your own code, you could use the `@ignoreEndpoint` annotation from the previous section, or make it `abstract` as shown below.
+To prevent usage of the base `Calculator` endpoint, it might be appropriate to hide it.
+If the base class was defined in another module as shown above, then this is currently not possible. But if it's part of your own code, you could use the `@ignoreEndpoint` annotation from the previous section, or make it `abstract` as shown below.
 
 ### Inheriting from an `abstract` base class
 
-Endpoints marked as `abstract` require that they get sub-classed in order to be exposed on the server.
+Endpoints marked as `abstract` require that they get subclassed to be exposed on the server.
 
 Suppose you had the following base class:
 
@@ -157,9 +157,9 @@ abstract class Calculator extends Endpoint {
 }
 ```
 
-So far this would not generate any client or server code.
+So far, this would not generate any client or server code.
 
-If you then added a subclass which extends this base class, this subclass would be exposed to clients.
+If you then added a subclass that extends this base class, this subclass would be exposed to clients.
 
 ```dart
 import 'package:serverpod/serverpod.dart';
@@ -183,7 +183,7 @@ Now the `MyCalculator` endpoint exposes the inherited `add` endpoint method as w
 
 ### Inheriting from an `@ignoreEndpoint` base class
 
-Suppose you had a endpoint class marked with `@ignoreEndpoint`, in which case no code would be generated for it.
+Suppose you had an endpoint class marked with `@ignoreEndpoint`, in which case no code would be generated for it.
 
 ```dart
 import 'package:serverpod/serverpod.dart';
@@ -204,8 +204,8 @@ import 'package:serverpod/serverpod.dart';
 class MyCalculator extends Calculator {}
 ```
 
-Now all of the public endpoint methods of the base class, in this case just `add` would be exposed by the `MyCalculator` client.
-Additionally further methods could be added to the `MyCalculator` subclass.
+Now, all of the public endpoint methods of the base class, in this case just `add`, would be exposed by the `MyCalculator` client.
+Additionally, further methods could be added to the `MyCalculator` subclass.
 
 ### Overriding endpoint methods
 
@@ -221,9 +221,9 @@ abstract class GreeterBase extends Endpoint {
 }
 ```
 
-Now suppose you want to change the behavior of `greet`, to make it a little more excited. That could be achieved by subclassing that endpoint.
+Now, suppose you want to change the behavior of `greet`, to make it a little more excited. That could be achieved by subclassing that endpoint.
 
-In this case the base class is marked as `abstract`, but the following behavior would work just the same if it were marked with `@ignoredEndpoint` or just a plain `class`. Only that in the letter case you'd end up with 2 endpoints in the end.
+In this case, the base class is marked as `abstract`, but the following behavior would work just the same if it were marked with `@ignoredEndpoint` or just a plain `class`. Only that in the letter case, you'd end up with 2 endpoints in the end.
 
 ```dart
 import 'package:serverpod/serverpod.dart';
@@ -236,9 +236,9 @@ class ExcitedGreeter extends GreeterBase {
 }
 ```
 
-The `ExcitedGreeter` endpoint will now contain the single `greet` method, and it's implementation will augment the base class' one by adding `!!!` to that result.
+The `ExcitedGreeter` endpoint will now contain the single `greet` method, and its implementation will augment the base class's one by adding `!!!` to that result.
 
-This way you can modify the behavior of endpoint methods, while still sharing the implementation through calls to `super` where it makes sense. Only be aware that the method signature has to be compatible with the base class per Dart's rules, meaning you can add optional parameters, but can not add required parameters or change the return type.
+This way, you can modify the behavior of endpoint methods, while still sharing the implementation through calls to `super` where it makes sense. Only be aware that the method signature has to be compatible with the base class per Dart's rules, meaning you can add optional parameters, but can not add required parameters or change the return type.
 
 ### Hiding endpoint methods with `@ignoreEndpoint`
 
@@ -258,7 +258,7 @@ abstract class Calculator extends Endpoint {
 }
 ```
 
-You might want to re-use the `add` methodm but do not want a `subtract` method on your endpoint.
+You might want to re-use the `add` method, but do not want a `subtract` method on your endpoint.
 To achieve this, subclass the `Calculator`, but hide `subtract` with `@ignoreEndpoint` like so:
 
 ```dart
@@ -272,7 +272,7 @@ class Adder extends Calculator {
 }
 ```
 
-This `Adder` endpoint will only generate code for the `add` method, whereas `subtract` will not be visible from the client. Thus don't worry about the exception here. That is only added to satisfy the Dart compiler – in practice nothing will ever call this method on `Adder`.
+This `Adder` endpoint will only generate code for the `add` method, whereas `subtract` will not be visible from the client. Thus, don't worry about the exception here. That is only added to satisfy the Dart compiler – in practice nothing will ever call this method on `Adder`.
 
 ### Unhiding endpoint methods with `@ignoreEndpoint`
 
@@ -294,9 +294,9 @@ abstract class Calculator extends Endpoint {
 }
 ```
 
-Since the base class is marked `abstract` no client or server code is generated so far at all.
+Since the base class is marked `abstract`, no client or server code is generated so far at all.
 
-Now if you just subclass the `Calculator` endpoint like this, the generated client will only expose the simple `add` method.
+Now, if you just subclass the `Calculator` endpoint like this, the generated client will only expose the simple `add` method.
 
 ```dart
 import 'package:serverpod/serverpod.dart';
@@ -323,7 +323,7 @@ Now the `MyCalculator` endpoint will expose both the `add` and `addBig` methods.
 
 Endpoint subclassing is not just useful to inherit (or hide) methods, it can also be used to pre-configure any other property of the `Endpoint` class.
 
-For example you could define a base class that requires callers to be logged in:
+For example, you could define a base class that requires callers to be logged in:
 
 ```dart
 abstract class LoggedInEndpoint extends Endpoint {
@@ -334,7 +334,7 @@ abstract class LoggedInEndpoint extends Endpoint {
 
 And now every endpoint that extends `LoggedInEndpoint` will check that the user is logged in.
 
-Similarly you could wrap up a specific set of required scopes in a base endpoint, which you can then easily use for the app's endpoints instead of repeating the scopes in each:
+Similarly, you could wrap up a specific set of required scopes in a base endpoint, which you can then easily use for the app's endpoints instead of repeating the scopes in each:
 
 ```dart
 abstract class AdminEndpoint extends Endpoint {

--- a/docs/06-concepts/01-working-with-endpoints.md
+++ b/docs/06-concepts/01-working-with-endpoints.md
@@ -164,7 +164,7 @@ The generated client code will only be able to access `MyCalculatorEndpoint`, as
 
 #### Extending an `abstract` `Endpoint` class
 
-In the above example the `MyCalculatorEndpoint` only exposed the inherited `add` method. It can be further extended with custom methods like this:
+In the above example, the `MyCalculatorEndpoint` only exposed the inherited `add` method. It can be further extended with custom methods like this:
 
 ```dart
 import 'package:serverpod/serverpod.dart';
@@ -176,7 +176,7 @@ class MyCalculatorEndpoint extends CalculatorEndpoint {
 }
 ```
 
-In this case it will expose both an `add` and a `subtract` method.
+In this case, it will expose both an `add` and a `subtract` method.
 
 ### Inheriting from an `Endpoint` class annotated with `@ignoreEndpoint`
 
@@ -199,7 +199,7 @@ Since `CalculatorEndpoint` is marked as `@ignoreEndpoint` it will not be exposed
 
 ### Overriding endpoint methods
 
-It is possible to override methods of the super class. This can be useful when you want to modify the behavior of specific methods but preserve the rest.
+It is possible to override methods of the superclass. This can be useful when you want to modify the behavior of specific methods but preserve the rest.
 
 ```dart
 import 'package:serverpod/serverpod.dart';
@@ -218,9 +218,9 @@ class ExcitedGreeterEndpoint extends GreeterBaseEndpoint {
 }
 ```
 
-Since `GreeterBaseEndpoint` is `abstract`, it will not be exposed on the server. The `ExcitedGreeterEndpoint` will expose a single `greet` method, and its implementation will augment the super class's one by adding `!!!` to that result.
+Since `GreeterBaseEndpoint` is `abstract`, it will not be exposed on the server. The `ExcitedGreeterEndpoint` will expose a single `greet` method, and its implementation will augment the superclass's one by adding `!!!` to that result.
 
-This way, you can modify the behavior of endpoint methods, while still sharing the implementation through calls to `super`. Be aware that the method signature has to be compatible with the base class per Dart's rules, meaning you can add optional parameters, but can not add required parameters or change the return type.
+This way, you can modify the behavior of endpoint methods while still sharing the implementation through calls to `super`. Be aware that the method signature has to be compatible with the base class per Dart's rules, meaning you can add optional parameters, but can not add required parameters or change the return type.
 
 ### Hiding endpoint methods with `@ignoreEndpoint`
 
@@ -247,10 +247,10 @@ class AdderEndpoint extends CalculatorEndpoint {
 }
 ```
 
-Since `CalculatorEndpoint` is `abstract` it will not be exposed on the server. `AdderEndpoint` inherits all methods from its parent class, but since it opts to hide `subtract` by annotating it with `@ignoreEndpoint` only the `add` method will be exposed.
-Don't worry about the exception in the `subtract` implementation. That is only added to satisfy the Dart compiler – in practice nothing will ever call this method on `AdderEndpoint`.
+Since `CalculatorEndpoint` is `abstract`, it will not be exposed on the server. `AdderEndpoint` inherits all methods from its parent class, but since it opts to hide `subtract` by annotating it with `@ignoreEndpoint` only the `add` method will be exposed.
+Don't worry about the exception in the `subtract` implementation. That is only added to satisfy the Dart compiler – in practice, nothing will ever call this method on `AdderEndpoint`.
 
-Hiding endpoints from a super class is only appropriate in case the parent `class` is `abstract` or annotated with `@ignoreEndpoint`. Otherwise the method that should be hidden on the child would still be accessible via the parent class.
+Hiding endpoints from a super class is only appropriate in case the parent `class` is `abstract` or annotated with `@ignoreEndpoint`. Otherwise, the method that should be hidden on the child would still be accessible via the parent class.
 
 ### Unhiding endpoint methods annotated with `@ignoreEndpoint` in the super class
 
@@ -279,7 +279,7 @@ class MyCalculatorEndpoint extends CalculatorEndpoint {
 }
 ```
 
-Since `CalculatorEndpoint` is `abstract` it will not be exposed on the server. `MyCalculatorEndpoint` will expose both the `add` and `addBig` methods, since `addBig` was overriden and thus lost the `@ignoreEndpoint` annotation.
+Since `CalculatorEndpoint` is `abstract`, it will not be exposed on the server. `MyCalculatorEndpoint` will expose both the `add` and `addBig` methods, since `addBig` was overridden and thus lost the `@ignoreEndpoint` annotation.
 
 ### Building base endpoints for behavior
 

--- a/docs/06-concepts/01-working-with-endpoints.md
+++ b/docs/06-concepts/01-working-with-endpoints.md
@@ -161,7 +161,6 @@ class MyCalculatorEndpoint extends CalculatorEndpoint {}
 The generated client code will only be able to access `MyCalculatorEndpoint`, as the abstract `CalculatorEndpoint` is not exposed on the server.
 `MyCalculatorEndpoint` exposes the `add` method it inherited from `CalculatorEndpoint`.
 
-
 #### Extending an `abstract` `Endpoint` class
 
 In the above example the `MyCalculatorEndpoint` only exposed the inherited `add` method. It can be further extended with custom methods like this:
@@ -246,7 +245,6 @@ class AdderEndpoint extends CalculatorEndpoint {
   }
 }
 ```
-
 
 Since `CalculatorEndpoint` is `abstract` it will not be exposed on the server. `AdderEndpoint` inherits all methods from its parent class, but since it opts to hide `subtract` by annotating it with `@ignoreEndpoint` only the `add` method will be exposed.
 Don't worry about the exception in the `subtract` implementation. That is only added to satisfy the Dart compiler – in practice nothing will ever call this method on `AdderEndpoint`.

--- a/docs/06-concepts/17-backward-compatibility.md
+++ b/docs/06-concepts/17-backward-compatibility.md
@@ -10,9 +10,9 @@ Following a simple set of rules, your server will stay compatible with older app
 
 ## Managing breaking changes with endpoint inheritance
 
-An [endpoint sub-class](/concepts/working-with-endpoints) can be useful when having to do a breaking change on an entire endpoint, but you need to keep supporting existing clients. Doing so also allows you to keep sharing most of its implementation with the old endpoint.
+An [endpoint sub-class](/concepts/working-with-endpoints) can be useful when you have to make a breaking change to an entire endpoint but need to keep supporting existing clients. Doing so allows you to share most of its implementation with the old endpoint.
 
-Imagine you had a "team" management endpoint where before a user could join if they had an e-mail address ending in the expected domain, but now it should be opened up for anyone to join if they can provide an "invite code". Additionally the return type (serialized classes) should be updated across the entire endpoint, which would not be allowed on the existing one.
+Imagine you had a "team" management endpoint where before a user could join if they had an e-mail address ending in the expected domain, but now it should be opened up for anyone to join if they can provide an "invite code". Additionally, the return type (serialized classes) should be updated across the entire endpoint, which would not be allowed on the existing one.
 
 Transitioning from the current to the new endpoint structure might look like this:
 
@@ -23,7 +23,7 @@ class TeamEndpoint extends Endpoint {
     // …
   }
   
-  // many more methods, like `leave` etc.
+  // many more methods, like `leave`, etc.
 }
 
 class TeamV2Endpoint extends TeamEndpoint {
@@ -41,10 +41,10 @@ class TeamV2Endpoint extends TeamEndpoint {
 
 In the above example, we created a new `TeamV2` endpoint, which hides the `join` method and instead exposes a `joinWithCode` method with the added parameter and the new return type. Additionally all the other inherited (and untouched) methods from the parent class are exposed.
 
-While we may have liked to re-use the `join` method name, Dart inheritance rules do not allow doing so. Otherwise we would have to write the endpoint from scratch, meaning without inheritance, and re-implement all methods we would like to keep.
+While we may have liked to re-use the `join` method name, Dart inheritance rules do not allow doing so. Otherwise, we would have to write the endpoint from scratch, meaning without inheritance, and re-implement all methods we would like to keep.
 
-In your client, you could then move all usages from `client.team` to `client.teamV2` and eventually (after all clients have upgraded) remove the old endpoint on the server. That means either marking the old endpoint with `@ignoreEndpoint` on the class or delete it and move the re-used method implementations you want to keep to the new V2 endpoint class.
+In your client, you could then move all usages from `client.team` to `client.teamV2` and eventually (after all clients have upgraded) remove the old endpoint on the server. That means either marking the old endpoint with `@ignoreEndpoint` on the class or deleting it and moving the re-used method implementations you want to keep to the new V2 endpoint class.
 
-An alternative pattern to consider would be to move all the business logic for an endpoint into a helper class and then call into that from the endpoint. In case you want to create a V2 version later, you might be able to reuse most of the underlying business logic through that helper class, and don't have to sub-class the old endpoint. This has the added benefit of the endpoint class clearly listing all exposed methods, and you don't have to wonder what you inherit from the base class.
+An alternative pattern to consider would be to move all the business logic for an endpoint into a helper class and then call into that from the endpoint. In case you want to create a V2 version later, you might be able to reuse most of the underlying business logic through that helper class, and don't have to subclass the old endpoint. This has the added benefit of the endpoint class clearly listing all exposed methods, and you don't have to wonder what you inherit from the base class.
 
 Either approach has pros and cons, and it depends on the concrete circumstances to pick the most useful one. Both give you all the tools you need to extend and update your API while gracefully moving clients along and giving them time to update.

--- a/docs/06-concepts/17-backward-compatibility.md
+++ b/docs/06-concepts/17-backward-compatibility.md
@@ -7,3 +7,44 @@ Following a simple set of rules, your server will stay compatible with older app
 1. __Avoid changing parameter names in endpoint methods.__ In the REST API Serverpod generates, the parameters are passed by name. This means that changing the parameter names of the endpoint methods will break backward compatibility.
 2. __Do not delete endpoint methods or change their signature.__ Instead, add new methods if you must pass another set of parameters. Technically, you can add new named parameters if they are not required, but creating a new method may still feel cleaner.
 3. __Avoid changing or removing fields and types in the serialized classes.__ However, you are free to add new fields as long as they are nullable.
+
+## Managing breaking changes with endpoint inheritance
+
+An [endpoint sub-class](/concepts/working-with-endpoints) can be useful when having to do a breaking change on an entire endpoint, but you need to keep supporting existing clients. Doing so also allows you to keep sharing most of its implementation with the old endpoint.
+
+Imagine you had a "team" management endpoint where before a user could join if they had an e-mail address ending in the expected domain, but now it should be opened up for anyone to join if they can provide an "invite code". Additionally the return type (serialized classes) should be updated across the entire endpoint, which would not be allowed on the existing one.
+
+Transitioning from the current to the new endpoint structure might look like this:
+
+```dart
+@Deprecated('Use TeamV2Endpoint instead')
+class TeamEndpoint extends Endpoint {
+  Future<TeamInfo> join(Session session) async {
+    // …
+  }
+  
+  // many more methods, like `leave` etc.
+}
+
+class TeamV2Endpoint extends TeamEndpoint {
+  @override
+  @ignoreEndpoint
+  Future<TeamInfo> join(Session session) async {
+    throw UnimplementedError();
+  }
+
+  Future<NewTeamInfo> joinWithCode(Session session, String invitationCode) async {
+    // …
+  }
+}
+```
+
+In the above example, we created a new `TeamV2` endpoint, which hides the `join` method and instead exposes a `joinWithCode` method with the added parameter and the new return type. Additionally all the other inherited (and untouched) methods from the parent class are exposed.
+
+While we may have liked to re-use the `join` method name, Dart inheritance rules do not allow doing so. Otherwise we would have to write the endpoint from scratch, meaning without inheritance, and re-implement all methods we would like to keep.
+
+In your client, you could then move all usages from `client.team` to `client.teamV2` and eventually (after all clients have upgraded) remove the old endpoint on the server. That means either marking the old endpoint with `@ignoreEndpoint` on the class or delete it and move the re-used method implementations you want to keep to the new V2 endpoint class.
+
+An alternative pattern to consider would be to move all the business logic for an endpoint into a helper class and then call into that from the endpoint. In case you want to create a V2 version later, you might be able to reuse most of the underlying business logic through that helper class, and don't have to sub-class the old endpoint. This has the added benefit of the endpoint class clearly listing all exposed methods, and you don't have to wonder what you inherit from the base class.
+
+Either approach has pros and cons, and it depends on the concrete circumstances to pick the most useful one. Both give you all the tools you need to extend and update your API while gracefully moving clients along and giving them time to update.


### PR DESCRIPTION
* `@ignoreEndpoint` annotation on classes and methods.
* Endpoint inheritance.
* Endpoint inheritance from abstract classes.
* Versioning your API (Inheritance + deprecated annotation + changes in new API).