### PR TITLE
fix: Gemini model in getting started guide

### DIFF
--- a/docs/01-get-started/01-creating-endpoints.md
+++ b/docs/01-get-started/01-creating-endpoints.md
@@ -65,7 +65,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash-latest',
+      model: 'gemini-1.5-flash',
       apiKey: geminiApiKey,
     );
 

--- a/docs/01-get-started/01-creating-endpoints.md
+++ b/docs/01-get-started/01-creating-endpoints.md
@@ -65,7 +65,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash',
+      model: 'gemini-2.0-flash',
       apiKey: geminiApiKey,
     );
 

--- a/docs/01-get-started/02-models-and-data.md
+++ b/docs/01-get-started/02-models-and-data.md
@@ -91,7 +91,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash',
+      model: 'gemini-2.0-flash',
       apiKey: geminiApiKey,
     );
 

--- a/docs/01-get-started/02-models-and-data.md
+++ b/docs/01-get-started/02-models-and-data.md
@@ -91,7 +91,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash-latest',
+      model: 'gemini-1.5-flash',
       apiKey: geminiApiKey,
     );
 

--- a/docs/01-get-started/03-working-with-the-database.md
+++ b/docs/01-get-started/03-working-with-the-database.md
@@ -127,7 +127,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash',
+      model: 'gemini-2.0-flash',
       apiKey: geminiApiKey,
     );
 

--- a/docs/01-get-started/03-working-with-the-database.md
+++ b/docs/01-get-started/03-working-with-the-database.md
@@ -127,7 +127,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash-latest',
+      model: 'gemini-1.5-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.7.0/01-get-started/01-creating-endpoints.md
+++ b/versioned_docs/version-2.7.0/01-get-started/01-creating-endpoints.md
@@ -66,7 +66,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash-latest',
+      model: 'gemini-1.5-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.7.0/01-get-started/01-creating-endpoints.md
+++ b/versioned_docs/version-2.7.0/01-get-started/01-creating-endpoints.md
@@ -66,7 +66,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash',
+      model: 'gemini-2.0-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.7.0/01-get-started/02-models-and-data.md
+++ b/versioned_docs/version-2.7.0/01-get-started/02-models-and-data.md
@@ -91,7 +91,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash',
+      model: 'gemini-2.0-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.7.0/01-get-started/02-models-and-data.md
+++ b/versioned_docs/version-2.7.0/01-get-started/02-models-and-data.md
@@ -91,7 +91,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash-latest',
+      model: 'gemini-1.5-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.7.0/01-get-started/03-working-with-the-database.md
+++ b/versioned_docs/version-2.7.0/01-get-started/03-working-with-the-database.md
@@ -122,7 +122,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash',
+      model: 'gemini-2.0-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.7.0/01-get-started/03-working-with-the-database.md
+++ b/versioned_docs/version-2.7.0/01-get-started/03-working-with-the-database.md
@@ -122,7 +122,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash-latest',
+      model: 'gemini-1.5-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.8.0/01-get-started/01-creating-endpoints.md
+++ b/versioned_docs/version-2.8.0/01-get-started/01-creating-endpoints.md
@@ -66,7 +66,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash-latest',
+      model: 'gemini-1.5-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.8.0/01-get-started/01-creating-endpoints.md
+++ b/versioned_docs/version-2.8.0/01-get-started/01-creating-endpoints.md
@@ -66,7 +66,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash',
+      model: 'gemini-2.0-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.8.0/01-get-started/02-models-and-data.md
+++ b/versioned_docs/version-2.8.0/01-get-started/02-models-and-data.md
@@ -91,7 +91,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash',
+      model: 'gemini-2.0-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.8.0/01-get-started/02-models-and-data.md
+++ b/versioned_docs/version-2.8.0/01-get-started/02-models-and-data.md
@@ -91,7 +91,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash-latest',
+      model: 'gemini-1.5-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.8.0/01-get-started/03-working-with-the-database.md
+++ b/versioned_docs/version-2.8.0/01-get-started/03-working-with-the-database.md
@@ -122,7 +122,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash',
+      model: 'gemini-2.0-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.8.0/01-get-started/03-working-with-the-database.md
+++ b/versioned_docs/version-2.8.0/01-get-started/03-working-with-the-database.md
@@ -122,7 +122,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash-latest',
+      model: 'gemini-1.5-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.9.0/01-get-started/01-creating-endpoints.md
+++ b/versioned_docs/version-2.9.0/01-get-started/01-creating-endpoints.md
@@ -65,7 +65,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash-latest',
+      model: 'gemini-1.5-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.9.0/01-get-started/01-creating-endpoints.md
+++ b/versioned_docs/version-2.9.0/01-get-started/01-creating-endpoints.md
@@ -65,7 +65,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash',
+      model: 'gemini-2.0-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.9.0/01-get-started/02-models-and-data.md
+++ b/versioned_docs/version-2.9.0/01-get-started/02-models-and-data.md
@@ -91,7 +91,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash',
+      model: 'gemini-2.0-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.9.0/01-get-started/02-models-and-data.md
+++ b/versioned_docs/version-2.9.0/01-get-started/02-models-and-data.md
@@ -91,7 +91,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash-latest',
+      model: 'gemini-1.5-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.9.0/01-get-started/03-working-with-the-database.md
+++ b/versioned_docs/version-2.9.0/01-get-started/03-working-with-the-database.md
@@ -127,7 +127,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash',
+      model: 'gemini-2.0-flash',
       apiKey: geminiApiKey,
     );
 

--- a/versioned_docs/version-2.9.0/01-get-started/03-working-with-the-database.md
+++ b/versioned_docs/version-2.9.0/01-get-started/03-working-with-the-database.md
@@ -127,7 +127,7 @@ class RecipeEndpoint extends Endpoint {
       throw Exception('Gemini API key not found');
     }
     final gemini = GenerativeModel(
-      model: 'gemini-1.5-flash-latest',
+      model: 'gemini-1.5-flash',
       apiKey: geminiApiKey,
     );
 


### PR DESCRIPTION
Heya, found a small bug in the getting started guide and wanted to fix it up!

1. Follow the gettin started guide
2. Blindly copy-paste the server endpoint code into my project
3. Update the Flutter app as well
4. Run the app
5. Try to get a recipe -- Oh no! Internal server error

## Error

```
2025-09-26 13:35:07.499922Z  558569213 ERROR          n/a                      Publisher Model `projects/generativelanguage-ga/locations/us-central1/publishers/google/models/gemini-1.5-flash-002` was not found or your project does not have access to it. Please ensure you are using a valid model version. For more information, see: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions
```

## Fix

By following the link in the error message above, it looks like the name of the [auto-updated aliases](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions) has changed.

## Effect

After applying the new name, the sample is able to call the Gemini Model as expected

```
2025-09-26 13:42:53.811809Z  857062088 METHOD         recipe.generateRecipe    user=null, queries=0, duration=11.6ms
```

And I see the recipe in my Chrome browser

<img width="971" height="592" alt="Screenshot 2025-09-26 at 2 46 09 PM" src="https://github.com/user-attachments/assets/0f54b022-b4ca-4323-b457-2f85c3f3a110" />
