### PR TITLE
docs: Rename starting-path folder to Get Started

### DIFF
--- a/docs/04-get-started/_category_.json
+++ b/docs/04-get-started/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Serverpod Academy",
+  "label": "Get Started",
   "collapsed": false,
-  "className": "sidebar-icon-learn"
+  "className": "sidebar-icon-getting-started"
 }


### PR DESCRIPTION
## Summary

- `"label": "Serverpod Academy"` → `"label": "Get Started"` on the starting-path sidebar entry.
- `"className": "sidebar-icon-learn"` → `"className": "sidebar-icon-getting-started"` (sprout icon).

Chapter content untouched. URLs unchanged.

## Test plan

- [ ] Sidebar shows "Get Started" with the sprout icon.