### PR TITLE
docs: Update version references to 4.0

### DIFF
--- a/docs/04-get-started/01-installation.md
+++ b/docs/04-get-started/01-installation.md
@@ -24,7 +24,7 @@ $ flutter doctor
 Serverpod is installed using the Dart package manager. To install Serverpod, run the following command in your terminal:
 
 ```txt
-$ dart install serverpod_cli 4.0.0
+$ dart install serverpod_cli 4.0.0-beta.0
 ```
 
 This command will install the Serverpod command-line interface (CLI) globally on your machine. You can verify the installation by running:

--- a/docs/04-get-started/01-installation.md
+++ b/docs/04-get-started/01-installation.md
@@ -24,7 +24,7 @@ $ flutter doctor
 Serverpod is installed using the Dart package manager. To install Serverpod, run the following command in your terminal:
 
 ```txt
-$ dart install serverpod_cli 3.5.0-beta.9
+$ dart install serverpod_cli 4.0.0
 ```
 
 This command will install the Serverpod command-line interface (CLI) globally on your machine. You can verify the installation by running:

--- a/docs/06-concepts/11-authentication/01-get-started.md
+++ b/docs/06-concepts/11-authentication/01-get-started.md
@@ -12,7 +12,7 @@ This guide walks you through that, then shows how to test signing up and signing
 
 ## Prerequisites
 
-- A project created with `serverpod create` on Serverpod 3.5 or later. For older projects, see [Setup](./setup) first to add the auth module.
+- A project created with `serverpod create` on Serverpod 4.0 or later. For older projects, see [Setup](./setup) first to add the auth module.
 - The Flutter SDK installed, so you can run the app.
 - Docker installed and running, if your project uses a Docker Postgres. Projects on the embedded Postgres option don't need Docker.
 

--- a/docs/06-concepts/11-authentication/04-providers/07-github/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/07-github/01-setup.md
@@ -9,7 +9,7 @@ Before following this guide, make sure you have:
 - A GitHub account with access to [Developer Settings](https://github.com/settings/apps).
 - A running Serverpod project (server, client, and Flutter app packages from `serverpod create`).
 - The Serverpod auth module installed and configured per the [authentication setup](../../setup). If your project was generated with an older Serverpod version, follow that guide first to add `serverpod_auth_idp_server` and `serverpod_auth_idp_flutter` and to configure `pod.initializeAuthServices()` before continuing.
-- `serverpod_auth_idp_server` 4.0.0 or later (required for the web callback route).
+- `serverpod_auth_idp_server` 4.0.0-beta.0 or later (required for the web callback route).
 
 ## Get your GitHub credentials
 

--- a/docs/06-concepts/11-authentication/04-providers/07-github/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/07-github/01-setup.md
@@ -9,7 +9,7 @@ Before following this guide, make sure you have:
 - A GitHub account with access to [Developer Settings](https://github.com/settings/apps).
 - A running Serverpod project (server, client, and Flutter app packages from `serverpod create`).
 - The Serverpod auth module installed and configured per the [authentication setup](../../setup). If your project was generated with an older Serverpod version, follow that guide first to add `serverpod_auth_idp_server` and `serverpod_auth_idp_flutter` and to configure `pod.initializeAuthServices()` before continuing.
-- `serverpod_auth_idp_server` 3.5.0-beta.8 or later (required for the web callback route).
+- `serverpod_auth_idp_server` 4.0.0 or later (required for the web callback route).
 
 ## Get your GitHub credentials
 


### PR DESCRIPTION
## Summary

Updates the remaining Serverpod 3.5 version references in the current docs to 4.0:

- `serverpod_cli` install version in the installation guide.
- The auth get-started prerequisite (Serverpod 4.0 or later).
- The GitHub provider's `serverpod_auth_idp_server` minimum.

Part of #584
