### PR TITLE
docs: Document custom serializable exceptions

### DIFF
--- a/docs/06-concepts/04-exceptions.md
+++ b/docs/06-concepts/04-exceptions.md
@@ -64,7 +64,7 @@ Serverpod treats the exception as an internal server error.
 ```dart
 import 'package:serverpod_serialization/serverpod_serialization.dart';
 
-class UserFacingException implements SerializableException {
+class UserFacingException implements SerializableException, Exception {
   final String message;
   final String? code;
 
@@ -99,7 +99,7 @@ Register it in the server project's `config/generator.yaml`, then run
 
 ```yaml
 extraClasses:
-  - package:my_project_shared/my_project_shared.dart:UserFacingException
+  - "package:my_project_shared/my_project_shared.dart:UserFacingException"
 ```
 
 The `SerializableException` interface marks the exception as safe to serialize

--- a/docs/06-concepts/04-exceptions.md
+++ b/docs/06-concepts/04-exceptions.md
@@ -53,6 +53,59 @@ catch(e) {
 }
 ```
 
+### Custom serializable exception classes
+
+Use the `exception` keyword in a Serverpod model file when you define a new
+exception for your project. If you already have a Dart exception class in a
+package shared by the server and client, the class must implement
+`SerializableException` for Serverpod to send it to the client. Otherwise,
+Serverpod treats the exception as an internal server error.
+
+```dart
+import 'package:serverpod_serialization/serverpod_serialization.dart';
+
+class UserFacingException implements SerializableException {
+  final String message;
+  final String? code;
+
+  UserFacingException({
+    required this.message,
+    this.code,
+  });
+
+  factory UserFacingException.fromJson(Map<String, dynamic> json) {
+    return UserFacingException(
+      message: json['message'] as String,
+      code: json['code'] as String?,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return {
+      'message': message,
+      'code': code,
+    };
+  }
+
+  @override
+  String toString() => message;
+}
+```
+
+The class must also be known to Serverpod's generated serialization manager.
+Register it in the server project's `config/generator.yaml`, then run
+`serverpod generate`:
+
+```yaml
+extraClasses:
+  - package:my_project_shared/my_project_shared.dart:UserFacingException
+```
+
+The `SerializableException` interface marks the exception as safe to serialize
+to the client. The `extraClasses` entry lets Serverpod generate the
+deserialization code needed to reconstruct the exception on the client.
+
 ### Default values in exceptions
 
 Serverpod allows you to specify default values for fields in exceptions, similar to how it's done in models using the `default` and `defaultModel` keywords. If you're unfamiliar with how these keywords work, you can refer to the [Default Values](models#default-values) section in the [Working with Models](models) documentation.

--- a/docs/06-concepts/04-exceptions.md
+++ b/docs/06-concepts/04-exceptions.md
@@ -55,11 +55,7 @@ catch(e) {
 
 ### Custom serializable exception classes
 
-Use the `exception` keyword in a Serverpod model file when you define a new
-exception for your project. If you already have a Dart exception class in a
-package shared by the server and client, the class must implement
-`SerializableException` for Serverpod to send it to the client. Otherwise,
-Serverpod treats the exception as an internal server error.
+If you already have a Dart exception class in a package shared by the server and client, the class must implement `SerializableException` for Serverpod to send it to the client. Otherwise, Serverpod treats the exception as an internal server error.
 
 ```dart
 import 'package:serverpod_serialization/serverpod_serialization.dart';
@@ -93,18 +89,14 @@ class UserFacingException implements SerializableException {
 }
 ```
 
-The class must also be known to Serverpod's generated serialization manager.
-Register it in the server project's `config/generator.yaml`, then run
-`serverpod generate`:
+The class must also be known to Serverpod's generated serialization manager. Register it in the server project's `config/generator.yaml`, then run `serverpod generate`:
 
 ```yaml
 extraClasses:
   - package:my_project_shared/my_project_shared.dart:UserFacingException
 ```
 
-The `SerializableException` interface marks the exception as safe to serialize
-to the client. The `extraClasses` entry lets Serverpod generate the
-deserialization code needed to reconstruct the exception on the client.
+The `SerializableException` interface marks the exception as safe to serialize to the client. See [Custom serializable classes](configuration#custom-serializable-classes) for how the `extraClasses` entry registers the type for code generation.
 
 ### Default values in exceptions
 

--- a/docs/06-concepts/04-exceptions.md
+++ b/docs/06-concepts/04-exceptions.md
@@ -64,7 +64,7 @@ Serverpod treats the exception as an internal server error.
 ```dart
 import 'package:serverpod_serialization/serverpod_serialization.dart';
 
-class UserFacingException implements SerializableException, Exception {
+class UserFacingException implements SerializableException {
   final String message;
   final String? code;
 
@@ -99,7 +99,7 @@ Register it in the server project's `config/generator.yaml`, then run
 
 ```yaml
 extraClasses:
-  - "package:my_project_shared/my_project_shared.dart:UserFacingException"
+  - package:my_project_shared/my_project_shared.dart:UserFacingException
 ```
 
 The `SerializableException` interface marks the exception as safe to serialize


### PR DESCRIPTION
## Summary

- Add guidance for custom Dart exception classes that should be serialized to the client.
- Document that custom exception classes must implement `SerializableException`.
- Clarify that external/shared exception classes still need an `extraClasses` entry so generated serialization can reconstruct them on the client.

## Verification

- `npx --yes --cache ./.npm-cache markdownlint-cli docs/06-concepts/04-exceptions.md`
- `git diff --check`

I did not run a docs build because `serverpod_docs/AGENTS.md` says not to run build commands locally.

Closes serverpod/serverpod#3421