### PR TITLE
docs(cloud): Rewrite Introduction, refresh Install scloud, relabel Get started

### DIFF
--- a/cloud_docs/01-getting-started/01-installation.md
+++ b/cloud_docs/01-getting-started/01-installation.md
@@ -1,28 +1,30 @@
 ---
-sidebar_label: Installation
+title: Install scloud
+sidebar_label: Install scloud
 sidebar_class_name: sidebar-installation-icon
+description: Install scloud, Serverpod Cloud's command-line interface, and authenticate it with your account.
 ---
 
-# Installation
+# Install scloud
 
-This page shows how to install `scloud`, Serverpod Cloud's command line interface, and how to authenticate it with your account. After completing these steps, you're ready to deploy your first Serverpod server.
+This page shows how to install `scloud`, Serverpod Cloud's command-line interface, and authenticate it with your account. After completing these steps, you're ready to deploy your first Serverpod app.
 
 ## Prerequisites
 
-Before installing the CLI, make sure you have the following:
+Before installing the CLI, make sure you have:
 
-- **Dart installed** – Follow the official guide: [https://dart.dev/get-dart#install](https://dart.dev/get-dart#install)
-- **A Serverpod Cloud account** – Sign up at [https://console.serverpod.cloud/auth/signup](https://console.serverpod.cloud/auth/signup)
+- **Dart installed.** Follow [Dart's install guide](https://dart.dev/get-dart#install).
+- **A Serverpod Cloud account.** [Sign up for Cloud](https://console.serverpod.cloud/auth/signup).
 
 ## Install the Serverpod Cloud CLI
 
-Install the `serverpod_cloud_cli` package globally using Dart to make the `scloud` command available:
+Install `serverpod_cloud_cli` to make the `scloud` command available:
 
 ```bash
-dart pub global activate serverpod_cloud_cli
+dart install serverpod_cloud_cli
 ```
 
-After installation, verify that the CLI is available:
+Verify the CLI is available:
 
 ```bash
 scloud version
@@ -38,4 +40,4 @@ Log in to your Serverpod Cloud account from the terminal:
 scloud auth login
 ```
 
-This command opens a browser window where you can authenticate your account. Once authentication completes, the CLI is authorized to manage your Serverpod Cloud projects.
+This opens a browser window where you authenticate. Once authentication completes, the CLI is authorized to manage your Serverpod Cloud projects.

--- a/cloud_docs/01-getting-started/_category_.json
+++ b/cloud_docs/01-getting-started/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Getting started",
+  "label": "Get started",
   "collapsed": false,
   "className": "sidebar-icon-getting-started"
 }

--- a/cloud_docs/index.md
+++ b/cloud_docs/index.md
@@ -3,56 +3,29 @@ title: Introduction
 sidebar_position: -1
 sidebar_label: Introduction
 sidebar_class_name: sidebar-introduction-icon
+description: Serverpod Cloud is a managed hosting platform for Serverpod apps. Deploy from the command line; Cloud manages runtime, networking, database, and secrets.
 ---
 
 # Introduction
 
-**Serverpod Cloud** is a fully managed hosting platform for Serverpod apps. It lets you deploy and run your Serverpod backend from the command line or via CI/CD. The platform manages all infrastructure needed to run your service in production. It can seamlessly scale to any size, and pricing is predictable. Serverpod Cloud handles networking, load balancing, custom domain names, and your database.
-
-This documentation covers account setup, installing and using the `scloud` command, deploying your server, configuring environments, and operating your services in production.
-
-## Zero-configuration deployments
-
-Deploy your Serverpod server directly from your project directory using the command line or integrate it into your CI/CD pipeline. No manual VM setup, container configuration, or infrastructure orchestration is needed.
+Serverpod Cloud is a managed hosting platform for Serverpod apps. You deploy and manage your app with the `scloud` command-line interface; a web console covers project management, billing, and inspection.
 
 ```bash
-### Install the CLI tool
-dart pub global activate serverpod_cloud_cli
-
-### Launch your Serverpod project
+dart install serverpod_cloud_cli
 scloud launch
 ```
 
-## Managed runtime and networking
+## What Cloud manages
 
-Your deployment automatically receives a production-ready runtime environment with:
+- **Runtime and scaling.** Your app runs on a production runtime that scales automatically.
+- **Networking and TLS.** Encrypted endpoints and certificates work without configuration.
+- **Managed Postgres** (optional). Cloud can provision a production-grade Postgres database with automatic migrations and backups.
+- **Secrets and environment variables.** Manage sensitive values through `scloud`; values are encrypted where applicable.
+- **Custom domains.** Attach your own domain; TLS certificates are provisioned and renewed. Cloud hosts both your backend and a preconfigured website for your Flutter web app.
+- **Logs and inspection.** View logs in the CLI or in Serverpod Insights, the desktop log viewer (requires a database).
+- **PubSub, caching, and file storage.** Supported through the Serverpod framework using third-party services today; managed services are on the roadmap.
 
-- Encrypted endpoints and certificates that work reliably with high loads and streaming data.
-- Load balancing and automatic scaling to any size.
-- Health checks for your backend and related services.
+## Where to go next
 
-This allows your server to run reliably without configuring networking or reverse proxies.
-
-## Managed database (optional)
-
-Serverpod Cloud can provision and manage a production-grade PostgreSQL database for your project. When enabled, database migrations are applied automatically during deployment. All authentication tokens and keys are fully managed and configured, and your database is frequently backed up.
-
-## Secure passwords and secrets
-
-Manage secrets, passwords, and environment variables through the `scloud` CLI. Sensitive values are encrypted where applicable, allowing you to easily connect to 3rd party services while keeping your app's configuration out of your source code.
-
-## Custom domains and web server
-
-Attach your own domain to a deployment. TLS certificates are automatically provisioned and renewed. Serverpod Cloud will host both your backend service and a website preconfigured for a Flutter web app.
-
-## Insights, logs, and diagnostics
-
-Serverpod Cloud comes with Serverpod Insights, our visual log viewer, preconfigured (requires a database). This gives you access to our world-class logging and server monitoring.
-
-## PubSub and caching
-
-The Serverpod framework has built-in support for sending messages between your servers, and caching objects works out of the box. We are working on building a service native to Serverpod Cloud; in the meantime, it's easy to configure a 3rd party service.
-
-## File storage buckets
-
-A fully managed file upload and storage service is planned for Serverpod Cloud. While it's being built, you can still use a 3rd party service, such as GCP or AWS, as these (and other compatible services) are supported by the Serverpod framework.
+- [Install scloud](/cloud/getting-started/installation) to set up the CLI.
+- [Deploy your first app](/cloud/getting-started/launch) for a guided first deploy.

--- a/cloud_docs/index.md
+++ b/cloud_docs/index.md
@@ -8,19 +8,18 @@ description: Serverpod Cloud is a managed hosting platform for Serverpod apps. D
 
 # Introduction
 
-Serverpod Cloud is a managed hosting platform for Serverpod apps with predictable pricing. You deploy and run your app with the `scloud` command-line interface, and use the web console for account setup, billing, and project dashboards.
+Serverpod Cloud is a managed hosting platform for Serverpod apps with predictable pricing. You deploy your app with the `scloud` command-line interface or via CI/CD, and use the web console for account setup, billing, and project dashboards.
 
-Your first deploy is two commands. No Dockerfile, no container config, no infrastructure setup:
+With [`scloud` installed](/cloud/getting-started/installation), launch your first project with one command. No Dockerfile, no container config, no infrastructure setup:
 
 ```bash
-dart install serverpod_cloud_cli
 scloud launch
 ```
 
 ## What Serverpod Cloud manages
 
 - **Runtime and scaling.** Your app runs on a production runtime that scales automatically.
-- **Networking and TLS.** Encrypted endpoints and certificates work without configuration.
+- **Networking and TLS.** Encrypted endpoints, certificates, and load balancing work without configuration.
 - **Managed Postgres** (optional). Cloud can provision a production-grade Postgres database with automatic migrations and backups.
 - **Secrets and environment variables.** Manage sensitive values through `scloud`; values are encrypted where applicable.
 - **Custom domains.** Attach your own domain; TLS certificates are provisioned and renewed. Cloud hosts both your backend and a preconfigured website for your Flutter web app.

--- a/cloud_docs/index.md
+++ b/cloud_docs/index.md
@@ -18,7 +18,7 @@ scloud launch
 
 ## What Serverpod Cloud manages
 
-- **Runtime and scaling.** Your app runs on a production runtime that scales automatically.
+- **Runtime and scaling.** Your app runs on a production runtime that scales as traffic grows.
 - **Networking and TLS.** Encrypted endpoints, certificates, and load balancing work without configuration.
 - **Managed Postgres** (optional). Cloud can provision a production-grade Postgres database with automatic migrations and backups.
 - **Secrets and environment variables.** Manage sensitive values through `scloud`; values are encrypted where applicable.

--- a/cloud_docs/index.md
+++ b/cloud_docs/index.md
@@ -8,7 +8,9 @@ description: Serverpod Cloud is a managed hosting platform for Serverpod apps. D
 
 # Introduction
 
-Serverpod Cloud is a managed hosting platform for Serverpod apps. You deploy and manage your app with the `scloud` command-line interface; a web console covers project management, billing, and inspection.
+Serverpod Cloud is a managed hosting platform for Serverpod apps. You deploy and run your app with the `scloud` command-line interface, and use the web console for account setup, billing, and project dashboards.
+
+Deploy is two commands. No Dockerfile, no container config, no infrastructure setup:
 
 ```bash
 dart install serverpod_cloud_cli

--- a/cloud_docs/index.md
+++ b/cloud_docs/index.md
@@ -8,16 +8,16 @@ description: Serverpod Cloud is a managed hosting platform for Serverpod apps. D
 
 # Introduction
 
-Serverpod Cloud is a managed hosting platform for Serverpod apps. You deploy and run your app with the `scloud` command-line interface, and use the web console for account setup, billing, and project dashboards.
+Serverpod Cloud is a managed hosting platform for Serverpod apps with predictable pricing. You deploy and run your app with the `scloud` command-line interface, and use the web console for account setup, billing, and project dashboards.
 
-Deploy is two commands. No Dockerfile, no container config, no infrastructure setup:
+Your first deploy is two commands. No Dockerfile, no container config, no infrastructure setup:
 
 ```bash
 dart install serverpod_cloud_cli
 scloud launch
 ```
 
-## What Cloud manages
+## What Serverpod Cloud manages
 
 - **Runtime and scaling.** Your app runs on a production runtime that scales automatically.
 - **Networking and TLS.** Encrypted endpoints and certificates work without configuration.


### PR DESCRIPTION
First PR of the Cloud IA rollout ([#568](https://github.com/serverpod/serverpod_docs/issues/568)).

## Changes

- **`cloud_docs/index.md`**: Introduction rewritten from a feature tour into a conceptual overview. Drops the 8 H2 sections in favour of a short pitch, a small code sample, a "What Cloud manages" bullet list, and "Where to go next" links. Every capability the old page surfaced is preserved in bullet form (Flutter web hosting, Insights' database requirement, PubSub/caching/file storage roadmap).
- **`cloud_docs/01-getting-started/01-installation.md`**: added `title: Install scloud`, retitled the page, swapped `dart pub global activate` → `dart install` (the Dart 3.10+ install command), small wording cleanups.
- **`cloud_docs/01-getting-started/_category_.json`**: sidebar label "Getting started" → "Get started".

I believe humans and LLMs will now find these pages easier to scan, understand and expand on through checking other pages (to be added or improved).

## Verification

- `dart install --help` and `scloud launch --help` confirm the commands.
- `npm run build` passes.

## What's next

PR 2: Deployments concept (NEW). PR 3: Deploy your first app rewrite (uses PR 2). Full rollout sequence in the [#568 tracking comment](https://github.com/serverpod/serverpod_docs/issues/568#issuecomment-4612251937).

**New Intro**:

<img width="3600" height="2296" alt="image" src="https://github.com/user-attachments/assets/a2b7b0cb-8251-4317-9496-94d77e0927c6" />

**New Installation**:

<img width="3600" height="2556" alt="image" src="https://github.com/user-attachments/assets/af1952cb-26fd-4b37-9b8a-4d07cb2a9d18" />
