### PR TITLE
docs: Add docs for passwords available through env variables

### DIFF
--- a/docs/06-concepts/07-configuration.md
+++ b/docs/06-concepts/07-configuration.md
@@ -79,6 +79,12 @@ Secrets are declared in the `passwords.yaml` file. The password file is structur
 | SERVERPOD_SERVICE_SECRET    | serviceSecret  | -       | The token used to connect with insights must be at least 20 chars |
 | SERVERPOD_REDIS_PASSWORD    | redis          | -       | The password for the Redis server                                 |
 
+In addition to the predefined secrets above, you can define custom passwords using environment variables with the `SERVERPOD_PASSWORD_` prefix. For example, `SERVERPOD_PASSWORD_myApiKey` will be available in your code as `myApiKey` (the prefix is stripped) through the `Session.passwords` map. These environment variables will override any passwords defined in the [passwords file](#passwords-file-example) if the name (after stripping the prefix) matches. Like the `shared` section in the passwords file, these environment variables are available in all run modes.
+
+| Environment variable format | Description                                                                                                                               |
+| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| SERVERPOD_PASSWORD\_\*      | Custom password that will be available in the Session.passwords map. The prefix `SERVERPOD_PASSWORD_` will be stripped from the key name. |
+
 #### Secrets for first party packages
 
 - [serverpod_cloud_storage_gcp](https://pub.dev/packages/serverpod_cloud_storage_gcp): Google Cloud Storage

--- a/docs/06-concepts/07-configuration.md
+++ b/docs/06-concepts/07-configuration.md
@@ -208,7 +208,6 @@ The password file contains the secrets used by the server to connect to differen
 ```yaml
 shared:
   myCustomSharedSecret: 'secret_key'
-  stripeApiKey: 'sk_test_123...'
 
 development:
   database: 'development_password'

--- a/docs/06-concepts/07-configuration.md
+++ b/docs/06-concepts/07-configuration.md
@@ -99,9 +99,7 @@ The following secrets are used by official Serverpod packages:
 
 #### Custom Secrets
 
-You can define your own custom secrets in the [passwords file](#passwords-file-example) by adding them to either the `shared` section (to make them available in all run modes) or to specific run mode sections. These custom secrets will be available in your code through the `Session.passwords` map.
-
-You can define custom passwords in two ways:
+You can define your own custom secrets in two ways.
 
 ##### 1. Via Passwords File
 

--- a/docs/06-concepts/07-configuration.md
+++ b/docs/06-concepts/07-configuration.md
@@ -71,9 +71,7 @@ These can be separately declared for each run mode in the corresponding yaml fil
 
 ### Secrets
 
-Secrets are declared in the `passwords.yaml` file. The password file is structured with a common `shared` section, any secret put here will be used in all run modes. The other sections are the names of the run modes followed by respective key/value pairs.
-
-You can define your own custom secrets in the [passwords file](#passwords-file-example) by adding them to either the `shared` section (to make them available in all run modes) or to specific run mode sections. These custom secrets will be available in your code through the `Session.passwords` map.
+Secrets are declared in the `passwords.yaml` file. The password file is structured with a common `shared` section, any secret put here will be used in all run modes. The other sections are the names of the run modes followed by respective key/value pairs. You can also define custom secrets using [environment variables](#2-via-environment-variables).
 
 #### Built-in Secrets
 
@@ -101,11 +99,13 @@ The following secrets are used by official Serverpod packages:
 
 #### Custom Secrets
 
+You can define your own custom secrets in the [passwords file](#passwords-file-example) by adding them to either the `shared` section (to make them available in all run modes) or to specific run mode sections. These custom secrets will be available in your code through the `Session.passwords` map.
+
 You can define custom passwords in two ways:
 
 ##### 1. Via Passwords File
 
-Add your custom secrets directly to the passwords file under the `shared` section (available in all run modes) or under specific run mode sections:
+Add your custom secrets directly to the passwords file under the `shared` section (available in all run modes) or under specific run mode sections.
 
 ```yaml
 shared:

--- a/docs/06-concepts/07-configuration.md
+++ b/docs/06-concepts/07-configuration.md
@@ -83,9 +83,27 @@ Secrets are declared in the `passwords.yaml` file. The password file is structur
 
 In addition to the predefined secrets above, you can define custom passwords using environment variables with the `SERVERPOD_PASSWORD_` prefix. For example, `SERVERPOD_PASSWORD_myApiKey` will be available in your code as `myApiKey` (the prefix is stripped) through the `Session.passwords` map. These environment variables will override any passwords defined in the [passwords file](#passwords-file-example) if the name (after stripping the prefix) matches. Like the `shared` section in the passwords file, these environment variables are available in all run modes.
 
-| Environment variable format | Description                                                                                                                               |
-| --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| SERVERPOD_PASSWORD\_\*      | Custom password that will be available in the Session.passwords map. The prefix `SERVERPOD_PASSWORD_` will be stripped from the key name. |
+| Environment variable format | Description                                                                                                                                      |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| SERVERPOD_PASSWORD\_\*      | Custom password that will be available in the Session.passwords map. The prefix `SERVERPOD_PASSWORD_` prefix will be stripped from the key name. |
+
+#### Example
+
+To define a custom password, set it as an environment variable:
+
+```bash
+export SERVERPOD_PASSWORD_stripe_api_key=sk_test_123...
+```
+
+You can then access it in your endpoint code:
+
+```dart
+Future<void> processPayment(Session session, PaymentData data) async {
+  final stripeApiKey = session.passwords['stripe_api_key'];
+  // Use the API key to make requests to Stripe
+  ...
+}
+```
 
 #### Secrets for first party packages
 

--- a/docs/06-concepts/07-configuration.md
+++ b/docs/06-concepts/07-configuration.md
@@ -79,6 +79,8 @@ Secrets are declared in the `passwords.yaml` file. The password file is structur
 | SERVERPOD_SERVICE_SECRET    | serviceSecret  | -       | The token used to connect with insights must be at least 20 chars |
 | SERVERPOD_REDIS_PASSWORD    | redis          | -       | The password for the Redis server                                 |
 
+### Custom Passwords
+
 In addition to the predefined secrets above, you can define custom passwords using environment variables with the `SERVERPOD_PASSWORD_` prefix. For example, `SERVERPOD_PASSWORD_myApiKey` will be available in your code as `myApiKey` (the prefix is stripped) through the `Session.passwords` map. These environment variables will override any passwords defined in the [passwords file](#passwords-file-example) if the name (after stripping the prefix) matches. Like the `shared` section in the passwords file, these environment variables are available in all run modes.
 
 | Environment variable format | Description                                                                                                                               |

--- a/docs/06-concepts/07-configuration.md
+++ b/docs/06-concepts/07-configuration.md
@@ -89,17 +89,17 @@ In addition to the predefined secrets above, you can define custom passwords usi
 
 #### Example
 
-To define a custom password, set it as an environment variable:
+To define a custom password through an environment variable, set it as an environment variable with the prefix:
 
 ```bash
-export SERVERPOD_PASSWORD_stripe_api_key=sk_test_123...
+export SERVERPOD_PASSWORD_stripeApiKey=sk_test_123...
 ```
 
 You can then access it in your endpoint code:
 
 ```dart
 Future<void> processPayment(Session session, PaymentData data) async {
-  final stripeApiKey = session.passwords['stripe_api_key'];
+  final stripeApiKey = session.passwords['stripeApiKey'];
   // Use the API key to make requests to Stripe
   ...
 }

--- a/docs/06-concepts/07-configuration.md
+++ b/docs/06-concepts/07-configuration.md
@@ -99,11 +99,11 @@ The following secrets are used by official Serverpod packages:
 | SERVERPOD_AWS_ACCESS_KEY_ID  | AWSAccessKeyId  | -       | The access key ID for AWS authentication for serverpod_cloud_storage_s3   |
 | SERVERPOD_AWS_SECRET_KEY     | AWSSecretKey    | -       | The secret key for AWS authentication for serverpod_cloud_storage_s3      |
 
-### Custom Passwords
+#### Custom Secrets
 
 You can define custom passwords in two ways:
 
-#### 1. Via Passwords File
+##### 1. Via Passwords File
 
 Add your custom secrets directly to the passwords file under the `shared` section (available in all run modes) or under specific run mode sections:
 
@@ -125,7 +125,7 @@ production:
   twilioApiKey: 'prod_twilio_key'
 ```
 
-#### 2. Via Environment Variables
+##### 2. Via Environment Variables
 
 You can also define custom passwords using environment variables with the `SERVERPOD_PASSWORD_` prefix. For example, `SERVERPOD_PASSWORD_myApiKey` will be available as `myApiKey` (the prefix is stripped). These environment variables will override any passwords defined in the passwords file if the name (after stripping the prefix) matches. Like the `shared` section in the passwords file, these environment variables are available in all run modes.
 


### PR DESCRIPTION
Related to https://github.com/serverpod/serverpod/pull/3656

This PR adds documentation for the new ability for passwords to be defined via environment variabled prefixed with `SERVERPOD_PASSWORD_`

### Screenshot

<details>
<summary>Image</summary>

![image](https://github.com/user-attachments/assets/64c4122c-9ade-4ef8-a076-226e8b156f15)
</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Documentation**
  - Enhanced the secrets configuration guide with a detailed "Custom Secrets" section.
  - Clarified the distinction between built-in and custom secrets and their configuration methods.
  - Added examples demonstrating password file setup and environment variable usage.
  - Included code snippets showing how to access custom secrets in endpoint code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->