### PR TITLE
docs: Rename Deploy section and fix GCP typo

### DIFF
--- a/docs/08-deployments/03-deploying-to-gcr-console.md
+++ b/docs/08-deployments/03-deploying-to-gcr-console.md
@@ -1,4 +1,4 @@
-# Google Cloud Run with CGP Console
+# Google Cloud Run with GCP Console
 
 If your server does not maintain a state and you aren't using future calls, running your Serverpod on Google Cloud Run can be a great option. Cloud Run is the easiest way to deploy your server but may be less flexible as your application grows. Check the [Choosing deployment strategy](deployment-strategy) page for more information on choosing the best solution for your needs.
 

--- a/docs/08-deployments/_category_.json
+++ b/docs/08-deployments/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "Deploying Serverpod",
+  "label": "Deploy your app",
   "className": "sidebar-icon-deploying"
 }


### PR DESCRIPTION
## Summary

- Section sidebar label: `"Deploying Serverpod"` → `"Deploy your app"`.
- Page H1: `Google Cloud Run with CGP Console` → `Google Cloud Run with GCP Console` (typo fix).

URLs unchanged. The Custom hosting subfolder restructure and the Deploy-to-Cloud page are deferred until 3.5 GA.

## Test plan

- [ ] Sidebar shows "Deploy your app" where it previously showed "Deploying Serverpod".
- [ ] The Google Cloud Run page title now reads "GCP Console".