### PR TITLE
chore: Add restriction to prevent forks from running deploy script.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
     deploy:
+        if: github.repository == 'serverpod/serverpod_docs'
         runs-on: ubuntu-latest
         environment: deploy
         steps:


### PR DESCRIPTION
Adds a check that validates that this is not a fork before attempting to run the deploy script.