### PR TITLE
docs(cloud): Fill empty and short CLI command intros + 'scloud <command>' titles

### DIFF
--- a/cloud_docs/reference/cli/commands/auth/_auth.md
+++ b/cloud_docs/reference/cli/commands/auth/_auth.md
@@ -1,4 +1,4 @@
-# `auth`
+# scloud auth
 
 Handle user authentication.
 

--- a/cloud_docs/reference/cli/commands/completion/_completion.md
+++ b/cloud_docs/reference/cli/commands/completion/_completion.md
@@ -1,4 +1,4 @@
-# Command line completion
+# scloud completion
 
 As an `scloud` user, you can enable command line completion in most shells.
 

--- a/cloud_docs/reference/cli/commands/db/_db.md
+++ b/cloud_docs/reference/cli/commands/db/_db.md
@@ -1,4 +1,4 @@
-# `db`
+# scloud db
 
 `scloud db` provides commands for managing your Serverpod Cloud database for projects that have the database enabled.
 

--- a/cloud_docs/reference/cli/commands/deploy/_deploy.md
+++ b/cloud_docs/reference/cli/commands/deploy/_deploy.md
@@ -1,4 +1,4 @@
-# `deploy`
+# scloud deploy
 
 Deploys a Serverpod project to the cloud and can be run from the project's server directory or by specifying a path (`--project-dir`).
 

--- a/cloud_docs/reference/cli/commands/deployment/_deployment.md
+++ b/cloud_docs/reference/cli/commands/deployment/_deployment.md
@@ -1,0 +1,5 @@
+# `deployment`
+
+`scloud deployment` inspects existing deploys: list history, show status, view build logs. Use it after a deploy to confirm what shipped, watch one in progress, or debug a failure.
+
+For deploying new code, use [`scloud deploy`](/cloud/reference/cli/commands/deploy). For the deploy lifecycle and how to recover from a failed deploy, see [Deployments](/cloud/concepts/deployments) and [Recover from a failed deploy](/cloud/guides/recover-from-a-failed-deploy).

--- a/cloud_docs/reference/cli/commands/deployment/_deployment.md
+++ b/cloud_docs/reference/cli/commands/deployment/_deployment.md
@@ -1,4 +1,4 @@
-# `deployment`
+# scloud deployment
 
 `scloud deployment` inspects existing deploys: list history, show status, view build logs. Use it after a deploy to confirm what shipped, watch one in progress, or debug a failure.
 

--- a/cloud_docs/reference/cli/commands/domain/_domain.md
+++ b/cloud_docs/reference/cli/commands/domain/_domain.md
@@ -1,4 +1,4 @@
-# `domain`
+# scloud domain
 
 The `scloud domain` command offers custom domain management for your Serverpod Cloud projects.
 

--- a/cloud_docs/reference/cli/commands/help/_help.md
+++ b/cloud_docs/reference/cli/commands/help/_help.md
@@ -1,4 +1,4 @@
-# `help`
+# scloud help
 
 `scloud help` lists every available command with a short description. Run `scloud help <command>` to drill into one command's arguments and examples; every command also accepts `--help` directly.
 

--- a/cloud_docs/reference/cli/commands/help/_help.md
+++ b/cloud_docs/reference/cli/commands/help/_help.md
@@ -1,3 +1,5 @@
 # `help`
 
-Display help information for scloud.
+`scloud help` lists every available command with a short description. Run `scloud help <command>` to drill into one command's arguments and examples; every command also accepts `--help` directly.
+
+For options that apply to every command, see [Global options](/cloud/reference/cli/global_options).

--- a/cloud_docs/reference/cli/commands/launch/_launch.md
+++ b/cloud_docs/reference/cli/commands/launch/_launch.md
@@ -1,4 +1,4 @@
-# `launch`
+# scloud launch
 
 An interactive, guided setup of a new Serverpod Cloud project.
 

--- a/cloud_docs/reference/cli/commands/launch/_launch.md
+++ b/cloud_docs/reference/cli/commands/launch/_launch.md
@@ -1,8 +1,8 @@
 # `launch`
 
-An interactive, guided set up of a new Serverpod Cloud project.
+An interactive, guided setup of a new Serverpod Cloud project.
 
-Promts for the needed settings.
+Prompts for the needed settings.
 (The settings can also be specified on the command line.)
 
 The user will be asked for confirmation before performing any work.

--- a/cloud_docs/reference/cli/commands/log/_log.md
+++ b/cloud_docs/reference/cli/commands/log/_log.md
@@ -1,4 +1,4 @@
-# `log`
+# scloud log
 
 The `scloud log` command provides a way to retrieve logs for your live service.
 

--- a/cloud_docs/reference/cli/commands/me/_me.md
+++ b/cloud_docs/reference/cli/commands/me/_me.md
@@ -1,4 +1,4 @@
-# `me`
+# scloud me
 
 `scloud me` prints the user currently logged in to the CLI. Use it to confirm which account you're authenticated as before running a privileged command, or when sharing context with support.
 

--- a/cloud_docs/reference/cli/commands/me/_me.md
+++ b/cloud_docs/reference/cli/commands/me/_me.md
@@ -1,0 +1,5 @@
+# `me`
+
+`scloud me` prints the user currently logged in to the CLI. Use it to confirm which account you're authenticated as before running a privileged command, or when sharing context with support.
+
+If the CLI isn't authenticated, the command exits with an error. Log in with [`scloud auth login`](/cloud/reference/cli/commands/auth).

--- a/cloud_docs/reference/cli/commands/password/_password.md
+++ b/cloud_docs/reference/cli/commands/password/_password.md
@@ -1,4 +1,4 @@
-# `password`
+# scloud password
 
 ## Summary
 

--- a/cloud_docs/reference/cli/commands/password/_password.md
+++ b/cloud_docs/reference/cli/commands/password/_password.md
@@ -41,7 +41,7 @@ scloud password unset database
 ```
 
 :::note
-If you need to set a secret without the `SERVERPOD_PASSWORD_` prefix, you can do so by using the [`secret create`](/cloud/reference/cli/commands/secret) command.
+If you need to set a secret without the `SERVERPOD_PASSWORD_` prefix, you can do so by using the [`secret set`](/cloud/reference/cli/commands/secret) command.
 :::
 
 ## Related commands

--- a/cloud_docs/reference/cli/commands/project/_project.md
+++ b/cloud_docs/reference/cli/commands/project/_project.md
@@ -1,4 +1,4 @@
-# `project`
+# scloud project
 
 `scloud project` provides commands for managing your Serverpod Cloud projects.
 

--- a/cloud_docs/reference/cli/commands/project/_project.md
+++ b/cloud_docs/reference/cli/commands/project/_project.md
@@ -8,7 +8,7 @@ A project is created by running the following command:
 scloud project create my-project --enable-db
 ```
 
-If the project does not need a databse (e.g. if it is a [Serverpod Mini project](https://docs.serverpod.dev/get-started-with-mini)), the `--no-enable-db` flag can instead be passed.
+If the project does not need a database (e.g. if it is a [Serverpod Mini project](https://docs.serverpod.dev/get-started-with-mini)), the `--no-enable-db` flag can instead be passed.
 
 See the [`deploy` command](./deploy) on how to deploy your project.
 

--- a/cloud_docs/reference/cli/commands/secret/_secret.md
+++ b/cloud_docs/reference/cli/commands/secret/_secret.md
@@ -1,9 +1,5 @@
 # `secret`
 
-The `scloud secret` command provides management of secrets for your project.
+`scloud secret` stores sensitive values that your server reads from `Platform.environment` (rather than through Serverpod's `getPassword()` API). Secrets are encrypted at rest and injected as environment variables under names you choose.
 
-To add a secret, use the `create` command:
-
-```bash
-scloud secret create MY_SECRET secretvalue
-```
+For values you read through Serverpod's API, use [`scloud password`](/cloud/reference/cli/commands/password). For non-sensitive config, use [`scloud variable`](/cloud/reference/cli/commands/variable). See [Passwords, secrets, and environment variables](/cloud/concepts/passwords-secrets-env-vars) for when to use which.

--- a/cloud_docs/reference/cli/commands/secret/_secret.md
+++ b/cloud_docs/reference/cli/commands/secret/_secret.md
@@ -1,4 +1,4 @@
-# `secret`
+# scloud secret
 
 `scloud secret` stores sensitive values that your server reads from `Platform.environment` (rather than through Serverpod's `getPassword()` API). Secrets are encrypted at rest and injected as environment variables under names you choose.
 

--- a/cloud_docs/reference/cli/commands/settings/_settings.md
+++ b/cloud_docs/reference/cli/commands/settings/_settings.md
@@ -1,16 +1,3 @@
 # `settings`
 
-The `scloud settings` command provides management of your local `scloud` CLI settings.
-
-To view your current settings just run it without options:
-
-```bash
-scloud settings
-```
-
-To change the analytics setting, run one of the following:
-
-```bash
-scloud settings --analytics
-scloud settings --no-analytics
-```
+`scloud settings` manages local CLI preferences stored on your machine. The settings persist across commands and only affect this CLI installation; they don't change anything about your Cloud projects. The current setting toggles whether the CLI sends analytics.

--- a/cloud_docs/reference/cli/commands/settings/_settings.md
+++ b/cloud_docs/reference/cli/commands/settings/_settings.md
@@ -1,3 +1,3 @@
-# `settings`
+# scloud settings
 
 `scloud settings` manages local CLI preferences stored on your machine. The settings persist across commands and only affect this CLI installation; they don't change anything about your Cloud projects. The current setting toggles whether the CLI sends analytics.

--- a/cloud_docs/reference/cli/commands/variable/_variable.md
+++ b/cloud_docs/reference/cli/commands/variable/_variable.md
@@ -2,10 +2,10 @@
 
 The `scloud variable` command provides management of environment variables for your Serverpod Cloud projects.
 
-To add an environment variable, use the `create` command:
+To add an environment variable, use the `set` command:
 
 ```bash
-scloud variable create MY_VAR myvalue
+scloud variable set MY_VAR myvalue
 ```
 
 :::note

--- a/cloud_docs/reference/cli/commands/variable/_variable.md
+++ b/cloud_docs/reference/cli/commands/variable/_variable.md
@@ -1,4 +1,4 @@
-# `variable`
+# scloud variable
 
 The `scloud variable` command provides management of environment variables for your Serverpod Cloud projects.
 

--- a/cloud_docs/reference/cli/commands/version/_version.md
+++ b/cloud_docs/reference/cli/commands/version/_version.md
@@ -1,3 +1,5 @@
 # `version`
 
-Prints the version of the Serverpod Cloud CLI.
+`scloud version` prints the version of the Serverpod Cloud CLI you have installed. Include the version when reporting a bug or asking for help, so the response can target your build.
+
+To update to the latest version, see [Install scloud](/cloud/getting-started/installation).

--- a/cloud_docs/reference/cli/commands/version/_version.md
+++ b/cloud_docs/reference/cli/commands/version/_version.md
@@ -1,4 +1,4 @@
-# `version`
+# scloud version
 
 `scloud version` prints the version of the Serverpod Cloud CLI you have installed. Include the version when reporting a bug or asking for help, so the response can target your build.
 


### PR DESCRIPTION
Stacked on top of #606 (Recover from a failed deploy guide).

## Summary

Two commits land together:

**Commit 1: `docs(cloud): Fill empty and short CLI command intros`.** Six previously empty or stub intros are now meta-shaped (lead + cross-links): `deployment`, `me`, `help`, `version`, `secret`, `settings`. Style anchor: the auto-generated CLI help renders below each intro, so the intro stays terse — positioning + routing to the concept pages where the model lives. Plus four sweep-on-touch corrections:

- `_password.md` had `secret create` → fixed to `secret set` (the actual subcommand).
- `_project.md:11` "databse" → "database".
- `_launch.md` "Promts" → "Prompts" and "set up" (noun) → "setup".
- `_variable.md` `scloud variable create MY_VAR myvalue` → `scloud variable set MY_VAR myvalue` (same `set` is the actual subcommand, not `create`).

**Commit 2: `docs(cloud): Use 'scloud <command>' as the H1 across all CLI command pages`.** Replaces \`\` # \`<command>\` \`\` (which renders as a code-chip in the page title) with `# scloud <command>` (which reads as a normal heading). Applied across all 16 command intro pages for consistency.

## Out of scope (for PR 12)

The older detailed intros (`auth`, `password`, `project`, `db`, `domain`, `log`, `variable`, etc.) have content that either duplicates the auto-gen below or covers ground already on the concept pages. Cleaning those up to match the new terse pattern is PR 12's job — including the same code-chip rendering issue on sub-headings like \`\` ## \`auth login\` \`\`.

## Test plan

- [ ] \`npm run build\` passes locally
- [ ] Render each of the six new intros and confirm the cross-doc links resolve
- [ ] Confirm the new \`# scloud <command>\` H1 renders as plain heading text, not a code chip