### PR TITLE
docs: Rename top-level Deploy sidebar label

### DIFF
--- a/docs/08-deployments/_category_.json
+++ b/docs/08-deployments/_category_.json
@@ -1,4 +1,4 @@
 {
-  "label": "Deploy your app",
+  "label": "Deploy",
   "className": "sidebar-icon-deploying"
 }


### PR DESCRIPTION
The top-level "Deploy your app" entry duplicated the sidebar label in the Get started folder, which was confusing in navigation. Renamed the top-level category to "Deploy" so the two surfaces are visually distinct.

Closes #567