### PR TITLE
docs: Add docs for specifying env vars for google client secret and firebase service account key

### DIFF
--- a/docs/06-concepts/11-authentication/04-providers/02-google.md
+++ b/docs/06-concepts/11-authentication/04-providers/02-google.md
@@ -40,6 +40,8 @@ Create the server credentials in the google cloud console. Navigate to _Credenti
 
 Download the JSON file for your web application OAuth client. This file contains both the client id and the client secret. Rename the file to `google_client_secret.json` and place it in your server's `config` directory.
 
+Alternatively, you can provide the contents of the JSON file through the environment variable `SERVERPOD_PASSWORD_serverpod_auth_googleClientSecret`.
+
 :::warning
 
 The `google_client_secret.json` contains a private key and should not be version controlled.

--- a/docs/06-concepts/11-authentication/04-providers/05-firebase.md
+++ b/docs/06-concepts/11-authentication/04-providers/05-firebase.md
@@ -16,6 +16,8 @@ The server needs the service account credentials for access to your Firebase pro
 
 This will download the JSON file, rename it to `firebase_service_account_key.json` and place it in the `config` folder in your server project. Note that if this file is corrupt or if the name does not follow the convention here the authentication with firebase will fail.
 
+Alternatively, you can provide the contents of the JSON file through the environment variable `SERVERPOD_PASSWORD_serverpod_auth_firebaseServiceAccountKey`.
+
 :::danger
 The firebase_service_account_key.json file gives admin access to your Firebase project, never store it in version control.
 :::
@@ -87,8 +89,8 @@ You can also trigger the Firebase auth UI by calling the method `signInWithFireb
 
 ```dart
 await signInWithFirebase(
-  context: context, 
-  caller: client.modules.auth, 
+  context: context,
+  caller: client.modules.auth,
   authProviders: [
     firebase.PhoneAuthProvider(),
   ],


### PR DESCRIPTION
Related to https://github.com/serverpod/serverpod/pull/3664

This PR aims to add documentation about the environment variables now available to define the Google Secret Client and Firebase Service Account Key
