### PR TITLE
docs: Corrections to Middleware page

### DIFF
--- a/docs/06-concepts/01-working-with-endpoints/03-middleware.md
+++ b/docs/06-concepts/01-working-with-endpoints/03-middleware.md
@@ -34,9 +34,11 @@ void run(List<String> args) async {
 A middleware is a function with this signature:
 
 ```dart
+typedef Handler = FutureOr<Result> Function(Request request);
 typedef Middleware = Handler Function(Handler innerHandler);
-typedef Handler = Future<Response> Function(Request request);
 ```
+
+`Result` is a sealed type with three subclasses: `Response`, `Hijack`, and `WebSocketUpgrade`. Middleware that modifies response-specific fields must first narrow to `Response` with an `is` check.
 
 ### Simple middleware example
 


### PR DESCRIPTION
## Summary

Fact-checked the Middleware page. One correction:

- The `Handler` typedef was documented as `Future<Response> Function(Request)` but Relic actually defines it as `FutureOr<Result> Function(Request)`. `Result` is a sealed type with `Response`, `Hijack`, and `WebSocketUpgrade` subclasses, which is why the example's `if (result is Response)` narrowing is required.

Added a one-line note explaining `Result` so readers can see why the type check exists.

## Test plan

- [ ] Render the page locally and confirm the typedef block reads correctly.