### PR TITLE
docs(cloud): Trim onboarding bullet from Recover guide prereqs

### DIFF
--- a/cloud_docs/02-guides/08-recover-from-a-failed-deploy.md
+++ b/cloud_docs/02-guides/08-recover-from-a-failed-deploy.md
@@ -11,7 +11,6 @@ Your `scloud deploy` just failed. This guide walks you through finding what brok
 
 - The `scloud` CLI installed and authenticated. See [Install scloud](/cloud/getting-started/installation).
 - A Serverpod Cloud project with at least one deploy attempt.
-- Run the commands below from your server directory (so `scloud.yaml` is auto-detected), or pass `-p <project-id>` from anywhere else.
 
 ## Confirm the deploy failed
 


### PR DESCRIPTION
Drops the "Run the commands below from your server directory..." bullet from the *Before you start* prereq list of the Recover from a failed deploy guide.

## Test plan

- [ ] `npm run build` passes
- [ ] Render the guide and confirm the prereq list reads cleanly with two bullets