### PR TITLE
docs: Tighten Quickstart opener, remove Docker prerequisite, clarify create prompts

### DIFF
--- a/docs/04-get-started/02-quickstart.md
+++ b/docs/04-get-started/02-quickstart.md
@@ -11,11 +11,11 @@ import TabItem from '@theme/TabItem';
 
 # Quickstart
 
-In this tutorial we will walk through creating a full-stack app with Flutter and Serverpod and deploying it to the cloud as a web app. **You will have an app up and hosted within 10–15 minutes.** We have tested the default setup with Antigravity, Cursor, and Claude Code, but most agentic editors will work.
+Build and deploy a full-stack Flutter and Serverpod app, hosted on the web, in 10–15 minutes. We have tested the default setup with Antigravity, Cursor, and Claude Code, but most agentic editors will work.
 
 :::info
 
-Before we start, make sure that you have [Serverpod installed](./installation). You will also need to have Docker installed.
+Before we start, make sure that you have [Serverpod installed](./installation).
 
 :::
 
@@ -27,7 +27,7 @@ Use Serverpod's `create` command to create a new project. The `create` command i
 $ serverpod create my_project
 ```
 
-Create the project with all the default settings. Just select which editor/agent you are planning to use. Hit the Enter key to create the project.
+Step through the prompts, accepting the default for each by pressing Enter. When you reach the editor selection, choose the editor or agent you plan to use, then press Enter to create the project.
 
 Next, open your newly created project with your favorite AI powered editor. Open the root folder of the full project, for example, `my_project`, which includes the server, client, and Flutter app.
 

--- a/docs/04-get-started/02-quickstart.md
+++ b/docs/04-get-started/02-quickstart.md
@@ -27,7 +27,7 @@ Use Serverpod's `create` command to create a new project. The `create` command i
 $ serverpod create my_project
 ```
 
-Step through the prompts, accepting the default for each by pressing Enter. When you reach the editor selection, choose the editor or agent you plan to use, then press Enter to create the project.
+The command opens an interactive screen with sensible defaults already selected. Leave the defaults as they are, but make sure to select the editor or agent you plan to use, since the rest of this guide relies on it to build your app. Navigate with the arrow keys, press `Space` to select it, then press `Enter` to create the project.
 
 Next, open your newly created project with your favorite AI powered editor. Open the root folder of the full project, for example, `my_project`, which includes the server, client, and Flutter app.
 


### PR DESCRIPTION
Three small corrections to the Quickstart:

- **Opener:** leads with what the reader gets instead of "In this tutorial we will...".
- **Docker prerequisite removed:** beta.9 uses embedded Postgres, so Docker is no longer required.
- **Create step:** clarifies that `serverpod create` has several prompts to step through, not a single editor choice.

The Cloud section is left as-is for now; a separate follow-up will reconcile the Cloud account/billing flow.

Closes: https://github.com/serverpod/serverpod_docs/issues/544