### PR TITLE
docs: Add getting started guide for email authentication setup

### DIFF
--- a/docs/06-concepts/11-authentication/01-get-started.md
+++ b/docs/06-concepts/11-authentication/01-get-started.md
@@ -13,8 +13,8 @@ This guide walks you through that, then shows how to test signing up and signing
 ## Prerequisites
 
 - A project created with `serverpod create` on Serverpod 3.5 or later. If you are upgrading an older project, follow [Migrate to the new auth module](./setup) first to add authentication.
-- Docker installed and running, so the server can start its database.
 - The Flutter SDK installed, so you can run the app.
+- Docker installed and running, if your project uses a Docker Postgres. Projects on the embedded Postgres option don't need Docker.
 
 ## Show the sign-in screen
 

--- a/docs/06-concepts/11-authentication/01-get-started.md
+++ b/docs/06-concepts/11-authentication/01-get-started.md
@@ -12,7 +12,7 @@ This guide walks you through that, then shows how to test signing up and signing
 
 ## Prerequisites
 
-- A project created with `serverpod create` on Serverpod 3.5 or later. If you are upgrading an older project, follow [Migrate to the new auth module](./setup) first to add authentication.
+- A project created with `serverpod create` on Serverpod 3.5 or later. For older projects, see [Setup](./setup) first to add the auth module.
 - The Flutter SDK installed, so you can run the app.
 - Docker installed and running, if your project uses a Docker Postgres. Projects on the embedded Postgres option don't need Docker.
 

--- a/docs/06-concepts/11-authentication/01-get-started.md
+++ b/docs/06-concepts/11-authentication/01-get-started.md
@@ -12,7 +12,7 @@ This guide walks you through that, then shows how to test signing up and signing
 
 ## Prerequisites
 
-- A project created with `serverpod create` on Serverpod 3.4 or later. If you are upgrading an older project, follow [Migrate to the new auth module](./setup) first to add authentication.
+- A project created with `serverpod create` on Serverpod 3.5 or later. If you are upgrading an older project, follow [Migrate to the new auth module](./setup) first to add authentication.
 - Docker installed and running, so the server can start its database.
 - The Flutter SDK installed, so you can run the app.
 

--- a/docs/06-concepts/11-authentication/01-get-started.md
+++ b/docs/06-concepts/11-authentication/01-get-started.md
@@ -1,0 +1,73 @@
+---
+sidebar_label: Get started
+---
+
+# Get started with authentication
+
+When you create a project with `serverpod create`, email sign-in is already built in. The server is configured, the database is ready, and your app is connected to it. You only need to turn on the sign-in screen and run the app.
+
+This guide walks you through that, then shows how to test signing up and signing in.
+
+![Sign-in with Serverpod](/img/authentication/sign-in-widget-device.png)
+
+## Prerequisites
+
+- A project created with `serverpod create` on Serverpod 3.4 or later. If you are upgrading an older project, follow [Migrate to the new auth module](./setup) first to add authentication.
+- Docker installed and running, so the server can start its database.
+- The Flutter SDK installed, so you can run the app.
+
+## Show the sign-in screen
+
+Your app already includes a sign-in screen. It is just turned off by default. Turn it on with two small edits to your app's `main.dart`.
+
+First, import the screen:
+
+```dart
+import 'screens/sign_in_screen.dart';
+```
+
+Then show it as the home screen. In `MyHomePage.build()`, comment out the existing `body:` line and uncomment the `SignInScreen` block right below it, so it reads:
+
+```dart
+// body: const GreetingsScreen(),
+body: SignInScreen(
+  child: GreetingsScreen(
+    onSignOut: () async {
+      await client.auth.signOutDevice();
+    },
+  ),
+),
+```
+
+That is the only change your app needs.
+
+## Start your project
+
+From the project root, start everything with one command:
+
+```bash
+serverpod start
+```
+
+This sets up the database and starts the server and your app.
+
+The app opens on the sign-in screen. To create an account:
+
+1. Choose to create a new account, enter your email, and continue.
+2. Look in the server console for the verification code. While testing, it is logged instead of emailed:
+
+   ```text
+   [EmailIdp] Registration code (you@example.com): 12345678
+   ```
+
+3. Enter the code, then set a password to finish.
+
+Once you are signed in, the app shows your content with a sign-out button.
+
+## Next steps
+
+- Send real verification emails through an email service. See [Email provider setup](./providers/email/setup).
+- Customize the sign-in screen or build your own. See [Customizing the UI](./providers/email/customizing-the-ui).
+- Change password rules, code length, and rate limits. See [Email configuration](./providers/email/configuration).
+- Require sign-in on your endpoints. See [The basics](./basics#requiring-authentication-on-endpoints).
+- Add more sign-in options, like Google or Apple. See [Identity providers configuration](./setup#identity-providers-configuration).

--- a/docs/06-concepts/11-authentication/01-setup.md
+++ b/docs/06-concepts/11-authentication/01-setup.md
@@ -1,16 +1,8 @@
----
-sidebar_label: Migrate auth module
----
+# Setup
 
-# Migrate to the new auth module
+Serverpod comes with built-in user management and authentication. It is possible to build a [custom authentication implementation](custom-overrides), but the recommended way to authenticate users is to use the `serverpod_auth_idp` module. The module makes it easy to authenticate with email, social sign-ins and more.
 
-This guide is for existing projects upgrading from an older Serverpod version to the modular `serverpod_auth_idp` auth module. It covers the server, client, and app.
-
-:::note
-New projects created with `serverpod create` (Serverpod 3.4 or later) already include `serverpod_auth_idp`. See [Get started with authentication](./get-started) to turn on the sign-in screen.
-:::
-
-`serverpod_auth_idp` supports email, social sign-ins (Google, Apple, GitHub, and more), and passkeys. See [Identity providers configuration](#identity-providers-configuration) below for the full list, or [Custom authentication](./custom-overrides) if you need full control over the flow.
+The list of identity providers is continuously growing and new providers are added as they are developed. If you want to contribute a new provider, please consider [contributing](/contribute) your code. See the [identity providers configuration](#identity-providers-configuration) section for details on all available providers.
 
 ![Sign-in with Serverpod](/img/authentication/sign-in-widget-device.png)
 

--- a/docs/06-concepts/11-authentication/01-setup.md
+++ b/docs/06-concepts/11-authentication/01-setup.md
@@ -1,8 +1,16 @@
-# Setup
+---
+sidebar_label: Migrate auth module
+---
 
-Serverpod comes with built-in user management and authentication. It is possible to build a [custom authentication implementation](custom-overrides), but the recommended way to authenticate users is to use the `serverpod_auth_idp` module. The module makes it easy to authenticate with email, social sign-ins and more.
+# Migrate to the new auth module
 
-The list of identity providers is continuously growing and new providers are added as they are developed. If you want to contribute a new provider, please consider [contributing](/contribute) your code. See the [identity providers configuration](#identity-providers-configuration) section for details on all available providers.
+This guide is for existing projects upgrading from an older Serverpod version to the modular `serverpod_auth_idp` auth module. It covers the server, client, and app.
+
+:::note
+New projects created with `serverpod create` (Serverpod 3.4 or later) already include `serverpod_auth_idp`. See [Get started with authentication](./get-started) to turn on the sign-in screen.
+:::
+
+`serverpod_auth_idp` supports email, social sign-ins (Google, Apple, GitHub, and more), and passkeys. See [Identity providers configuration](#identity-providers-configuration) below for the full list, or [Custom authentication](./custom-overrides) if you need full control over the flow.
 
 ![Sign-in with Serverpod](/img/authentication/sign-in-widget-device.png)
 


### PR DESCRIPTION
## Summary

New projects on Serverpod 3.5+ already ship with the auth module installed, but the existing `01-setup.md` page is dense and oriented at users adding the module manually. That's a rough first-touch experience for someone who just wants to turn on email sign-in.

This PR:

- Adds a new `01-get-started.md` page that walks a new-project user through the smooth path: turn on the sign-in screen, run `serverpod start`, sign up using the dev console code, sign in.
- Reframes `01-setup.md` as a migration guide for upgrading existing projects, with a note redirecting new-project users to the new page.
- Adds `sidebar_label` on both pages so they don't overflow the sidebar.

A small follow-up PR will rename `01-setup.md` to `02-migrate-auth-module.md` and renumber the rest of the auth section. Kept separate to keep this PR scoped to content.