### PR TITLE
docs: Add an example of custom runtime parameters extending the builder

### DIFF
--- a/docs/06-concepts/06-database/12-runtime-parameters.md
+++ b/docs/06-concepts/06-database/12-runtime-parameters.md
@@ -101,7 +101,7 @@ await session.db.transaction((transaction) async {
 
 ### Creating custom runtime parameters
 
-Custom parameter groups can be created in one of two ways:
+Custom parameter groups can be created in one of the following ways:
 
 #### Using `MapRuntimeParameters`
 
@@ -126,7 +126,7 @@ await session.db.transaction((transaction) async {
 
 #### Extending `RuntimeParameters`
 
-Extending the base `RuntimeParameters` class directly, overriding the `options` getter:
+Extend the base `RuntimeParameters` class directly, overriding the `options` getter:
 
 ```dart
 import 'package:serverpod/database.dart';
@@ -146,6 +146,52 @@ class CustomRuntimeParameters extends RuntimeParameters {
     'another_param': param2,
   };
 }
+```
+
+#### Extending the builder class with custom methods
+
+Create an extension on `RuntimeParametersBuilder` to add custom methods that return instances of your custom runtime parameters class:
+
+```dart
+import 'package:serverpod/database.dart';
+
+extension CustomRuntimeParametersExtension on RuntimeParametersBuilder {
+  // Directly with `MapRuntimeParameters`, without a custom class.
+  MapRuntimeParameters mapCustomParameters({
+    required int param1,
+    required int param2,
+  }) {
+    return MapRuntimeParameters({
+      'custom_param': param1,
+      'another_param': param2,
+    });
+  }
+
+  // With a custom runtime parameters class as declared above.
+  CustomRuntimeParameters classCustomParameters({
+    required int param1,
+    required int param2,
+  }) {
+    return CustomRuntimeParameters(
+      param1: param1,
+      param2: param2,
+    );
+  }
+}
+```
+
+This allows you to use your custom parameters with the same builder pattern:
+
+```dart
+await session.db.transaction((transaction) async {
+  await transaction.setRuntimeParameters((params) => [
+    params.mapCustomParameters(param1: 100, param2: 200),
+    params.classCustomParameters(param1: 300, param2: 400),
+    params.hnswIndexQuery(efSearch: 64), // Can combine with built-in parameters
+  ]);
+
+  // Your queries here...
+});
 ```
 
 ### Parameter values


### PR DESCRIPTION
Address the [pending comment](https://github.com/serverpod/serverpod_docs/pull/296#discussion_r2162119265) from PR #296.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded documentation to include a new method for creating custom runtime parameter groups using a builder extension.
  - Added example code demonstrating the new approach and its integration with built-in parameters.
  - Improved clarity with minor wording adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->