### PR TITLE
docs: Rename pgvector upgrade page to active voice

### DIFF
--- a/docs/06-concepts/02-models/03-vector-fields.md
+++ b/docs/06-concepts/02-models/03-vector-fields.md
@@ -13,7 +13,7 @@ All vector types support specialized distance operations for similarity search a
 To ensure optimal performance with vector similarity searches, consider creating specialized vector indexes on your vector fields. See the [Vector indexes](../database/indexing#vector-indexes) section for more details.
 
 :::info
-The usage of Vector fields requires the pgvector PostgreSQL extension to be installed, which comes by default on new Serverpod projects. To upgrade an existing project, see the [Upgrading to pgvector support](../../upgrading/upgrade-to-pgvector) guide.
+The usage of Vector fields requires the pgvector PostgreSQL extension to be installed, which comes by default on new Serverpod projects. To upgrade an existing project, see the [Upgrade to pgvector](../../upgrading/upgrade-to-pgvector) guide.
 :::
 
 ## Vector

--- a/docs/09-upgrading/03-upgrade-to-pgvector.md
+++ b/docs/09-upgrading/03-upgrade-to-pgvector.md
@@ -1,4 +1,4 @@
-# Upgrading to pgvector support
+# Upgrade to pgvector
 
 New Serverpod projects automatically include pgvector support through the `pgvector/pgvector` PostgreSQL Docker image. However, existing projects need to be upgraded to use vector functionality.
 
@@ -12,7 +12,7 @@ If trying to use vector fields without upgrading, you will encounter an error wh
 
 ## For Docker-based environments
 
-1. Update your `docker-compose.yml` to use a PostgreSQL image with pgvector (e.g., `pgvector/pgvector:pg16`):
+1. Update your `docker-compose.yaml` to use a PostgreSQL image with pgvector (e.g., `pgvector/pgvector:pg16`):
 
 ```yaml
 services:


### PR DESCRIPTION
## Summary

- Rename `# Upgrading to pgvector support` → `# Upgrade to pgvector` to match sibling pages (`Upgrade to 3.0`, `Upgrade from Mini to full`).
- Update the one inbound link in `docs/06-concepts/02-models/03-vector-fields.md` to match.
- Fix `docker-compose.yml` → `docker-compose.yaml` (the extension the CLI actually generates).

URL unchanged.

## Test plan

- [ ] `npm run build` passes.
- [ ] Sidebar entry, page H1, and inbound link text all read "Upgrade to pgvector".