### PR TITLE
docs(cloud): Add Recover from a failed deploy guide

### DIFF
--- a/cloud_docs/02-concepts/01-deployments.md
+++ b/cloud_docs/02-concepts/01-deployments.md
@@ -155,6 +155,8 @@ Common causes are missing dependencies in `pubspec.yaml` or compile errors in yo
 
 **Package resolution failure.** Update your `pubspec.yaml` (run `dart pub get` locally to verify), then redeploy.
 
+For a step-by-step walkthrough, see [Recover from a failed deploy](/cloud/guides/recover-from-a-failed-deploy).
+
 ## Related
 
 - [Deployment hooks](/cloud/concepts/deployment-hooks) for pre- and post-deploy automation.

--- a/cloud_docs/02-concepts/02-logs.md
+++ b/cloud_docs/02-concepts/02-logs.md
@@ -41,6 +41,8 @@ scloud deployment build-log > build-log.txt
 scloud deployment build-log | grep ERROR
 ```
 
+For a step-by-step walkthrough of diagnosing and recovering from a failed deploy, see [Recover from a failed deploy](/cloud/guides/recover-from-a-failed-deploy).
+
 ## View runtime logs
 
 Runtime logs are the live output of your deployed service. Each entry contains:

--- a/cloud_docs/02-concepts/02-logs.md
+++ b/cloud_docs/02-concepts/02-logs.md
@@ -47,8 +47,7 @@ Runtime logs are the live output of your deployed service. Each entry contains:
 
 - **Timestamp**: local time by default, UTC with `--utc`
 - **Level**: `INFO`, `ERROR`, and so on
-- **Origin service**: `API`, `insights`, or `web`
-- **Message body**
+- **Content**: the log message body
 
 Fetch the most recent records:
 
@@ -123,10 +122,10 @@ Press `Ctrl+C` to stop. `--tail` cannot be combined with `--since` or `--until`.
 
 ## Configure session logging
 
-Two environment variables control how each request's session logs are handled. By default:
+Two environment variables control session logging. With a database enabled (the typical Cloud configuration), the defaults are:
 
-- `SERVERPOD_SESSION_CONSOLE_LOG_ENABLED` defaults to `true`. Session logs print to the runtime console.
-- `SERVERPOD_SESSION_PERSISTENT_LOG_ENABLED` defaults to `false`. Session logs are not written to the database for later inspection.
+- `SERVERPOD_SESSION_PERSISTENT_LOG_ENABLED` defaults to `true`. Session logs are written to the database and visible in Insights.
+- `SERVERPOD_SESSION_CONSOLE_LOG_ENABLED` defaults to `false`. Session logs are not printed to the runtime console and don't appear in `scloud log` output. Set it to `true` to enable both.
 
 To change either default, set the value with `scloud variable set`. See [Passwords, secrets, and environment variables](/cloud/concepts/passwords-secrets-env-vars) for variable management.
 

--- a/cloud_docs/02-concepts/03-passwords-secrets-env-vars.md
+++ b/cloud_docs/02-concepts/03-passwords-secrets-env-vars.md
@@ -39,7 +39,7 @@ scloud password set myApiKey "your_secret_value"
 Read the value in code:
 
 ```dart
-final apiKey = await session.serverpod.getPassword('myApiKey');
+final apiKey = session.serverpod.getPassword('myApiKey');
 ```
 
 Pass `--from-file` when the value is long, multi-line, or shouldn't appear in shell history:

--- a/cloud_docs/02-concepts/04-custom-domains.md
+++ b/cloud_docs/02-concepts/04-custom-domains.md
@@ -69,7 +69,7 @@ Complete the setup by adding the records to your DNS configuration
 
 ## Verify the domain
 
-DNS changes typically propagate within a few minutes but can take up to 48 hours. Once propagation completes, Serverpod Cloud verifies the domain automatically.
+DNS changes typically propagate within a few minutes but can take up to 24 hours. Once propagation completes, Serverpod Cloud verifies the domain automatically.
 
 To force a verification attempt without waiting:
 
@@ -103,7 +103,7 @@ scloud domain detach example.com
 
 ## Troubleshooting
 
-**Verification fails.** DNS records may be missing or still propagating. Confirm the records are in place at your registrar, then wait up to 48 hours and retry with `scloud domain verify <domain>`.
+**Verification fails.** DNS records may be missing or still propagating. Confirm the records are in place at your registrar, then wait up to 24 hours and retry with `scloud domain verify <domain>`.
 
 **Can't attach the domain.** The domain is already attached to another project. Detach it from that project first.
 

--- a/cloud_docs/02-concepts/05-database.md
+++ b/cloud_docs/02-concepts/05-database.md
@@ -39,7 +39,7 @@ Your server reads these through Serverpod's standard configuration. You don't wr
 
 When Cloud deploys your server, the container starts with `--apply-migrations`. Any pending migrations in your project's `migrations/` directory are applied before the server begins serving requests.
 
-If a migration fails to apply, the server fails to start and the deployment is reported as failed. Fix the migration in your project and redeploy.
+If a migration fails to apply, the server fails to start and the deployment is reported as failed. Fix the migration in your project and redeploy. For a step-by-step walkthrough, see [Recover from a failed deploy](/cloud/guides/recover-from-a-failed-deploy).
 
 To undo a migration that already applied successfully, create a repair migration with `serverpod create-repair-migration` targeting the version you want to roll back to, then redeploy. Cloud applies the repair on the next deploy. Only the schema is rolled back; data is not. See the framework's [Migrations](/concepts/database/migrations#rolling-back-migrations) guide for details.
 

--- a/cloud_docs/02-concepts/05-database.md
+++ b/cloud_docs/02-concepts/05-database.md
@@ -41,7 +41,7 @@ When Cloud deploys your server, the container starts with `--apply-migrations`. 
 
 If a migration fails to apply, the server fails to start and the deployment is reported as failed. Fix the migration in your project and redeploy.
 
-To undo a migration that already applied successfully, write a new migration that reverses the change and deploy. Serverpod's migration system rolls forward, not backward.
+To undo a migration that already applied successfully, create a repair migration with `serverpod create-repair-migration` targeting the version you want to roll back to, then redeploy. Cloud applies the repair on the next deploy. Only the schema is rolled back; data is not. See the framework's [Migrations](/concepts/database/migrations#rolling-back-migrations) guide for details.
 
 ## Backups
 

--- a/cloud_docs/02-guides/08-recover-from-a-failed-deploy.md
+++ b/cloud_docs/02-guides/08-recover-from-a-failed-deploy.md
@@ -1,0 +1,97 @@
+---
+sidebar_label: Recover from a failed deploy
+description: Diagnose why your scloud deploy failed, read the build log, identify the failure type, and ship a fix to recover without disrupting any running version.
+---
+
+# Recover from a failed deploy
+
+Your `scloud deploy` just failed. This guide walks you through finding what broke and shipping a fix. A failed deploy doesn't disrupt a running version; Cloud only switches traffic to a successful deploy, so if a previous version was live, it stays live.
+
+## Before you start
+
+- The `scloud` CLI installed and authenticated. See [Install scloud](/cloud/getting-started/installation).
+- A Serverpod Cloud project with at least one deploy attempt.
+- Run the commands below from your server directory (so `scloud.yaml` is auto-detected), or pass `-p <project-id>` from anywhere else.
+
+## Confirm the deploy failed
+
+List recent deployments to see status:
+
+```bash
+scloud deployment list
+```
+
+A failed deploy shows `FAILURE` in the Status column and a short reason in the Info column:
+
+```text
+# | Project | Deploy Id                            | Status  | Started             | Finished            | Info
+--+---------+--------------------------------------+---------+---------------------+---------------------+-----------------------------------
+0 | my-app  | 73e66b41-64fc-4920-b6ef-4918cc6ceca1 | FAILURE | 2026-06-15 15:19:37 | 2026-06-15 15:20:34 | User build FAILURE - see build log
+```
+
+The Info column points at which lifecycle stage failed: Upload, Cloud build, Infra deploy, or Service rollout.
+
+## Read the build log
+
+Build logs are the only surface for build-time errors. Fetch the latest:
+
+```bash
+scloud deployment build-log
+```
+
+For a specific deploy, pass a sequence number (`0` is the latest) or the deploy UUID from `scloud deployment list`:
+
+```bash
+scloud deployment build-log 3
+scloud deployment build-log 73e66b41-64fc-4920-b6ef-4918cc6ceca1
+```
+
+For long logs, redirect to a file or grep for errors:
+
+```bash
+scloud deployment build-log > build-log.txt
+scloud deployment build-log | grep ERROR
+```
+
+## Identify the failure type
+
+Most failed deploys fall into one of these patterns. Match the log output to the closest one.
+
+**Pre-deploy hook failure.** A script in your `scloud.yaml` under `project.scripts.pre_deploy` exited non-zero, so the upload never happened. Run the failing command locally to reproduce, fix the script, commit, and redeploy. See [Deployment hooks](/cloud/concepts/deployment-hooks) for the failure semantics.
+
+**Upload timeout.** The CLI reports `Send Timeout. Please check your internet connection and try again.` The project never reached Cloud, so nothing was built. Common on first deploys with large project packages or slow connections. Retry with a longer timeout:
+
+```bash
+scloud deploy --timeout 120s
+```
+
+If the timeout keeps tripping at high values, the issue is likely upstream (network or Cloud-side); retry later.
+
+**Package resolution failure.** Cloud can't resolve your `pubspec.yaml`. Run `dart pub get` locally to reproduce the error, fix the pubspec (mismatched versions, missing packages, private dependencies that aren't configured), and redeploy. For private packages, see [Handling private dependencies](/cloud/reference/deployment/handling-private-dependencies).
+
+**Build failure.** Lines beginning with `ERROR:` or `FAILED:` in the build log, usually pointing at a Dart compile error, a missing import, or a missing dependency. Fix the file in your project, commit, and redeploy.
+
+**Migration failure.** The build succeeds but the server fails to start because a migration in your project's `migrations/` directory can't apply. The deploy is marked failed. Fix the migration locally (often a SQL error or a column that already exists), commit, and redeploy.
+
+## Fix and redeploy
+
+Commit the fix and redeploy:
+
+```bash
+scloud deploy
+```
+
+Watch the new attempt:
+
+```bash
+scloud deployment show
+```
+
+When **Service rollout** reports success, Cloud switches traffic to the new version.
+
+## Related
+
+- [Deployments](/cloud/concepts/deployments) for the deploy lifecycle and `scloud deploy --dry-run` to validate before shipping.
+- [Logs](/cloud/concepts/logs) for the build-log and runtime-log surfaces.
+- [Deployment hooks](/cloud/concepts/deployment-hooks) for pre- and post-deploy hook failure semantics.
+- [Database](/cloud/concepts/database) for the migration model and how to reverse a schema change.


### PR DESCRIPTION
## Summary

This branch ships two related changes as separate commits.

**Commit 1: `docs(cloud): Fix factual drift across four Cloud concept pages`** (`185ea77`). A focused audit of the concept pages introduced in #580 / #581 / #592 against the latest `serverpod_cloud` (v0.31.0) and `serverpod` (upstream main) source surfaced six refuted claims, corrected here:

**Commit 2: `docs(cloud): Add Recover from a failed deploy guide`** (`c4e7d7c`). New guide at `cloud_docs/02-guides/08-recover-from-a-failed-deploy.md` for the Builder whose `scloud deploy` just failed and needs to find what broke and ship a fix:

Three cross-doc pointers added from the Deployments, Logs, and Database concept pages to the new guide.

## Test plan

- [ ] `npm run build` passes locally
- [ ] Navigate from Deployments / Logs / Database concept pages to the new guide via the inline pointers
- [ ] Confirm the new guide's anchor links resolve: Install scloud, Deployments, Handling private dependencies, Deployment hooks, Logs, Database
- [ ] Confirm the Database concept's framework-side link to `/concepts/database/migrations#rolling-back-migrations` lands on the Rolling back migrations section