### PR TITLE
docs: Corrections to Inheritance and polymorphism page

### DIFF
--- a/docs/06-concepts/02-models/02-inheritance-and-polymorphism.md
+++ b/docs/06-concepts/02-models/02-inheritance-and-polymorphism.md
@@ -8,7 +8,7 @@ Serverpod models support inheritance, which allows you to define class hierarchi
 Adding a new subtype to a class hierarchy may introduce breaking changes for older clients. Ensure client compatibility when expanding class hierarchies to avoid deserialization issues.
 :::
 
-### Extending a Class
+### Extending a class
 
 To inherit from a class, use the `extends` keyword in your model files, as shown below:
 
@@ -68,7 +68,7 @@ indexes:
 
 Indexes can be defined on inherited fields in a child class with a table, and relations work normally with inherited table classes. To use a base model that is shared between server and client and extend it on the server with a table, see [Shared packages](../shared-packages).
 
-### Sealed Classes
+### Sealed classes
 
 In addition to the `extends` keyword, you can also use the `sealed` keyword to create sealed class hierarchies, enabling exhaustive type checking. With sealed classes, the compiler knows all subclasses, ensuring that every possible case is handled when working with the model.
 
@@ -98,7 +98,6 @@ sealed class ParentClass {
 }
 
 class ChildClass extends ParentClass {
-  String name;
   int age;
 }
 ```


### PR DESCRIPTION
## Summary

Fact-checked the Inheritance and polymorphism page. Three corrections:

- **Generated code example**: Showed `ChildClass extends ParentClass` redeclaring the parent's `String name` field. The analyzer explicitly forbids field redeclaration, and the actual generated code only declares new fields and forwards inherited ones via `super`. Removed the spurious line.
- **`### Extending a Class` → `### Extending a class`**: sentence case per STYLE_GUIDE.md.
- **`### Sealed Classes` → `### Sealed classes`**: same.

## Test plan

- [ ] Render the page locally and confirm the generated code block under "Sealed classes" shows only `int age` on the child.