### PR TITLE
docs: Corrections to Endpoint inheritance page

### DIFF
--- a/docs/06-concepts/01-working-with-endpoints/02-endpoint-inheritance.md
+++ b/docs/06-concepts/01-working-with-endpoints/02-endpoint-inheritance.md
@@ -79,7 +79,7 @@ class CalculatorEndpoint extends Endpoint {
 class MyCalculatorEndpoint extends CalculatorEndpoint {}
 ```
 
-Since `CalculatorEndpoint` is marked as `@doNotGenerate`, it will not be exposed on the server and no client class will be generated for it. Only `MyCalculatorEndpoint` will be accessible from the client, which provides the inherited `add` methods from its parent class. Unlike abstract endpoints, when a parent is marked with `@doNotGenerate`, the generated client class will implement the base endpoint class directly rather than extending a generated abstract parent class.
+Since `CalculatorEndpoint` is marked as `@doNotGenerate`, it will not be exposed on the server and no client class will be generated for it. Only `MyCalculatorEndpoint` will be accessible from the client, which provides the inherited `add` method from its parent class. Unlike abstract endpoints, when a parent is marked with `@doNotGenerate`, no parent client class is generated. The subclass's client class extends `EndpointRef` directly, with the parent's methods inlined alongside the subclass's own.
 
 ## Overriding endpoint methods
 
@@ -97,7 +97,7 @@ abstract class GreeterBaseEndpoint extends Endpoint {
 class ExcitedGreeterEndpoint extends GreeterBaseEndpoint {
   @override
   Future<String> greet(Session session, String name) async {
-    return '${super.hello(session, name)}!!!';
+    return '${await super.greet(session, name)}!!!';
   }
 }
 ```

--- a/docs/06-concepts/01-working-with-endpoints/02-endpoint-inheritance.md
+++ b/docs/06-concepts/01-working-with-endpoints/02-endpoint-inheritance.md
@@ -79,7 +79,7 @@ class CalculatorEndpoint extends Endpoint {
 class MyCalculatorEndpoint extends CalculatorEndpoint {}
 ```
 
-Since `CalculatorEndpoint` is marked as `@doNotGenerate`, it will not be exposed on the server and no client class will be generated for it. Only `MyCalculatorEndpoint` will be accessible from the client, which provides the inherited `add` method from its parent class. Unlike abstract endpoints, when a parent is marked with `@doNotGenerate`, no parent client class is generated. The subclass's client class extends `EndpointRef` directly, with the parent's methods inlined alongside the subclass's own.
+Since `CalculatorEndpoint` is marked as `@doNotGenerate`, it will not be exposed on the server, and no client class will be generated for it. Only `MyCalculatorEndpoint` will be accessible from the client, which provides the inherited `add` method from its parent class. When a parent is marked with `@doNotGenerate`, no client class is generated for the parent. The subclass's client class extends `EndpointRef` directly, with the parent's methods inlined alongside the subclass's own methods.
 
 ## Overriding endpoint methods
 


### PR DESCRIPTION
## Summary

Fact-checked the Endpoint inheritance page. Two corrections:

- Code example bug: `super.hello(...)` → `await super.greet(...)` (wrong method name + missing `await` on a `Future<String>`).
- `@doNotGenerate` parent: corrected wording to match actual generator output (no parent client class generated; child extends `EndpointRef` directly with parent methods inlined).

Verified by running `serverpod generate` on a real project.

## Test plan

- [ ] Render the page locally and confirm both code blocks read correctly.