### PR TITLE
docs: Adjust menu so working with endpoints and models show as subpages

### DIFF
--- a/docs/06-concepts/01-working-with-endpoints/01-working-with-endpoints.md
+++ b/docs/06-concepts/01-working-with-endpoints/01-working-with-endpoints.md
@@ -1,5 +1,6 @@
 ---
 slug: /concepts/working-with-endpoints
+sidebar_label: Working with endpoints
 ---
 
 # Working with endpoints

--- a/docs/06-concepts/01-working-with-endpoints/_category_.json
+++ b/docs/06-concepts/01-working-with-endpoints/_category_.json
@@ -1,8 +1,5 @@
 {
-  "label": "Working with endpoints",
+  "label": "Endpoints",
   "collapsed": true,
-  "link": {
-    "type": "doc",
-    "id": "concepts/working-with-endpoints/working-with-endpoints"
-  }
+  "link": null
 }

--- a/docs/06-concepts/02-models/01-models.md
+++ b/docs/06-concepts/02-models/01-models.md
@@ -1,5 +1,6 @@
 ---
 slug: /concepts/models
+sidebar_label: Working with models
 ---
 
 # Working with models

--- a/docs/06-concepts/02-models/_category_.json
+++ b/docs/06-concepts/02-models/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Models",
-  "collapsed": true,
-  "link": {
-    "type": "doc",
-    "id": "concepts/models/models"
-  }
+  "collapsed": true
 }


### PR DESCRIPTION
### Sidebar menu adjustment 

- "Working with endpoints" now shows as sub-items under 'Endpoints' category node
- "Working with models" now shows as sub-items under 'Models' category node

This is consistent with how other sub-items are displayed.

<img width="290" height="344" alt="image" src="https://github.com/user-attachments/assets/a0739eba-8e2f-431d-9203-431c5090d39c" />

### No broken inbound links

Both pages define a slug in their frontmatter that pins the page to a fixed URL regardless of where the file sits in the folder structure. Because the slugs are unchanged, all existing inbound links continue to resolve correctly.
