### PR TITLE
docs: Clarify how migrations are applied with serverpod start

### DIFF
--- a/docs/06-concepts/06-database/11-migrations.md
+++ b/docs/06-concepts/06-database/11-migrations.md
@@ -94,7 +94,9 @@ For each migration, five files are created:
 
 ## Apply migrations
 
-Migrations are applied using the server runtime. To apply migrations, navigate to your project's `server` package directory, then start the server with the `--apply-migrations` flag. Migrations are applied as part of the startup sequence and the framework asserts that each migration is only applied once to the database.
+During local development, `serverpod start` applies your migrations for you: pending migrations run on the first boot, and you can apply new ones at any time by pressing **A** in the terminal UI.
+
+To apply migrations explicitly, for example in production or an automated pipeline, start the server runtime with the `--apply-migrations` flag from your `server` package directory. Migrations are applied as part of the startup sequence and the framework asserts that each migration is only applied once to the database.
 
 ```bash
 $ dart run bin/main.dart --apply-migrations

--- a/docs/06-concepts/06-database/11-migrations.md
+++ b/docs/06-concepts/06-database/11-migrations.md
@@ -94,9 +94,16 @@ For each migration, five files are created:
 
 ## Apply migrations
 
-During local development, `serverpod start` applies your migrations for you: pending migrations run on the first boot, and you can apply new ones at any time by pressing **A** in the terminal UI.
+### During development
 
-To apply migrations explicitly, for example in production or an automated pipeline, start the server runtime with the `--apply-migrations` flag from your `server` package directory. Migrations are applied as part of the startup sequence and the framework asserts that each migration is only applied once to the database.
+`serverpod start` applies your migrations for you. With the `serverpod start` terminal focused:
+
+- Pending migrations are applied automatically on the first boot.
+- Press **A** to apply new migrations as you create them.
+
+### In production or CI
+
+To apply migrations explicitly, start the server runtime with the `--apply-migrations` flag from your `server` package directory. Migrations are applied as part of the startup sequence and the framework asserts that each migration is only applied once to the database.
 
 ```bash
 $ dart run bin/main.dart --apply-migrations


### PR DESCRIPTION
## Summary

Notes that `serverpod start` applies migrations during local development (on first boot, or by pressing **A** in the terminal UI). The explicit `--apply-migrations` runtime command stays documented for production and automated pipelines.

The remaining `dart run bin/main.dart` mentions are intentional: the `--role maintenance` and production invocations are runtime calls that `serverpod start` should not replace (it is a development tool and always applies migrations).

Part of #565
