### PR TITLE
fix: Correct import path for authUserId example

### DIFF
--- a/docs/06-concepts/11-authentication/03-working-with-users.md
+++ b/docs/06-concepts/11-authentication/03-working-with-users.md
@@ -8,7 +8,7 @@ All authenticated users have an authentication identifier, that uniquely identif
 
 ```dart
 var userIdString = session.authenticated?.userIdentifier;
-// requires `import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart';`
+// requires `import 'package:serverpod_auth_idp_server/core.dart';`
 var userIdUuidValue = session.authenticated?.authUserId;
 ```
 

--- a/versioned_docs/version-3.0.0/06-concepts/11-authentication/03-working-with-users.md
+++ b/versioned_docs/version-3.0.0/06-concepts/11-authentication/03-working-with-users.md
@@ -8,7 +8,7 @@ All authenticated users have an authentication identifier, that uniquely identif
 
 ```dart
 var userIdString = session.authenticated?.userIdentifier;
-// requires `import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart';`
+// requires `import 'package:serverpod_auth_idp_server/core.dart';`
 var userIdUuidValue = session.authenticated?.authUserId;
 ```
 

--- a/versioned_docs/version-3.1.0/06-concepts/11-authentication/03-working-with-users.md
+++ b/versioned_docs/version-3.1.0/06-concepts/11-authentication/03-working-with-users.md
@@ -8,7 +8,7 @@ All authenticated users have an authentication identifier, that uniquely identif
 
 ```dart
 var userIdString = session.authenticated?.userIdentifier;
-// requires `import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart';`
+// requires `import 'package:serverpod_auth_idp_server/core.dart';`
 var userIdUuidValue = session.authenticated?.authUserId;
 ```
 

--- a/versioned_docs/version-3.2.0/06-concepts/11-authentication/03-working-with-users.md
+++ b/versioned_docs/version-3.2.0/06-concepts/11-authentication/03-working-with-users.md
@@ -8,7 +8,7 @@ All authenticated users have an authentication identifier, that uniquely identif
 
 ```dart
 var userIdString = session.authenticated?.userIdentifier;
-// requires `import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart';`
+// requires `import 'package:serverpod_auth_idp_server/core.dart';`
 var userIdUuidValue = session.authenticated?.authUserId;
 ```
 

--- a/versioned_docs/version-3.3.0/06-concepts/11-authentication/03-working-with-users.md
+++ b/versioned_docs/version-3.3.0/06-concepts/11-authentication/03-working-with-users.md
@@ -8,7 +8,7 @@ All authenticated users have an authentication identifier, that uniquely identif
 
 ```dart
 var userIdString = session.authenticated?.userIdentifier;
-// requires `import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart';`
+// requires `import 'package:serverpod_auth_idp_server/core.dart';`
 var userIdUuidValue = session.authenticated?.authUserId;
 ```
 

--- a/versioned_docs/version-3.4.0/06-concepts/11-authentication/03-working-with-users.md
+++ b/versioned_docs/version-3.4.0/06-concepts/11-authentication/03-working-with-users.md
@@ -8,7 +8,7 @@ All authenticated users have an authentication identifier, that uniquely identif
 
 ```dart
 var userIdString = session.authenticated?.userIdentifier;
-// requires `import 'package:serverpod_auth_idp_server/serverpod_auth_idp_server.dart';`
+// requires `import 'package:serverpod_auth_idp_server/core.dart';`
 var userIdUuidValue = session.authenticated?.authUserId;
 ```
 


### PR DESCRIPTION
## Summary

Fixes an incorrect import comment in the auth page "Working with users".
Applied across all affected versions: current docs, 3.4.0, 3.3.0, 3.2.0, 3.1.0, and 3.0.0.

Closes #384. Credit to @xM1haix for identifying the issue.