### PR TITLE
chore: Update link to use 2.9.1 insights version.

### DIFF
--- a/docs/09-tools/01-insights.md
+++ b/docs/09-tools/01-insights.md
@@ -6,9 +6,9 @@ Serverpod has a companion app. It is currently available for Mac and Windows, bu
 
 ## Downloads
 
-| App version                | MacOS                                                                 | Windows       |
-| :------------------------- | :-------------------------------------------------------------------- | :------------ |
-| Serverpod 2.0.0 (latest)   | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.0.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.0.0.zip) |
-| Serverpod 1.2.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
-| Serverpod 1.1.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
-| Serverpod 1.0.0            | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        |     n/a       |
+| App version          | MacOS                                                                 | Windows                                                                 |
+| :------------------- | :-------------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| Serverpod 2 (latest) | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.9.1.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.9.1.zip) |
+| Serverpod 1.2.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
+| Serverpod 1.1.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
+| Serverpod 1.0.0      | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        | n/a                                                                     |

--- a/versioned_docs/version-1.2.0/08-insights.md
+++ b/versioned_docs/version-1.2.0/08-insights.md
@@ -6,9 +6,9 @@ Serverpod has a companion app. It is currently available for Mac and Windows, bu
 
 ## Downloads
 
-| App version                | MacOS                                                                 | Windows       |
-| :------------------------- | :-------------------------------------------------------------------- | :------------ |
-| Serverpod 2.0.0 (latest)   | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.0.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.0.0.zip) |
-| Serverpod 1.2.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
-| Serverpod 1.1.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
-| Serverpod 1.0.0            | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        |     n/a       |
+| App version          | MacOS                                                                 | Windows                                                                 |
+| :------------------- | :-------------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| Serverpod 2 (latest) | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.9.1.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.9.1.zip) |
+| Serverpod 1.2.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
+| Serverpod 1.1.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
+| Serverpod 1.0.0      | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        | n/a                                                                     |

--- a/versioned_docs/version-2.0.0/07-tools/02-insights.md
+++ b/versioned_docs/version-2.0.0/07-tools/02-insights.md
@@ -6,9 +6,9 @@ Serverpod has a companion app. It is currently available for Mac and Windows, bu
 
 ## Downloads
 
-| App version                | MacOS                                                                 | Windows       |
-| :------------------------- | :-------------------------------------------------------------------- | :------------ |
-| Serverpod 2.0.0 (latest)   | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.0.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.0.0.zip) |
-| Serverpod 1.2.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
-| Serverpod 1.1.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
-| Serverpod 1.0.0            | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        |     n/a       |
+| App version          | MacOS                                                                 | Windows                                                                 |
+| :------------------- | :-------------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| Serverpod 2 (latest) | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.9.1.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.9.1.zip) |
+| Serverpod 1.2.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
+| Serverpod 1.1.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
+| Serverpod 1.0.0      | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        | n/a                                                                     |

--- a/versioned_docs/version-2.1.0/09-tools/01-insights.md
+++ b/versioned_docs/version-2.1.0/09-tools/01-insights.md
@@ -6,9 +6,9 @@ Serverpod has a companion app. It is currently available for Mac and Windows, bu
 
 ## Downloads
 
-| App version                | MacOS                                                                 | Windows       |
-| :------------------------- | :-------------------------------------------------------------------- | :------------ |
-| Serverpod 2.0.0 (latest)   | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.0.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.0.0.zip) |
-| Serverpod 1.2.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
-| Serverpod 1.1.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
-| Serverpod 1.0.0            | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        |     n/a       |
+| App version          | MacOS                                                                 | Windows                                                                 |
+| :------------------- | :-------------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| Serverpod 2 (latest) | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.9.1.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.9.1.zip) |
+| Serverpod 1.2.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
+| Serverpod 1.1.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
+| Serverpod 1.0.0      | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        | n/a                                                                     |

--- a/versioned_docs/version-2.2.0/09-tools/01-insights.md
+++ b/versioned_docs/version-2.2.0/09-tools/01-insights.md
@@ -6,9 +6,9 @@ Serverpod has a companion app. It is currently available for Mac and Windows, bu
 
 ## Downloads
 
-| App version                | MacOS                                                                 | Windows       |
-| :------------------------- | :-------------------------------------------------------------------- | :------------ |
-| Serverpod 2.0.0 (latest)   | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.0.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.0.0.zip) |
-| Serverpod 1.2.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
-| Serverpod 1.1.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
-| Serverpod 1.0.0            | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        |     n/a       |
+| App version          | MacOS                                                                 | Windows                                                                 |
+| :------------------- | :-------------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| Serverpod 2 (latest) | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.9.1.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.9.1.zip) |
+| Serverpod 1.2.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
+| Serverpod 1.1.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
+| Serverpod 1.0.0      | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        | n/a                                                                     |

--- a/versioned_docs/version-2.3.0/09-tools/01-insights.md
+++ b/versioned_docs/version-2.3.0/09-tools/01-insights.md
@@ -6,9 +6,9 @@ Serverpod has a companion app. It is currently available for Mac and Windows, bu
 
 ## Downloads
 
-| App version                | MacOS                                                                 | Windows       |
-| :------------------------- | :-------------------------------------------------------------------- | :------------ |
-| Serverpod 2.0.0 (latest)   | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.0.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.0.0.zip) |
-| Serverpod 1.2.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
-| Serverpod 1.1.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
-| Serverpod 1.0.0            | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        |     n/a       |
+| App version          | MacOS                                                                 | Windows                                                                 |
+| :------------------- | :-------------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| Serverpod 2 (latest) | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.9.1.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.9.1.zip) |
+| Serverpod 1.2.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
+| Serverpod 1.1.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
+| Serverpod 1.0.0      | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        | n/a                                                                     |

--- a/versioned_docs/version-2.4.0/09-tools/01-insights.md
+++ b/versioned_docs/version-2.4.0/09-tools/01-insights.md
@@ -6,9 +6,9 @@ Serverpod has a companion app. It is currently available for Mac and Windows, bu
 
 ## Downloads
 
-| App version                | MacOS                                                                 | Windows       |
-| :------------------------- | :-------------------------------------------------------------------- | :------------ |
-| Serverpod 2.0.0 (latest)   | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.0.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.0.0.zip) |
-| Serverpod 1.2.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
-| Serverpod 1.1.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
-| Serverpod 1.0.0            | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        |     n/a       |
+| App version          | MacOS                                                                 | Windows                                                                 |
+| :------------------- | :-------------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| Serverpod 2 (latest) | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.9.1.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.9.1.zip) |
+| Serverpod 1.2.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
+| Serverpod 1.1.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
+| Serverpod 1.0.0      | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        | n/a                                                                     |

--- a/versioned_docs/version-2.5.0/09-tools/01-insights.md
+++ b/versioned_docs/version-2.5.0/09-tools/01-insights.md
@@ -6,9 +6,9 @@ Serverpod has a companion app. It is currently available for Mac and Windows, bu
 
 ## Downloads
 
-| App version                | MacOS                                                                 | Windows       |
-| :------------------------- | :-------------------------------------------------------------------- | :------------ |
-| Serverpod 2.0.0 (latest)   | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.0.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.0.0.zip) |
-| Serverpod 1.2.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
-| Serverpod 1.1.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
-| Serverpod 1.0.0            | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        |     n/a       |
+| App version          | MacOS                                                                 | Windows                                                                 |
+| :------------------- | :-------------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| Serverpod 2 (latest) | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.9.1.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.9.1.zip) |
+| Serverpod 1.2.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
+| Serverpod 1.1.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
+| Serverpod 1.0.0      | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        | n/a                                                                     |

--- a/versioned_docs/version-2.6.0/09-tools/01-insights.md
+++ b/versioned_docs/version-2.6.0/09-tools/01-insights.md
@@ -6,9 +6,9 @@ Serverpod has a companion app. It is currently available for Mac and Windows, bu
 
 ## Downloads
 
-| App version                | MacOS                                                                 | Windows       |
-| :------------------------- | :-------------------------------------------------------------------- | :------------ |
-| Serverpod 2.0.0 (latest)   | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.0.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.0.0.zip) |
-| Serverpod 1.2.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
-| Serverpod 1.1.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
-| Serverpod 1.0.0            | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        |     n/a       |
+| App version          | MacOS                                                                 | Windows                                                                 |
+| :------------------- | :-------------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| Serverpod 2 (latest) | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.9.1.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.9.1.zip) |
+| Serverpod 1.2.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
+| Serverpod 1.1.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
+| Serverpod 1.0.0      | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        | n/a                                                                     |

--- a/versioned_docs/version-2.7.0/09-tools/01-insights.md
+++ b/versioned_docs/version-2.7.0/09-tools/01-insights.md
@@ -6,9 +6,9 @@ Serverpod has a companion app. It is currently available for Mac and Windows, bu
 
 ## Downloads
 
-| App version                | MacOS                                                                 | Windows       |
-| :------------------------- | :-------------------------------------------------------------------- | :------------ |
-| Serverpod 2.0.0 (latest)   | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.0.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.0.0.zip) |
-| Serverpod 1.2.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
-| Serverpod 1.1.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
-| Serverpod 1.0.0            | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        |     n/a       |
+| App version          | MacOS                                                                 | Windows                                                                 |
+| :------------------- | :-------------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| Serverpod 2 (latest) | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.9.1.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.9.1.zip) |
+| Serverpod 1.2.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
+| Serverpod 1.1.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
+| Serverpod 1.0.0      | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        | n/a                                                                     |

--- a/versioned_docs/version-2.8.0/09-tools/01-insights.md
+++ b/versioned_docs/version-2.8.0/09-tools/01-insights.md
@@ -6,9 +6,9 @@ Serverpod has a companion app. It is currently available for Mac and Windows, bu
 
 ## Downloads
 
-| App version                | MacOS                                                                 | Windows       |
-| :------------------------- | :-------------------------------------------------------------------- | :------------ |
-| Serverpod 2.0.0 (latest)   | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.0.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.0.0.zip) |
-| Serverpod 1.2.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
-| Serverpod 1.1.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
-| Serverpod 1.0.0            | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        |     n/a       |
+| App version          | MacOS                                                                 | Windows                                                                 |
+| :------------------- | :-------------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| Serverpod 2 (latest) | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.9.1.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.9.1.zip) |
+| Serverpod 1.2.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
+| Serverpod 1.1.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
+| Serverpod 1.0.0      | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        | n/a                                                                     |

--- a/versioned_docs/version-2.9.0/09-tools/01-insights.md
+++ b/versioned_docs/version-2.9.0/09-tools/01-insights.md
@@ -6,9 +6,9 @@ Serverpod has a companion app. It is currently available for Mac and Windows, bu
 
 ## Downloads
 
-| App version                | MacOS                                                                 | Windows       |
-| :------------------------- | :-------------------------------------------------------------------- | :------------ |
-| Serverpod 2.0.0 (latest)   | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.0.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.0.0.zip) |
-| Serverpod 1.2.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
-| Serverpod 1.1.0            | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
-| Serverpod 1.0.0            | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        |     n/a       |
+| App version          | MacOS                                                                 | Windows                                                                 |
+| :------------------- | :-------------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| Serverpod 2 (latest) | [Download](https://downloads.serverpod.dev/macos/Serverpod-2.9.1.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-2.9.1.zip) |
+| Serverpod 1.2.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.2.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.2.0.zip) |
+| Serverpod 1.1.0      | [Download](https://downloads.serverpod.dev/macos/Serverpod-1.1.0.zip) | [Download](https://downloads.serverpod.dev/windows/serverpod-1.1.0.zip) |
+| Serverpod 1.0.0      | [Download](https://serverpod.dev/insights/Serverpod-1.0.0.zip)        | n/a                                                                     |


### PR DESCRIPTION
Bumps the link to the newest version.

Here are the links to test:
https://downloads.serverpod.dev/macos/Serverpod-2.9.1.zip
https://downloads.serverpod.dev/windows/serverpod-2.9.1.zip