### PR TITLE
fix: Switch to new compose tool

### DIFF
--- a/docs/01-get-started/03-working-with-the-database.md
+++ b/docs/01-get-started/03-working-with-the-database.md
@@ -422,7 +422,7 @@ First, we need to start the server and apply the migrations by adding the `--app
 
 ```bash
 $ cd magic_recipe/magic_recipe_server
-$ docker-compose up -d
+$ docker compose up -d
 $ dart bin/main.dart --apply-migrations
 ```
 

--- a/docs/06-concepts/11-authentication/01-setup.md
+++ b/docs/06-concepts/11-authentication/01-setup.md
@@ -59,7 +59,7 @@ $ serverpod create-migration
 Start your database container from the server project.
 
 ```bash
-$ docker-compose up --build --detach
+$ docker compose up --build --detach
 ```
 
 Then apply the migration by starting the server with the `apply-migrations` flag.

--- a/docs/06-concepts/19-testing/01-get-started.md
+++ b/docs/06-concepts/19-testing/01-get-started.md
@@ -211,7 +211,7 @@ The location of the test tools can be changed by changing the  `server_test_tool
 Before the test can be run the Postgres and Redis also have to be started:
 
 ```bash
-docker-compose up --build --detach
+docker compose up --build --detach
 ```
 Now the test is ready to be run:
 

--- a/docs/08-upgrading/02-upgrade-to-one-point-two.md
+++ b/docs/08-upgrading/02-upgrade-to-one-point-two.md
@@ -203,8 +203,8 @@ If it is not important to preserve the data that is in your database, you can si
     In a Serverpod development project, the database is hosted in a docker container. To remove the existing database and start a new one run the following commands:
 
     ```bash
-    $ docker-compose down -v
-    $ docker-compose up --build --detach 
+    $ docker compose down -v
+    $ docker compose up --build --detach 
     ```
 
     The command first removes the running container along with its volume and the second command starts a new database from scratch.


### PR DESCRIPTION
We still had some references to `docker-compose` but should use `docker compose` this is now changed in `/docs` but not for the existing versioned docs