### PR TITLE
docs: Align Cloud install command, trial wording, and setup flow across pages

### DIFF
--- a/docs/04-get-started/02-quickstart.md
+++ b/docs/04-get-started/02-quickstart.md
@@ -81,28 +81,30 @@ If the agent fails to reload the app, you can always hit the `R` key to force a 
 
 ## Deploy the app to the cloud
 
-To deploy your app to Serverpod Cloud, you will need to create an account and set up a new project in Serverpod Cloud. Head to the **[Serverpod Cloud Console](https://console.serverpod.cloud/)** and follow the instructions there. You get a 1-month free trial. No credit card required.
+Deploy your app to **[Serverpod Cloud](/cloud)**, a fully managed platform built by the Serverpod team. Your first project includes a one-month free trial, with no credit card required.
 
-Install the Serverpod Cloud command line tools:
+Create your Cloud account on the **[Serverpod Cloud Console](https://console.serverpod.cloud/)**, then install the Serverpod Cloud command line tools:
 
-```txt
-$ dart install serverpod_cloud_cli
+```bash
+$ dart pub global activate serverpod_cloud_cli
 ```
 
-With the Serverpod Cloud project set up and the CLI tools installed, you can deploy your backend and web app using the `scloud launch` command:
+From your project's root folder, launch your app:
 
-```txt
+```bash
 $ scloud launch
 ```
 
-After the project has been uploaded for the first time, use the `deploy` command whenever you make changes to your project:
+This creates the Cloud project, provisions a database, and deploys your backend along with the web build of your app.
 
-```txt
+After the first launch, redeploy changes with:
+
+```bash
 $ scloud deploy
 ```
 
 :::tip
 
-In the Serverpod Cloud console, open Serverpod Insights to view server logs, CPU usage, and other information.
+In the **[Serverpod Cloud Console](https://console.serverpod.cloud/)**, open Serverpod Insights to view server logs, CPU usage, and other information.
 
 :::

--- a/docs/08-deployments/01-deploy-to-serverpod-cloud.md
+++ b/docs/08-deployments/01-deploy-to-serverpod-cloud.md
@@ -25,7 +25,7 @@ Cloud manages the production infrastructure for you:
 
 You deploy with the `scloud` CLI:
 
-1. Install the `scloud` CLI.
+1. Install the `scloud` CLI with `dart pub global activate serverpod_cloud_cli`.
 2. Run `scloud launch`. It creates the Cloud project, provisions a database if you enable one, and deploys your server.
 3. Set any app secrets (API keys, OAuth credentials) with `scloud password set`.
 


### PR DESCRIPTION
Closes #552.

Brings the three framework pages that mention Serverpod Cloud into agreement, matching the wording the Cloud docs already use.

Changes:

- **Quickstart**: keep the explicit account-creation step (via the Cloud Console), but drop the "set up a project first" prerequisite since `scloud launch` creates the project inline. Updates the install command to `dart pub global activate serverpod_cloud_cli` (matches the Cloud docs), the trial wording to "your first project includes a one-month free trial" (accurate per testing), and switches `txt` code fences to `bash`.
- **Deploy to Serverpod Cloud**: makes the install command explicit (`dart pub global activate serverpod_cloud_cli`).
- **Build your first app deploy page** is already aligned (in #557).

Out of scope but flagging: the Cloud docs themselves don't currently mention the free trial. That's a Cloud-side gap to address separately.

Closes: https://github.com/serverpod/serverpod_docs/issues/552