### PR TITLE
chore: Add agent instructions for working with docs

### DIFF
--- a/.github/doc-templates/concept.md
+++ b/.github/doc-templates/concept.md
@@ -1,0 +1,99 @@
+# Concept page template
+
+A concept page is the home for one capability. The reader is past Get started; they want to understand what the capability is, when to use it, and how to do common operations on it. They might read top to bottom to learn, or jump to a specific section to do something.
+
+**Use for:** pages in the Concepts section, one per capability.  
+**Don't use for:** step-by-step new-user walkthroughs (tutorial), procedural how-tos spanning multiple capabilities (guide), or schema and rule lookups (reference).
+
+---
+
+## Skeleton
+
+```markdown
+---
+description: <One sentence summary, 120–160 chars. Used for SEO and AI retrieval. Required.>
+---
+
+# <Capability name>
+
+Two to four sentences. What the capability is, in plain language. The reader should leave this
+paragraph knowing what the feature does and roughly when they'd reach for it.
+
+Don't open with marketing. Open with the substance.
+If the capability has a roadmap item (workaround today, native support coming), say so here.
+
+## When to use <capability>
+
+OPTIONAL. Use when the reader has a decision to make: this vs an alternative, opt-in vs skip,
+etc. Skip if every user uses the capability the same way.
+
+Format: short paragraphs or a small decision table.
+
+## <Operation 1: action-shaped heading>
+
+One or two sentences on what this operation does and when the reader would do it.
+
+<command or action>
+
+<expected output or result>
+
+## <Operation 2: action-shaped heading>
+
+<as above>
+
+## Configuration
+
+OPTIONAL. Use when the capability has configuration knobs in scloud.yaml, environment variables,
+or CLI flags that aren't tied to a single operation. Link to the Reference page for the canonical
+lookup; this section is the readable explanation.
+
+## Cloud-specific behavior
+
+OPTIONAL. Use when Cloud handles this capability differently from self-hosted Serverpod and the
+difference matters to the reader.
+
+## Limits
+
+OPTIONAL. Use when the capability has hard limits the reader will hit or current limitations they
+should know about. Format: short list. Each item: the limit, what happens at the limit, what to
+do about it.
+
+## Troubleshooting
+
+OPTIONAL. Use only for 2–4 well-defined failure modes the reader will plausibly hit.
+Format: question-shaped headings. Each entry: cause, fix.
+
+## Related
+
+OPTIONAL but recommended.
+
+- [<Linked page>](path) — <one-line description>
+```
+
+---
+
+## Voice
+
+- **Mixed person.** Use "you" when telling the reader what they can do; no subject when describing the capability ("Logs are collected automatically"). Don't switch within a paragraph.
+- **Operations in imperative.** "Set a password," not "You should set a password."
+- **Action-shaped H2s.** "Set a password" beats "Password configuration".
+- **Honest about variants.** Name the variant in one sentence with a code example. Don't enumerate every flag — that's the CLI reference's job.
+
+## Length
+
+600–1,500 words plus code blocks. Under 400 words: consider folding into a related concept. Over 2,000 words: consider splitting.
+
+## Code samples
+
+If an operation has a primary form and a variant, show both in adjacent code blocks rather than commenting variants out.
+
+## Checklist before publishing
+
+- [ ] `description` frontmatter is present and reads well in isolation (120–160 chars).
+- [ ] Overview opens with what the capability is, in plain language. No marketing.
+- [ ] Roadmap status stated up front if relevant.
+- [ ] Operations are action-shaped headings, ordered by how often the reader needs them.
+- [ ] Code blocks are language-tagged; `title` attributes used for file content.
+- [ ] Optional sections present only when the capability has the content to justify them.
+- [ ] Related section is not padded.
+- [ ] No marketing language, no hedging, no speculative troubleshooting.

--- a/.github/doc-templates/guide.md
+++ b/.github/doc-templates/guide.md
@@ -1,0 +1,92 @@
+# Guide page template
+
+A guide is a procedural how-to. The reader has a specific task to accomplish, often spanning multiple capabilities or involving an external system. They open the page mid-task, follow the steps, and close it with the task done.
+
+If a procedure fits inside a single capability, it belongs as an operation on that capability's concept page, not as a guide.
+
+**Use for:** pages in the Guides section.  
+**Don't use for:** new-user walkthroughs (tutorial), single-capability operations (concept page), or schema and rule lookups (reference).
+
+---
+
+## Skeleton
+
+```markdown
+---
+description: <One sentence summary, 120–160 chars. Used for SEO and AI retrieval. Required.>
+---
+
+# <Action-shaped page title>
+
+What this guide helps the reader accomplish, in plain language. One short paragraph. Tell them
+what they'll have at the end and roughly how long it will take.
+
+Don't open with "In this guide, you will learn..." Open with the task:
+"Deploy your Serverpod app from a GitHub Actions workflow."
+
+If the guide is about a workaround, say so up front and link to the roadmap status.
+
+## Before you start
+
+- <Prerequisite 1>
+- <Prerequisite 2>
+- <Prerequisite 3>
+
+## <Step 1: action-shaped heading>
+
+One or two sentences explaining what this step does and why.
+
+<command, configuration, or action>
+
+<expected output or result>
+
+## <Step 2: action-shaped heading>
+
+<as above>
+
+## Verify
+
+OPTIONAL but recommended where the result isn't obvious. Tell the reader how to confirm the
+procedure worked.
+
+## Troubleshooting
+
+OPTIONAL. Use only for 2–4 well-defined failure modes the reader will plausibly hit.
+Don't reproduce content covered by a dedicated failure-mode guide — link there instead.
+Format: question-shaped headings. Each entry: cause, fix.
+
+## Related
+
+OPTIONAL but recommended.
+
+- [<Linked page>](path) — <one-line description>
+```
+
+---
+
+## Voice
+
+- **Second person, present tense.** "You'll get a confirmation email."
+- **Imperative steps.** "Add the secret to your repository," not "You should add the secret."
+- **Action-shaped headings.** Every H2 names what the reader is doing. The page title is also action-shaped.
+- **Acknowledge workarounds.** If the guide depends on a third-party service or a temporary path, say so.
+
+## Length
+
+400–1,200 words plus code blocks. Over 1,500 words: ask whether it's actually two guides.
+
+## Branching
+
+Guides can branch where tutorials cannot. Use tabs or sub-sections when the reader genuinely has different valid paths. Don't manufacture branching where one clear path serves most readers.
+
+## Checklist before publishing
+
+- [ ] `description` frontmatter is present and reads well in isolation (120–160 chars).
+- [ ] Page title and section headings are action-shaped.
+- [ ] The guide is genuinely cross-cutting; single-capability content belongs on the concept page.
+- [ ] Workaround or third-party dependency stated up front if applicable.
+- [ ] Prerequisites are complete and accurate.
+- [ ] Code blocks are language-tagged; `title` attributes used for file content.
+- [ ] Screenshots match the current state of the UI (labels, buttons, and layout match what the guide describes).
+- [ ] Verify section present where the result isn't obvious.
+- [ ] No marketing language, no manufactured complexity, no rehashed concept content.

--- a/.github/doc-templates/reference.md
+++ b/.github/doc-templates/reference.md
@@ -1,0 +1,88 @@
+# Reference page template
+
+A reference page is a lookup. The reader knows what they're looking for: a schema, a rule, a list of valid values, a parameter set. They open the page, find the answer, and close it. They're not reading top to bottom; they're scanning.
+
+**Use for:** pages in the Reference section — schemas, rules, exhaustive enumerations.  
+**Don't use for:** narrative capability explanations (concept), procedural how-tos (guide), or new-user walkthroughs (tutorial). The CLI reference is auto-generated and follows its own pattern.
+
+---
+
+## Skeleton
+
+```markdown
+---
+description: <One sentence summary, 120–160 chars. Used for SEO and AI retrieval. Required.>
+---
+
+# <Reference subject>
+
+One to three sentences. What this reference covers and when the reader needs it.
+Don't open with "This page documents..." Open with the substance.
+
+## <Lookup body>
+
+Format depends on the subject. Pick what makes the reader's lookup fastest:
+
+For a schema:
+  - Structured table or hierarchical list.
+  - Each entry: key name, type, required/optional, default, description.
+  - Group related keys under sub-headings.
+  - Show a complete example at the top or bottom.
+
+For rules:
+  - Lead with the rules as a bulleted list.
+  - Follow with valid and invalid examples.
+  - Document version selection logic or precedence explicitly.
+
+For enumerations:
+  - Table with one row per item.
+  - Columns are the attributes the reader will compare.
+  - Sort by what the reader is most likely to pick first.
+
+Avoid narrative paragraphs. Reference pages reward scanning; prose hides the answer.
+
+## Error messages
+
+OPTIONAL. Use when the subject produces specific error messages the reader will encounter.
+Format: each error gets a sub-heading with the verbatim message, followed by cause and fix.
+
+## Examples
+
+OPTIONAL. Use when the reader benefits from seeing the subject applied to several common cases.
+Omit if the lookup body already has sufficient examples inline.
+
+## Related
+
+OPTIONAL but recommended.
+
+- [<Linked page>](path) — <one-line description>
+```
+
+---
+
+## Voice
+
+- **Terse.** "Defaults to false" beats "This value defaults to false if you don't specify it."
+- **No hedging.** "Returns the deployment ID" not "Should return the deployment ID."
+- **No second person except in examples.** The body describes the subject; it doesn't address the reader.
+- **Verbatim accuracy.** Error messages, key names, and command syntax must match exactly what the system produces or accepts.
+
+## Length
+
+No fixed target — complete and no longer. A schema page might run 1,000–2,500 words; a rules page 200–400 words; an enumeration 300–800 words. Over 3,000 words: consider splitting by sub-topic.
+
+## Anchors
+
+Reference pages are linked to with anchor fragments more than any other page type. Keep H2 and H3 headings stable across rewrites; renaming them breaks inbound anchors silently.
+
+## Checklist before publishing
+
+- [ ] `description` frontmatter is present and reads well in isolation (120–160 chars).
+- [ ] Overview is brief (one to three sentences) and substantive (no marketing).
+- [ ] The lookup body uses the right format for the subject.
+- [ ] Every key, value, rule, or item is documented; nothing silently omitted.
+- [ ] Code blocks are language-tagged; `title` attributes used for complete file examples.
+- [ ] Error messages quote the exact text the system produces.
+- [ ] H2 and H3 headings are stable; no rewording of headings that have inbound anchors.
+- [ ] No narrative explanation, no best-practice commentary, no hedging.
+- [ ] Related section links to the paired concept page and any guides that use this subject.

--- a/.github/doc-templates/tutorial.md
+++ b/.github/doc-templates/tutorial.md
@@ -1,0 +1,82 @@
+# Tutorial page template
+
+A tutorial is a teaching page. The reader is new to the product or the feature, and we walk them through a working example end to end. They finish having done something real, with a concrete result they can see.
+
+A tutorial is not a how-to. A how-to assumes the reader knows what they want to do; a tutorial assumes they're new and need the experience of using the feature once before they can do it on their own.
+
+**Use for:** pages in Get started, and any page that introduces a feature through a guided walkthrough.  
+**Don't use for:** procedures for readers who already know what they're doing (guide), conceptual explanations (concept), or schema and rule lookups (reference).
+
+---
+
+## Skeleton
+
+```markdown
+---
+description: <One sentence summary, 120–160 chars. Used for SEO and AI retrieval. Required.>
+---
+
+# <Page title>
+
+What the reader will do on this page, in plain language. One paragraph, two to four sentences.
+Tell them what they'll have at the end.
+
+Don't start with "In this tutorial, we will..." Start with the thing they'll do.
+Example: "Deploy a Serverpod app to Cloud and see it running on a public URL."
+
+## Before you start
+
+- <Prerequisite 1 — link to install page, or concrete state, or external account>
+- <Prerequisite 2>
+- <Prerequisite 3>
+
+## <Step 1: action-shaped heading>
+
+One or two sentences explaining what this step does and why.
+
+<command or action>
+
+<expected output or result>
+
+## <Step 2: action-shaped heading>
+
+<as above>
+
+## What you've done
+
+Two to four sentences. Recap what they accomplished, then point them to the next thing:
+a Concepts page to deepen understanding, or a Guide for the next task.
+```
+
+---
+
+## Voice
+
+- **Second person, present tense.** "You'll see the deployment status print to the terminal."
+- **Direct steps, not options.** One path through the feature. Variants belong in Concepts or Reference.
+- **Show real output.** Don't paraphrase. Trim long output but show the actual format.
+- **Action-shaped headings.** "Deploy your project" beats "Deployment".
+
+## Length
+
+400–800 words plus code blocks. Readable in 5–10 minutes, doable in 15–30 minutes. Shorter suggests it's a how-to; longer suggests it should be split.
+
+## Code samples
+
+- Use real values, not placeholders, where possible. `my-app` beats `your-project-name`.
+- One language per code block.
+- Always tag the language fence (`bash`, `dart`, `yaml`, etc.).
+- Use the `title` attribute when the block represents a specific file.
+
+## Checklist before publishing
+
+- [ ] The reader can complete the tutorial on a clean machine following only this page.
+- [ ] Every step has a verifiable result.
+- [ ] `description` frontmatter is present and reads well in isolation (120–160 chars).
+- [ ] Headings are action-shaped.
+- [ ] Prerequisites are complete and accurate.
+- [ ] Code blocks are language-tagged; `title` attributes used for file content.
+- [ ] Screenshots match the current state of the UI (labels, buttons, and layout match what the tutorial describes).
+- [ ] Admonitions used sparingly and at the right severity level.
+- [ ] No marketing language, no hedging, no concept dumps.
+- [ ] Length is in the 400–800 word target range (excluding code blocks).

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -132,29 +132,50 @@ Stating specific facts about a third-party service that we don't own and would h
 ❌ `GitHub Apps allow up to 10 callback URLs (OAuth Apps allow only one).` — this is a GitHub product detail; if GitHub changes it, our docs silently become wrong.  
 ✅ Remove it, or if necessary to complete the task, link to GitHub's documentation for service-specific limits, and state only what the reader needs to do.
 
-### 14. Version history noise
+### 12. Version history noise
 
 Describing old Serverpod behavior in a current task page. The reader is completing a task with the current version; what the framework used to do is irrelevant unless they are migrating.
 
 ❌ `In previous versions of Serverpod the insert method mutated the input object by setting the id field. In the example above the input variable remains unmodified after the insert/insertRow call.`  
 ✅ Remove it. The code example already demonstrates current behavior. If an upgrade note is needed, it belongs in the version upgrade guide.
 
-### 15. Concept preamble on a task page
+### 13. Concept preamble on a task page
 
-Opening with multiple sentences explaining what a feature *is* and *why it exists*, before the first step. One short orienting sentence is acceptable; more delays the reader's first action.
+Applies to **guides and tutorials**. Opening with multiple sentences explaining what a feature *is* and *why it exists*, before the first step. One short orienting sentence is acceptable; more delays the reader's first action.
 
 ❌ Four-sentence explanation of what middleware is and why it's useful, before any code appears on a page whose job is to show how to add middleware.  
 ✅ One sentence: `Middleware runs before and after your route handlers, making it suitable for logging, API key validation, and CORS.` Then show the first step.
 
-Deeper concept explanation belongs on a dedicated concept page, not at the top of a task page.
+Deeper concept explanation belongs on a dedicated concept page, not at the top of a guide or tutorial.
 
-### 16. Obvious constraint restatement
+### 14. Obvious constraint restatement
 
 Stating API preconditions that Dart's type system or the runtime already enforces. Keep only constraints that are *silent* (produce wrong behavior without a compile error or exception) or require out-of-code setup.
 
 ❌ `The object that you update must have its id set to a non-null value and the id needs to exist on a row in the database.` — `id` is typed `int?`; passing `null` is a compile-time type error.  
 ❌ `At least one column must be specified in the columnValues parameter, otherwise an ArgumentError will be thrown.` — an empty list throws immediately with a descriptive error.  
 ✅ Remove both. Silent constraints — for example, a `deleteWhere` filter that matches more rows than the reader expects — are worth calling out.
+
+### 15. Sentence-starting code span
+
+Starting a sentence or paragraph with a backtick-wrapped identifier. An inline code span at the start reads as a symbol, not a sentence opener; lead with a noun phrase instead.
+
+❌ `` `dataPath` controls where Serverpod writes its data files. ``  
+✅ The `dataPath` setting controls where Serverpod writes its data files.
+
+### 16. Numbered folder prefixes in cross-doc links
+
+Including the numeric folder prefixes (`06-`, `11-`, `01-`) when linking to other docs pages. Docusaurus resolves links by slug, not by folder name, and numbered paths break the strict-mode broken-link check.
+
+❌ `[Setup](../06-concepts/11-authentication/01-setup)`  
+✅ `[Setup](../concepts/authentication/setup)`
+
+### 17. Opaque Related entry
+
+Linking to a page in a Related or See also section using a term the current page never explained. If the reader hasn't encountered the linked concept, the entry gives them nothing to act on.
+
+❌ `[.scloudignore](../concepts/scloudignore)` — only useful if the page already introduced `.scloudignore`.  
+✅ Describe what the linked page is for using terms the reader already knows: `[Excluding files from deployment](../concepts/scloudignore)`.
 
 ---
 

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -134,7 +134,7 @@ Stating specific facts about a third-party service that we don't own and would h
 
 ### 12. Version history noise
 
-Describing old Serverpod behavior in a current task page. The reader is completing a task with the current version; what the framework used to do is irrelevant unless they are migrating.
+Describing old Serverpod behavior in a current guide or tutorial. The reader is completing a task with the current version; what the framework used to do is irrelevant unless they are migrating.
 
 ❌ `In previous versions of Serverpod the insert method mutated the input object by setting the id field. In the example above the input variable remains unmodified after the insert/insertRow call.`  
 ✅ Remove it. The code example already demonstrates current behavior. If an upgrade note is needed, it belongs in the version upgrade guide.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,178 @@
+---
+applyTo: "docs/**,versioned_docs/**,cloud_docs/**"
+---
+
+# Docs quality instructions
+
+Apply these rules when writing new documentation or reviewing existing pages. The goal is the same in both cases: get the reader to a working outcome with minimum friction.
+
+## Creating a new page
+
+Before writing a new page or section, ask the user whether it is a **concept**, **guide**, **tutorial**, or **reference** page. Then follow the skeleton and rules in the matching template:
+
+- Concept — `.github/doc-templates/concept.md`
+- Guide — `.github/doc-templates/guide.md`
+- Tutorial — `.github/doc-templates/tutorial.md`
+- Reference — `.github/doc-templates/reference.md`
+
+---
+
+## Structure rules
+
+- **`description` frontmatter is required** on every page. It must be a single sentence, 120–160 characters, that reads well in isolation (used for SEO meta description and AI retrieval).
+- **Omit the `title` frontmatter field.** Docusaurus generates the page title from the first `#` heading; including both causes markdownlint to flag a duplicate.
+- **The first `#` heading** should be descriptive but short. For guides and tutorials it should be action-shaped ("Set up GitHub sign-in"). For concepts and reference pages it should be noun-shaped ("Passwords", "Custom domains").
+- **Use `sidebar_label`** frontmatter when a page title is too long for the sidebar. It should be a shorter version of the title, not a different title.
+---
+
+## Principles
+
+1. **One default path.** Each procedure follows one clear path. Advanced alternatives and edge cases belong in a Customizations or separate advanced section, not inline.
+2. **Say what to do, not why defaults are sensible.** If the reader should leave a setting on, say so. Don't explain the security reasoning behind GitHub's token expiration policy.
+3. **The reader's task drives the page.** Every sentence either moves the reader forward or is cut. Background, comparisons, and history that don't help the reader act are noise.
+
+---
+
+## Review checks
+
+When reviewing an existing page, also check for:
+
+- **Missing steps.** Is every required action explicitly stated? Would a Flutter developer with no backend experience know what to do next?
+- **Assumed knowledge.** Does the page use a term, concept, or tool without introducing it or linking to where it's explained? Flag any assumption that isn't basic Flutter or Dart knowledge.
+- **Skipped prerequisites.** Is there something the reader must have set up or installed before this step that the page doesn't mention? If a prerequisite involves steps in an external service, link to a maintained guide for those steps — a bare link to the service's homepage is not enough.
+- **Screenshot drift.** Do screenshots match the current state of the UI? Flag any screenshot where labels, buttons, or layout differ from what the guide describes.
+
+Basic Flutter knowledge (widgets, `main()`, `pubspec.yaml`, or Flutter code examples) can be assumed without explanation.
+
+---
+
+## Noise patterns
+
+Each pattern has a name, a definition, a bad example, and a good example.
+
+### 1. Form validation noise
+
+Repeating field constraints, character limits, or required/optional labels that the interface the reader is looking at (GitHub, Serverpod console, any third-party UI) already enforces or displays.
+
+❌ `**GitHub App name** (required, up to 34 characters, unique across GitHub).`  
+✅ `**GitHub App name**`
+
+### 2. Comparison jargon
+
+Explaining a concept by comparing it to another concept the reader likely doesn't know.
+
+❌ `GitHub Apps use fine-grained permissions instead of OAuth scopes.`  
+✅ `For sign-in you only need access to the user's profile.`
+
+### 3. Forward references in procedure steps
+
+Mentioning terms from a later section as if they orient the reader, before the reader has any context for them.
+
+❌ `The callback URL must match the redirect URI you pass to initializeGitHubSignIn in your Flutter app.`  
+✅ `The callback URL is where GitHub redirects the user after they authorize your app.`
+
+_(Link or refer back once the term is introduced later in the page.)_
+
+### 4. Reasoning padding
+
+Explaining the rationale behind a setting the reader just needs to leave alone.
+
+❌ `Leave **Expire user authorization tokens** enabled. Token expiration is recommended for sign-in flows so leaked tokens have a short useful lifetime.`  
+✅ `Leave **Expire user authorization tokens** enabled. Serverpod handles token refresh automatically.`
+
+### 5. Implementation detail exposure
+
+Surfacing internal class names, system APIs, or package internals the reader doesn't need to know to complete the task.
+
+❌ `The flutter_web_auth_2 package handles the redirect using ASWebAuthenticationSession.`  
+✅ `No special configuration is needed for a standard custom-scheme callback URL.`
+
+### 6. Misplaced admonitions
+
+Tips or notes about a topic not directly relevant to the step the reader is on. An admonition that could be removed without the reader missing a required action is noise.
+
+❌ A `:::tip` in the GitHub callback URL step explaining reverse-DNS naming conventions for iOS/Android app schemes.  
+✅ Remove it. The table already shows `com.example.yourapp://auth` as the example value.
+
+### 7. Ecosystem comparisons
+
+Comparing the service or tool being set up to an alternative mid-procedure, when the reader is already on a specific setup path and the comparison doesn't change what they do.
+
+❌ A note explaining the difference between GitHub Apps and OAuth Apps in the middle of the GitHub App setup flow.  
+✅ Remove. If the reader needs to choose between the two, surface that decision in prerequisites — before the procedure starts.
+
+### 8. Manufactured branching in the main flow
+
+Offering two valid paths inside the core procedure when one is the default for most readers and the other is an advanced or uncommon case.
+
+❌ Main setup section presenting both Serverpod-hosted web and separately-hosted web as equal paths with inline sub-sections.  
+✅ Follow the default (Serverpod-hosted) path in the main flow. Put the separately-hosted variant in a Customizations page or a clearly labelled advanced section at the bottom.
+
+### 9. Redundant qualifiers
+
+Words or phrases that state what's already obvious from context.
+
+❌ `Sign in with GitHub uses OAuth2 credentials from a GitHub App registered on GitHub.`  
+✅ `Sign in with GitHub uses OAuth2 credentials from a GitHub App.`
+
+❌ `The flutter_web_auth_2 package handles the OAuth2 redirect on every platform under the hood.`  
+✅ `The GitHub identity provider uses flutter_web_auth_2 to handle the OAuth2 redirect.`
+
+### 10. Internal mechanics exposure
+
+Describing how the framework or widget wires itself up internally when the reader only needs to know what to call or where to put something.
+
+❌ `SignInWidget auto-detects which identity provider endpoints are registered on the server, so once GitHubIdpEndpoint is exposed and client has been generated, the GitHub button appears.`  
+✅ `Once GitHubIdpEndpoint is registered and your app reloads, the GitHub sign-in button appears automatically.`
+
+### 11. Facts that belong in external docs
+
+Stating specific facts about a third-party service that we don't own and would have to maintain if they change. Link to the authoritative source instead.
+
+❌ `GitHub Apps allow up to 10 callback URLs (OAuth Apps allow only one).` — this is a GitHub product detail; if GitHub changes it, our docs silently become wrong.  
+✅ Remove it, or if necessary to complete the task, link to GitHub's documentation for service-specific limits, and state only what the reader needs to do.
+
+### 12. Ambiguous "app" in full-stack context
+
+Using "app" without qualification when it could mean the Flutter app, the Serverpod server, or the full-stack product. Serverpod projects have both a server and a Flutter app — be specific.
+
+❌ `The app calls your endpoint and displays the result.`  
+❌ `Leave the app running. Every time you save a file it hot-reloads.`  
+✅ `The Flutter app calls your endpoint and displays the result.`  
+✅ `Leave serverpod start running. Every time you save a file it regenerates code and hot-reloads the Flutter app.`
+
+### 14. Version history noise
+
+Describing old Serverpod behavior in a current task page. The reader is completing a task with the current version; what the framework used to do is irrelevant unless they are migrating.
+
+❌ `In previous versions of Serverpod the insert method mutated the input object by setting the id field. In the example above the input variable remains unmodified after the insert/insertRow call.`  
+✅ Remove it. The code example already demonstrates current behavior. If an upgrade note is needed, it belongs in the version upgrade guide.
+
+### 15. Concept preamble on a task page
+
+Opening with multiple sentences explaining what a feature *is* and *why it exists*, before the first step. One short orienting sentence is acceptable; more delays the reader's first action.
+
+❌ Four-sentence explanation of what middleware is and why it's useful, before any code appears on a page whose job is to show how to add middleware.  
+✅ One sentence: `Middleware runs before and after your route handlers, making it suitable for logging, API key validation, and CORS.` Then show the first step.
+
+Deeper concept explanation belongs on a dedicated concept page, not at the top of a task page.
+
+### 16. Obvious constraint restatement
+
+Stating API preconditions that Dart's type system or the runtime already enforces. Keep only constraints that are *silent* (produce wrong behavior without a compile error or exception) or require out-of-code setup.
+
+❌ `The object that you update must have its id set to a non-null value and the id needs to exist on a row in the database.` — `id` is typed `int?`; passing `null` is a compile-time type error.  
+❌ `At least one column must be specified in the columnValues parameter, otherwise an ArgumentError will be thrown.` — an empty list throws immediately with a descriptive error.  
+✅ Remove both. Silent constraints — for example, a `deleteWhere` filter that matches more rows than the reader expects — are worth calling out.
+
+---
+
+## Admonition guidelines
+
+Use admonitions sparingly. Before adding one, ask: does the reader need this to complete the task?
+
+- `:::warning` — use when a step has consequences the reader could miss (data loss, a secret exposed, a migration required).
+- `:::note` — use for a narrow exception that applies to some readers (not all), where the main flow doesn't cover it.
+- `:::tip` — almost never. If the tip is important, it belongs in the main body. If it isn't, cut it. Never wrap a substantial code example in a `:::tip` block — promote it to a labelled `## Advanced` section at the bottom of the page or move it to a dedicated page.
+
+Never use an admonition to deliver content that belongs in a different section or a different page.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -132,15 +132,6 @@ Stating specific facts about a third-party service that we don't own and would h
 ❌ `GitHub Apps allow up to 10 callback URLs (OAuth Apps allow only one).` — this is a GitHub product detail; if GitHub changes it, our docs silently become wrong.  
 ✅ Remove it, or if necessary to complete the task, link to GitHub's documentation for service-specific limits, and state only what the reader needs to do.
 
-### 12. Ambiguous "app" in full-stack context
-
-Using "app" without qualification when it could mean the Flutter app, the Serverpod server, or the full-stack product. Serverpod projects have both a server and a Flutter app — be specific.
-
-❌ `The app calls your endpoint and displays the result.`  
-❌ `Leave the app running. Every time you save a file it hot-reloads.`  
-✅ `The Flutter app calls your endpoint and displays the result.`  
-✅ `Leave serverpod start running. Every time you save a file it regenerates code and hot-reloads the Flutter app.`
-
 ### 14. Version history noise
 
 Describing old Serverpod behavior in a current task page. The reader is completing a task with the current version; what the framework used to do is irrelevant unless they are migrating.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,28 @@
 # Serverpod documentation
 
-This is the documentation for Serverpod an open-source backend for Flutter written in Dart. The documentation is created using Docusaurus.
+This is the documentation for Serverpod, an open-source backend for Flutter written in Dart. The documentation is built with Docusaurus.
 
-Rules:
+## Rules
 
 - When writing documentation, always follow the instructions in the STYLE_GUIDE.md.
 - Do NOT attempt to run `npm run build` or similar, instead ask the user for verification.
 - When linking to other pages in the documentation use this format: `[Working with endpoints](./concepts/working-with-endpoints)`. This will ensure that the links work within the same version of the docs.
+- When writing or reviewing documentation, apply the patterns in `.github/instructions/docs.instructions.md`.
+
+## Who reads these docs
+
+The majority of readers are Flutter developers. They range from developers new to backend and full-stack concepts to experienced engineers. Do not assume knowledge of server-side patterns, database configuration, OAuth flows, or deployment infrastructure unless the current page has already introduced it. Basic Flutter and Dart knowledge can be assumed.
+
+Three types of readers, in order of priority:
+
+**The Evaluator** — deciding whether to use Serverpod or Serverpod Cloud. New to the product, needs to reach a working outcome fast. Blocked by unfamiliar terms, unclear scope, and setup paths that assume too much.
+
+**The Builder** — actively shipping with Serverpod. Knows the basics, needs to find the answer to a specific task quickly. Blocked by scattered information and missing happy paths.
+
+**The Operator** — running real workloads, hitting real friction. Needs precise, trustworthy reference. Blocked by undocumented edge cases and content that doesn't match what the system actually does.
+
+The same person moves through all three stages. Write for the stage they're in right now, not the one they'll eventually reach.
+
+## The governing principle
+
+Get the reader to a working outcome with minimum friction. Every sentence should either move them forward or be cut.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -26,6 +26,20 @@ Strong: Switching between Dart on the frontend and another language on the backe
 Weak: Supercharge your backend journey.\
 Strong: Deploy your backend without touching a single config file.
 
+### Words to avoid
+
+The following words add length without adding meaning, or sound marketing-inflected in technical prose. Replace them with the plain version.
+
+| Avoid | Use instead |
+| --- | --- |
+| robust | reliable |
+| seamless | smooth |
+| powerful | (cut it, or say what it does) |
+| intuitive | (cut it, or say what it does) |
+| leverage | use |
+| facilitate | help, allow |
+| enables you to X | lets you X / you can X |
+
 ---
 
 ## 2. Terminology and naming consistency
@@ -131,3 +145,11 @@ Avoid:
 - Act now!
 - Limited time only!
 
+---
+
+## 8. Em dashes
+
+Avoid em dashes (—) in running text. They are hard to read aloud and almost always signal a sentence that should be split or rephrased. Use a comma, parenthesis, colon, or period instead.
+
+Avoid: `Call initializeAuthServices before pod.start — this registers the token managers.`\
+Prefer: `Call initializeAuthServices before pod.start. This registers the token managers.`


### PR DESCRIPTION
This PR introduces tooling to help maintainers, contributors, and LLM agents write and review documentation consistently.

The goal is to improve:

- Efficiency
- Quality
- Consistency

### New file: docs.instructions.md
A code review instructions file (auto-applied to docs/**, versioned_docs/**, cloud_docs/**). 

It defines: 

- 16 named noise patterns with bad/good examples drawn from real PR review comments
- Core writing principles and guidelines
- Review guidelines
- Structure rules
- Helpers for when creating new pages.

### Four page templates

Page skeletons for when creating new pages:

- Concept
- Guide
- Tutorial
- Reference

###  Test results

Tested using Cursor to review 7 files in the tree. Some screenshot from the review results:

<img width="610" height="623" alt="image" src="https://github.com/user-attachments/assets/038f7cfc-84b0-440f-a5a9-669dcf9c4621" />

<img width="890" height="823" alt="image" src="https://github.com/user-attachments/assets/82f7234f-05d7-4039-bc6f-93fa4c5da303" />

