### PR TITLE
docs: Clarify endpoint locations for JWT and Email IdP

### DIFF
--- a/docs/06-concepts/11-authentication/01-setup.md
+++ b/docs/06-concepts/11-authentication/01-setup.md
@@ -59,8 +59,7 @@ void run(List<String> args) async {
   await pod.start();
 }
 ```
-
-Then, extend the abstract endpoint for refreshing JWT tokens to expose it on the server:
+Then, extend the abstract endpoint for refreshing JWT tokens to expose it on the server, by creating a new endpoint file in your server's lib/src/endpoints/ directory so that the generator can detect and register the endpoint.
 
 ```dart
 import 'package:serverpod_auth_idp_server/core.dart' as core;

--- a/docs/06-concepts/11-authentication/01-setup.md
+++ b/docs/06-concepts/11-authentication/01-setup.md
@@ -59,7 +59,7 @@ void run(List<String> args) async {
   await pod.start();
 }
 ```
-Then, extend the abstract endpoint for refreshing JWT tokens to expose it on the server, by creating a new endpoint file in your server's lib/src/endpoints/ directory so that the generator can detect and register the endpoint.
+Then extend the abstract endpoint for refreshing JWT tokens to expose it on the server. Create the file anywhere under your server's `lib/` directory (for example, `<project>_server/lib/src/endpoints/`); the generator picks it up:
 
 ```dart
 import 'package:serverpod_auth_idp_server/core.dart' as core;

--- a/docs/06-concepts/11-authentication/04-providers/02-email/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/02-email/01-setup.md
@@ -68,7 +68,7 @@ void _sendPasswordResetCode(
 }
 ```
 
-Then, extend the abstract endpoint to expose it on the server:
+Then, extend the abstract endpoint to expose it on the server, by creating a new endpoint file in your `lib/src/endpoints/` directory to expose the email-specific authentication routes:
 
 ```dart
 import 'package:serverpod_auth_idp_server/providers/email.dart';

--- a/docs/06-concepts/11-authentication/04-providers/02-email/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/02-email/01-setup.md
@@ -68,7 +68,7 @@ void _sendPasswordResetCode(
 }
 ```
 
-Then, extend the abstract endpoint to expose it on the server, by creating a new endpoint file in your `lib/src/endpoints/` directory to expose the email-specific authentication routes:
+Then extend the abstract endpoint to expose the email authentication routes on the server. Create the file anywhere under your server's `lib/` directory (for example, `<project>_server/lib/src/endpoints/`); the generator picks it up:
 
 ```dart
 import 'package:serverpod_auth_idp_server/providers/email.dart';


### PR DESCRIPTION
While setting up a Flutter Web project with serverpod_auth_idp_server, I noticed the documentation didn't explicitly state where to place the extended endpoint classes. Added these details to help new users avoid configuration errors during the generate phase.