### PR TITLE
fix: Add documentation for concurrent future calls

### DIFF
--- a/docs/06-concepts/07-configuration.md
+++ b/docs/06-concepts/07-configuration.md
@@ -54,6 +54,9 @@ These can be separately declared for each run mode in the corresponding yaml fil
 | SERVERPOD_MAX_REQUEST_SIZE               | maxRequestSize                | 524288    | The maximum size of requests allowed in bytes                                                                                |
 | SERVERPOD_SESSION_PERSISTENT_LOG_ENABLED | sessionLogs.persistentEnabled | -         | Enables or disables logging session data to the database. Defaults to `true` if a database is configured, otherwise `false`. |
 | SERVERPOD_SESSION_CONSOLE_LOG_ENABLED    | sessionLogs.consoleEnabled    | -         | Enables or disables logging session data to the console. Defaults to `true` if no database is configured, otherwise `false`. |
+| SERVERPOD_FUTURE_CALL_EXECUTION_ENABLED  | futureCallExecutionEnabled    | true      | Enables or disables the execution of future calls.                                                                           |
+| SERVERPOD_FUTURE_CALL_CONCURRENCY_LIMIT  | futureCall.concurrencyLimit   | 1         | The maximum number of concurrent future calls allowed. If the value is negative or null, no limit is applied.                |
+| SERVERPOD_FUTURE_CALL_SCAN_INTERVAL      | futureCall.scanInterval       | 5000      | The interval in milliseconds for scanning future calls                                                                       |
 
 | Environment variable | Command line option | Default | Description                               |
 | -------------------- | ------------------- | ------- | ----------------------------------------- |
@@ -120,6 +123,12 @@ maxRequestSize: 524288
 sessionLogs:
   persistentEnabled: true
   consoleEnabled: true
+
+futureCallExecutionEnabled: true
+
+futureCall:
+  concurrencyLimit: 5
+  scanInterval: 2000
 ```
 
 ### Passwords file example

--- a/docs/06-concepts/07-configuration.md
+++ b/docs/06-concepts/07-configuration.md
@@ -55,9 +55,9 @@ These can be separately declared for each run mode in the corresponding yaml fil
 | SERVERPOD_SESSION_PERSISTENT_LOG_ENABLED | sessionLogs.persistentEnabled | -         | Enables or disables logging session data to the database. Defaults to `true` if a database is configured, otherwise `false`. |
 | SERVERPOD_SESSION_CONSOLE_LOG_ENABLED    | sessionLogs.consoleEnabled    | -         | Enables or disables logging session data to the console. Defaults to `true` if no database is configured, otherwise `false`. |
 
-|  Environment variable | Command line option | Default | Description                               |
-| --------------------- | ------------------- | ------- | ----------------------------------------- |
-| SERVERPOD_SERVER_ID   | `--server-id`       | default | Configures the id of the server instance. |
+| Environment variable | Command line option | Default | Description                               |
+| -------------------- | ------------------- | ------- | ----------------------------------------- |
+| SERVERPOD_SERVER_ID  | `--server-id`       | default | Configures the id of the server instance. |
 
 ### Secrets
 

--- a/docs/06-concepts/14-scheduling.md
+++ b/docs/06-concepts/14-scheduling.md
@@ -105,7 +105,7 @@ This option allows you to enable or disable the execution of future calls. By de
 Example configuration:
 
 ```yaml
-futureCallExecutionEnabled: true
+futureCallExecutionEnabled: false
 ```
 
 ### Concurrency limit

--- a/docs/06-concepts/14-scheduling.md
+++ b/docs/06-concepts/14-scheduling.md
@@ -4,6 +4,8 @@ With Serverpod you can schedule future work with the `future call` feature. Futu
 
 A future call is guaranteed to only execute once across all your instances that are running, but execution failures are not handled automatically. It is your responsibility to schedule a new future call if the work was not able to complete.
 
+## Future calls
+
 Creating a future call is simple, extend the `FutureCall` class and override the `invoke` method. The method takes two params the first being the [`Session`](sessions) object and the second being an optional SerializableModel ([See models](models)).
 
 :::info
@@ -80,4 +82,52 @@ This identifier can then be used to cancel all future calls registered with said
 
 ```dart
 await session.serverpod.cancelFutureCall('an-identifying-string');
+```
+
+## Configuration
+
+Future calls can be configured using options defined in the configuration files or environment variables. For a detailed list of configuration options, refer to the [Configuration](07-configuration.md) page.
+
+Below is an example of how you can configure future calls in a YAML file:
+
+```yaml
+futureCallExecutionEnabled: true
+
+futureCall:
+  concurrencyLimit: 5
+  scanInterval: 2000
+```
+
+### Enable or disable future call execution
+
+This option allows you to enable or disable the execution of future calls. By default, it is set to `true`. You might want to disable future call execution in environments where you don't want background tasks to run, such as during testing or in a staging environment where you want to focus on API behavior without triggering scheduled tasks.
+
+Example configuration:
+
+```yaml
+futureCallExecutionEnabled: true
+```
+
+### Concurrency limit
+
+This option sets the maximum number of future calls that can run concurrently. By default, it is set to `1`. Configuring this is useful if you have resource-intensive tasks and want to avoid overloading your server. For example, in a production environment, you might want to tune this value to ensure that not all of the server's resources are allocated to future calls, leaving room for other critical tasks.
+
+Setting this value to a negative number or `null` removes the limitation, allowing an unlimited number of concurrent future calls. However, this should be used with caution as it can lead to resource exhaustion.
+
+Example configuration:
+
+```yaml
+futureCall:
+  concurrencyLimit: 5  # Adjust this value based on your server's capacity
+```
+
+### Scan interval
+
+This option determines how often the system scans for future calls to execute, in milliseconds. The default value is `5000` (5 seconds). Adjusting this interval can help balance responsiveness and resource usage. For example, reducing the interval can make future calls execute closer to their scheduled time, while increasing it can reduce database load in environments with limited resources.
+
+Example configuration:
+
+```yaml
+futureCall:
+  scanInterval: 2000  # Adjust this value based on your server's responsiveness needs
 ```


### PR DESCRIPTION
Adds documentation for the new configuration option on future calls.

### Configuration page
![Screenshot 2025-05-13 at 13 59 43](https://github.com/user-attachments/assets/b9b5e5e0-05ca-487c-92c7-31652ac05fc0)

---- 
![Screenshot 2025-05-13 at 14 00 11](https://github.com/user-attachments/assets/80a02cdd-4c8b-4121-b38f-82c536f00950)
----


### Schedule page

![Screenshot 2025-05-13 at 14 06 10](https://github.com/user-attachments/assets/b420b7ec-cb17-455f-9bcf-6eb64fb21246)

----

![Screenshot 2025-05-13 at 14 05 54](https://github.com/user-attachments/assets/8f6c9110-3c45-464d-90ec-9f2602b681c9)



