### PR TITLE
docs: Update environment variable naming conventions in configuration documentation

### DIFF
--- a/docs/06-concepts/07-configuration.md
+++ b/docs/06-concepts/07-configuration.md
@@ -77,11 +77,11 @@ Secrets are declared in the `passwords.yaml` file. The password file is structur
 
 The following table shows the built-in secrets that Serverpod uses for its core functionality. These can be configured either through environment variables or by adding the corresponding key in a respective run mode or shared section in the passwords file. These are separate from any custom passwords you might define.
 
-| Environment variable        | Passwords file | Default | Description                                                       |
-| --------------------------- | -------------- | ------- | ----------------------------------------------------------------- |
-| SERVERPOD_DATABASE_PASSWORD | database       | -       | The password for the database                                     |
-| SERVERPOD_SERVICE_SECRET    | serviceSecret  | -       | The token used to connect with insights must be at least 20 chars |
-| SERVERPOD_REDIS_PASSWORD    | redis          | -       | The password for the Redis server                                 |
+| Environment variable             | Passwords file | Default | Description                                                       |
+| -------------------------------- | -------------- | ------- | ----------------------------------------------------------------- |
+| SERVERPOD_PASSWORD_database      | database       | -       | The password for the database                                     |
+| SERVERPOD_PASSWORD_serviceSecret | serviceSecret  | -       | The token used to connect with insights must be at least 20 chars |
+| SERVERPOD_PASSWORD_redis         | redis          | -       | The password for the Redis server                                 |
 
 #### Secrets for First Party Packages
 
@@ -93,10 +93,10 @@ The following secrets are used by official Serverpod packages:
 
 | Environment variable                                        | Passwords file                           | Default | Description                                                                   |
 | ----------------------------------------------------------- | ---------------------------------------- | ------- | ----------------------------------------------------------------------------- |
-| SERVERPOD_HMAC_ACCESS_KEY_ID                                | HMACAccessKeyId                          | -       | The access key ID for HMAC authentication for serverpod_cloud_storage_gcp     |
-| SERVERPOD_HMAC_SECRET_KEY                                   | HMACSecretKey                            | -       | The secret key for HMAC authentication for serverpod_cloud_storage_gcp        |
-| SERVERPOD_AWS_ACCESS_KEY_ID                                 | AWSAccessKeyId                           | -       | The access key ID for AWS authentication for serverpod_cloud_storage_s3       |
-| SERVERPOD_AWS_SECRET_KEY                                    | AWSSecretKey                             | -       | The secret key for AWS authentication for serverpod_cloud_storage_s3          |
+| SERVERPOD_PASSWORD_HMACAccessKeyId                          | HMACAccessKeyId                          | -       | The access key ID for HMAC authentication for serverpod_cloud_storage_gcp     |
+| SERVERPOD_PASSWORD_HMACSecretKey                            | HMACSecretKey                            | -       | The secret key for HMAC authentication for serverpod_cloud_storage_gcp        |
+| SERVERPOD_PASSWORD_AWSAccessKeyId                           | AWSAccessKeyId                           | -       | The access key ID for AWS authentication for serverpod_cloud_storage_s3       |
+| SERVERPOD_PASSWORD_AWSSecretKey                             | AWSSecretKey                             | -       | The secret key for AWS authentication for serverpod_cloud_storage_s3          |
 | SERVERPOD_PASSWORD_serverpod_auth_googleClientSecret        | serverpod_auth_googleClientSecret        | -       | The client secret for Google authentication for serverpod_auth_server         |
 | SERVERPOD_PASSWORD_serverpod_auth_firebaseServiceAccountKey | serverpod_auth_firebaseServiceAccountKey | -       | The service account key for Firebase authentication for serverpod_auth_server |
 


### PR DESCRIPTION
Since we have a new way of defining secrets through env (https://github.com/serverpod/serverpod/pull/3656), we should recommend users use this way to define all secrets instead of having special env vars for built-in secrets. This ensures consistency across all secrets, built-in and custom


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to reflect new naming conventions for environment variables related to secrets, now using the prefix SERVERPOD_PASSWORD_ followed by the key name in camelCase. This affects variables for database, service, Redis, HMAC, and AWS keys. Descriptions and default values remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->