### PR TITLE
docs(cloud): Consistency pass on the remaining CLI command intros

### DIFF
--- a/cloud_docs/02-concepts/03-passwords-secrets-env-vars.md
+++ b/cloud_docs/02-concepts/03-passwords-secrets-env-vars.md
@@ -24,7 +24,7 @@ All three commands follow the same shape:
 
 ## Manage passwords
 
-Passwords are the default tier for sensitive values the server reads through the Serverpod API. They are encrypted at rest, never shown after they're set, and accessed in code by the name you gave them. Each password is stored under a `SERVERPOD_PASSWORD_` prefix that the CLI adds on `set` and that `getPassword()` strips on read, so the name in your code stays clean.
+Passwords are the default tier for sensitive values the server reads through the Serverpod API. They are encrypted at rest, never shown after they're set, and accessed in code by the name you gave them. Each password is stored under a `SERVERPOD_PASSWORD_` prefix that the CLI adds on `set` and that `getPassword()` strips on read, so the name in your code stays clean. Common cases include database passwords, JWT signing secrets, third-party API keys, and email service credentials.
 
 Serverpod Cloud also provisions a set of platform-managed passwords automatically: database credentials, Insights tokens, `serverpod_auth_idp_server` keys, and keys for the legacy auth module. `scloud password list` groups them into four categories: **Custom** (passwords you add), **Services** (database, Insights, and related platform passwords), **Auth** (passwords for `serverpod_auth_idp_server`), and **Legacy Auth** (passwords for the legacy authentication module). The Status column marks platform-managed passwords `AUTO (Platform)` and user-set ones `SET (User)`.
 

--- a/cloud_docs/02-guides/05-redis.md
+++ b/cloud_docs/02-guides/05-redis.md
@@ -13,7 +13,6 @@ Serverpod uses Redis for **distributed caching** and **PubSub** when running acr
 
 - Completed the **Installation** steps (`scloud` installed and authenticated).
 - A Serverpod Cloud project already deployed (or ready to deploy).
-- Linked your project (run from your server directory, or use `-p your-project-id`).
 
 ## Create a Redis database on Upstash
 
@@ -40,13 +39,13 @@ Use the exact password from the Upstash database page.
 
 ## Set Redis connection variables
 
-Configure host, port, enable Redis, and require SSL using environment variables. From your server project directory (or with `-p your-project-id`):
+Configure host, port, enable Redis, and require SSL using environment variables:
 
 ```bash
-scloud variable create SERVERPOD_REDIS_HOST "YOUR_UPSTASH_ENDPOINT"
-scloud variable create SERVERPOD_REDIS_PORT "YOUR_UPSTASH_PORT"
-scloud variable create SERVERPOD_REDIS_ENABLED "true"
-scloud variable create SERVERPOD_REDIS_REQUIRE_SSL "true"
+scloud variable set SERVERPOD_REDIS_HOST "YOUR_UPSTASH_ENDPOINT"
+scloud variable set SERVERPOD_REDIS_PORT "YOUR_UPSTASH_PORT"
+scloud variable set SERVERPOD_REDIS_ENABLED "true"
+scloud variable set SERVERPOD_REDIS_REQUIRE_SSL "true"
 ```
 
 Replace `YOUR_UPSTASH_ENDPOINT` with the Upstash endpoint (host only, no `rediss://` or port). Replace `YOUR_UPSTASH_PORT` with the port number as a string (most likely `6380` for Upstash).
@@ -56,7 +55,7 @@ Replace `YOUR_UPSTASH_ENDPOINT` with the Upstash endpoint (host only, no `rediss
 If your Redis provider uses a username (e.g. ACL), you can set:
 
 ```bash
-scloud variable create SERVERPOD_REDIS_USER "default"
+scloud variable set SERVERPOD_REDIS_USER "default"
 ```
 
 :::

--- a/cloud_docs/reference/cli/commands/auth/_auth.md
+++ b/cloud_docs/reference/cli/commands/auth/_auth.md
@@ -1,22 +1,12 @@
 # scloud auth
 
-Handle user authentication.
+`scloud auth` manages your login session: log in to Serverpod Cloud, log out, and revoke other sessions or tokens. Most `scloud` commands authenticate against the cloud API, so you need to be logged in (or pass a token) to do anything that touches your projects.
 
-See also the [Personal access tokens](/cloud/concepts/personal-access-tokens)
-concept page on how to prepare and use personal access tokens for CI pipelines,
-scripts, or headless environments where you cannot run `scloud auth login`.
-
-## `auth login`
-
-Log in to Serverpod Cloud. Most `scloud` commands requires the CLI to be authenticated.
-
-## `auth logout`
-
-Log out from Serverpod Cloud and remove stored credentials.
+For long-lived authentication (CI pipelines, scripts), see [Personal access tokens](/cloud/concepts/personal-access-tokens), which covers token creation, the `SERVERPOD_CLOUD_TOKEN` environment variable, and the `--token` flag.
 
 ## Credentials storage
 
-After running `auth login`, your authentication token is stored locally at:
+After running `scloud auth login`, your authentication token is stored locally at:
 
 ```text
 ~/.serverpod/cloud/serverpod_cloud_auth.json
@@ -28,23 +18,4 @@ This file contains a JSON object with your token:
 {"token": "your-token-here"}
 ```
 
-## Using the token
-
-### Environment variable
-
-You can set the `SERVERPOD_CLOUD_TOKEN` environment variable to authenticate without logging in:
-
-```bash
-export SERVERPOD_CLOUD_TOKEN="your-token-here"
-scloud me 
-```
-
-### Command-line flag
-
-Alternatively, use the `--token` flag with any command:
-
-```bash
-scloud --token="your-token-here" me
-```
-
-This is useful for CI/CD pipelines and automated scripts.
+Delete the file (or run `scloud auth logout`) to clear stored credentials.

--- a/cloud_docs/reference/cli/commands/completion/_completion.md
+++ b/cloud_docs/reference/cli/commands/completion/_completion.md
@@ -2,15 +2,11 @@
 
 As an `scloud` user, you can enable command line completion in most shells.
 
-Two completion tools are supported, _completely_ and _carapace_.
+Two completion tools are supported: Completely and Carapace.
 
-Completely is easier to set up for the end user, but only has direct support
-for bash and zsh.
-See also: https://github.com/bashly-framework/completely
+Completely is easier to set up for the end user, but only has direct support for bash and zsh. See [Completely on GitHub](https://github.com/bashly-framework/completely).
 
-Carapace supports nearly all shells but requires the end user to install
-the carapace tool.
-See also: https://carapace.sh/
+Carapace supports nearly all shells but requires the end user to install the Carapace tool. See the [Carapace docs](https://carapace.sh/).
 
 ## Installing completion
 
@@ -58,22 +54,19 @@ source ~/.local/share/bash-completion/completions/scloud.bash
 
 ### Nearly all shells with Carapace
 
-Carapace supports nearly all shells but requires the end user to install
-the carapace tool.
-See also: https://carapace.sh/
+Carapace supports nearly all shells but requires the end user to install the Carapace tool. See the [Carapace docs](https://carapace.sh/).
 
 #### Prerequisites
 
-To install `carapace` on macOS:
+To install Carapace on macOS:
 
 ```sh
 brew install carapace
 ```
 
-For installing in other environments, see:
-https://carapace-sh.github.io/carapace-bin/install.html
+For other environments, see the [Carapace install guide](https://carapace-sh.github.io/carapace-bin/install.html).
 
-#### Enable carapace completion for scloud
+#### Enable Carapace completion for scloud
 
 Run the following once for the current shell,
 or add to your shell startup script:
@@ -91,5 +84,4 @@ zstyle ':completion:*' format $'\e[2;37mCompleting %d\e[m'
 source <(carapace scloud)
 ```
 
-For more information and installing in other shells, see:
-https://carapace-sh.github.io/carapace-bin/setup.html
+For other shells, see the [Carapace setup guide](https://carapace-sh.github.io/carapace-bin/setup.html).

--- a/cloud_docs/reference/cli/commands/db/_db.md
+++ b/cloud_docs/reference/cli/commands/db/_db.md
@@ -1,30 +1,5 @@
 # scloud db
 
-`scloud db` provides commands for managing your Serverpod Cloud database for projects that have the database enabled.
+`scloud db` manages your project's database directly: print connection details, create and reset superusers for `psql` or GUI clients, and wipe the database during development. These operations are independent of how your server connects (the server's credentials are injected by Cloud separately).
 
-
-### Get DB connection details
-
-To get the connection details for connecting directly to the database, run the the `db connection` subcommand:
-
-```bash
-scloud db connection
-```
-
-### Create a new superuser
-
-To create a new superuser for directly accessing the database, run the the `db user create` subcommand:
-
-```bash
-scloud db user create my_new_username
-```
-
-**Save the printed password in you password manager.** It cannot be retrieved again.
-
-### Reset a DB user password
-
-To reset the password for a database user, run the the `db user reset-password` subcommand:
-
-```bash
-scloud db user reset-password my_new_username
-```
+See [Database](/cloud/concepts/database) for the model, common operations, and security notes around direct access.

--- a/cloud_docs/reference/cli/commands/deploy/_deploy.md
+++ b/cloud_docs/reference/cli/commands/deploy/_deploy.md
@@ -1,9 +1,7 @@
 # scloud deploy
 
-Deploys a Serverpod project to the cloud and can be run from the project's server directory or by specifying a path (`--project-dir`).
+`scloud deploy` packages your project, uploads it to Serverpod Cloud, and waits for the new version to go live. Run it from the directory containing `scloud.yaml` (typically your project root or server directory) or pass `--project-dir`.
 
-To follow the progress of a deployment, use the [`deployment show` command](./deployment):
+To preview what will be uploaded without deploying, use `scloud deploy --dry-run` (optionally with `--show-files`). To follow an in-flight deploy, run `scloud deployment show`.
 
-```bash
-scloud deployment show
-```
+For the full deploy lifecycle, pre-deploy hooks, and how to recover from a failed deploy, see [Deployments](/cloud/concepts/deployments) and [Recover from a failed deploy](/cloud/guides/recover-from-a-failed-deploy).

--- a/cloud_docs/reference/cli/commands/domain/_domain.md
+++ b/cloud_docs/reference/cli/commands/domain/_domain.md
@@ -1,32 +1,5 @@
 # scloud domain
 
-The `scloud domain` command offers custom domain management for your Serverpod Cloud projects.
+`scloud domain` attaches a custom domain to one of your project's surfaces (`web`, `api`, or `insights`), prints the DNS records to add at your registrar, and tracks verification + TLS provisioning.
 
-To attach a custom domain to [your linked project](project), run the `scloud domain attach` command:
-
-```bash
-scloud domain attach www.mydomain.com --target web
-```
-
-The valid targets are:
-
-- `web`: Relic server (e.g. REST API or a Flutter web app)
-- `api`: Serverpod endpoints
-- `insights`: Serverpod insights
-
-To complete the setup, follow these steps:
-
-- Add a CNAME or ANAME record with the value of your domain (`www.mydomain.com` in the example above) to the DNS configuration for this domain.
-- Wait for the update to propagate. This can take up to a few hours.
-- Run the following command to verify the DNS record (Serverpod Cloud will also try to verify the record periodically):
-
-```bash
-scloud domain verify www.mydomain.com
-```
-
-- When verification succeeds, the custom domain will shortly become active.
-- Run the following command to check the status:
-
-```bash
-    scloud domain list
-```
+See [Custom domains](/cloud/concepts/custom-domains) for the attach flow, DNS record types for apex vs subdomain, propagation timing, and TLS details.

--- a/cloud_docs/reference/cli/commands/launch/_launch.md
+++ b/cloud_docs/reference/cli/commands/launch/_launch.md
@@ -1,12 +1,7 @@
 # scloud launch
 
-An interactive, guided setup of a new Serverpod Cloud project.
+`scloud launch` is the front door for new projects: it interactively creates a Serverpod Cloud project, links your local server to it, and deploys for the first time. The flow prompts for the project name, whether to enable a database, and confirms each step before performing it.
 
-Prompts for the needed settings.
-(The settings can also be specified on the command line.)
+Once your project is linked, you typically switch to `scloud deploy` for subsequent updates. For non-interactive project creation (no prompts), use `scloud project create` and pass the settings as flags.
 
-The user will be asked for confirmation before performing any work.
-
-```bash
-scloud launch
-```
+See [Deploy your first app](/cloud/getting-started/launch) for the full walkthrough.

--- a/cloud_docs/reference/cli/commands/log/_log.md
+++ b/cloud_docs/reference/cli/commands/log/_log.md
@@ -1,38 +1,5 @@
 # scloud log
 
-The `scloud log` command provides a way to retrieve logs for your live service.
+`scloud log` fetches the runtime logs from your deployed service. Use it to read recent activity, filter by time range (`--since` / `--until`), or stream new records as they arrive (`--tail`).
 
-Running the base command below fetches the most recent logs:
-
-```bash
-scloud log
-```
-
-To retrieve logs within specific time ranges, the `--until` and `--since` options can be used. Both options accept either ISO date strings (e.g., "2024-01-15T10:30:00Z") or duration strings (e.g., "5m", "3h", "1d"). See some examples below:
-
-```bash
-# Using ISO date strings
-scloud log --until=2024-12-01T00:00:00Z --since=2024-11-01T00:00:00Z
-scloud log --since=2024-11-01T00:00:00Z
-
-# Using duration strings
-scloud log --since=5m
-scloud log --since=1h --until=30m
-
-# Mixing ISO dates and durations
-scloud log --since=2024-11-01T00:00:00Z --until=10m
-```
-
-The `--until` option can also be passed as the first positional argument:
-
-```bash
-scloud log 10m
-scloud log 3h
-scloud log 14d
-```
-
-To tail the logs (i.e. get streaming real-time updates), add the `--tail` flag:
-
-```bash
-scloud log --tail
-```
+See [Logs](/cloud/concepts/logs) for the time-format options (duration strings, ISO 8601), how `--tail` interacts with `--since` / `--until`, and session-log configuration.

--- a/cloud_docs/reference/cli/commands/password/_password.md
+++ b/cloud_docs/reference/cli/commands/password/_password.md
@@ -1,52 +1,5 @@
 # scloud password
 
-## Summary
+`scloud password` manages encrypted password values your server reads through Serverpod's `getPassword()` API. Each password is stored under a `SERVERPOD_PASSWORD_` prefix that the CLI adds on `set` and that `getPassword()` strips on read.
 
-The `scloud password` command provides management of passwords for Serverpod Cloud projects. Passwords are automatically prefixed with `SERVERPOD_PASSWORD_` and will be injected as environment variables. Passwords defined by this command can be accessed with Serverpod's `getPassword()` function.
-
-Use this command when you need to manage passwords that will be accessed via Serverpod's `getPassword()` API, such as database passwords, JWT secrets, or email service passwords.
-
-## Setting passwords
-
-To set a password, use the `set` command:
-
-```bash
-scloud password set database "my_database_password"
-```
-
-The password name should be provided without the `SERVERPOD_PASSWORD_` prefix. The prefix is automatically added by Serverpod Cloud.
-
-You can also set a password from a file:
-
-```bash
-scloud password set database --from-file password.txt
-```
-
-## Listing passwords
-
-To list all passwords (both user-set and platform-managed):
-
-```bash
-scloud password list
-```
-
-This displays passwords grouped by category: Custom, Services, Auth, and Legacy Auth.
-
-## Unsetting passwords
-
-To remove a user-set password:
-
-```bash
-scloud password unset database
-```
-
-:::note
-If you need to set a secret without the `SERVERPOD_PASSWORD_` prefix, you can do so by using the [`secret set`](/cloud/reference/cli/commands/secret) command.
-:::
-
-## Related commands
-
-- [`scloud secret`](/cloud/reference/cli/commands/secret) - Manage general secrets without the `SERVERPOD_PASSWORD_` prefix
-- [`scloud variable`](/cloud/reference/cli/commands/variable) - Manage non-sensitive configuration values
-
-For detailed information about when to use passwords vs secrets vs variables, see the [Passwords, secrets, and environment variables](/cloud/concepts/passwords-secrets-env-vars) concept page.
+For the model (when to use passwords vs secrets vs variables, platform-managed defaults, and naming rules), see [Passwords, secrets, and environment variables](/cloud/concepts/passwords-secrets-env-vars).

--- a/cloud_docs/reference/cli/commands/project/_project.md
+++ b/cloud_docs/reference/cli/commands/project/_project.md
@@ -1,37 +1,21 @@
 # scloud project
 
-`scloud project` provides commands for managing your Serverpod Cloud projects.
+`scloud project` creates and manages projects on Serverpod Cloud. For an interactive walkthrough that also deploys for the first time, use `scloud launch`.
 
-A project is created by running the following command:
+To create a project from the command line:
 
 ```bash
 scloud project create my-project --enable-db
 ```
 
-If the project does not need a database (e.g. if it is a [Serverpod Mini project](https://docs.serverpod.dev/get-started-with-mini)), the `--no-enable-db` flag can instead be passed.
+If the project doesn't need a database (e.g., a [Serverpod Mini project](https://docs.serverpod.dev/get-started-with-mini)), pass `--no-enable-db` instead. Once created, deploy with [`scloud deploy`](/cloud/reference/cli/commands/deploy).
 
-See the [`deploy` command](./deploy) on how to deploy your project.
+## Link an existing project
 
-## Linking an existing project
+`scloud project link <project-id>` connects a local Serverpod codebase to an existing Cloud project. Use it when you've created the project in the Cloud console or when joining a teammate's project.
 
-If you have an existing Serverpod Cloud project and want to connect your local codebase to it, use the `link` command:
+The link command writes or updates three files in your local project directory:
 
-```bash
-scloud project link my-project
-```
-
-### What the link command does
-
-The `link` command creates or updates configuration files in your local project directory to connect it to an existing Serverpod Cloud project. Specifically, it:
-
-1. **Creates or updates `scloud.yaml`**: This file contains the project ID that identifies which Serverpod Cloud project your local codebase is connected to. The file is created in your server package directory (or the directory specified with `--project-dir`).
-
-2. **Creates `.scloudignore`**: If this file doesn't exist, the command creates it with a template that specifies which files should be ignored when uploading to Serverpod Cloud. This file works similarly to `.gitignore`.
-
-3. **Updates `.gitignore`**: If your project is part of a workspace, the command automatically adds the `.scloud/` directory to your `.gitignore` file to prevent deployment artifacts from being committed to version control.
-
-### When to use link
-
-Use the `link` command when:
-- You have an existing Serverpod Cloud project and want to connect a local codebase to it
-- You're working with a project that was created through the web console or by another team member
+1. **`scloud.yaml`**: contains the project ID that ties your codebase to the Cloud project. Created in your server package directory (or the one specified with `--project-dir`).
+2. **`.scloudignore`**: created from a template if it doesn't exist; defines which files should be excluded when uploading to Cloud (syntax mirrors `.gitignore`).
+3. **`.gitignore`**: if your project is a workspace, the `.scloud/` directory is added to keep deployment artifacts out of version control.

--- a/cloud_docs/reference/cli/commands/project/_project.md
+++ b/cloud_docs/reference/cli/commands/project/_project.md
@@ -8,7 +8,7 @@ To create a project from the command line:
 scloud project create my-project --enable-db
 ```
 
-If the project doesn't need a database (e.g., a [Serverpod Mini project](https://docs.serverpod.dev/get-started-with-mini)), pass `--no-enable-db` instead. Once created, deploy with [`scloud deploy`](/cloud/reference/cli/commands/deploy).
+If the project doesn't need a database, pass `--no-enable-db` instead. Once created, deploy with [`scloud deploy`](/cloud/reference/cli/commands/deploy).
 
 ## Link an existing project
 

--- a/cloud_docs/reference/cli/commands/variable/_variable.md
+++ b/cloud_docs/reference/cli/commands/variable/_variable.md
@@ -1,19 +1,5 @@
 # scloud variable
 
-The `scloud variable` command provides management of environment variables for your Serverpod Cloud projects.
+`scloud variable` manages plaintext environment variables for non-sensitive configuration (URLs, feature flags, log levels). Variables are visible in the CLI and the Cloud console; for sensitive values, use `scloud secret` or `scloud password` instead.
 
-To add an environment variable, use the `set` command:
-
-```bash
-scloud variable set MY_VAR myvalue
-```
-
-:::note
-Some limitations to keep in mind:
-
-- Environment variable names can only contain lowercase letters `a-z`, uppercase letters `A-Z`, digits `0-9` and underscore `_` for separation. The name has to start with a letter.
-- Maximum name length is `255`.
-- The maximum total size of all environment variables cannot exceed `64kB`.
-
-:::
-
+See [Passwords, secrets, and environment variables](/cloud/concepts/passwords-secrets-env-vars) for the tier comparison, naming rules, and size limits.

--- a/cloud_docs/reference/cli/env_vars/env_vars.md
+++ b/cloud_docs/reference/cli/env_vars/env_vars.md
@@ -7,13 +7,13 @@ The `scloud` command supports a number of environment variables, many of which
 override the default behavior and / or can be used in place of specifying the
 values on the command line.
 
-| Name | In lieu of option | Example value | Description |
-|------|-------------------|---------------|-------------|
-| `SERVERPOD_CLOUD_PROJECT_ID` | `-p` / `--project` | `my-project-id` | The ID of the project. |
-| `SERVERPOD_CLOUD_DISPLAY_UTC` | `-u` / `--utc` | `true` or `false` | Display timestamps in UTC timezone instead of local. |
-| `SERVERPOD_CLOUD_COMMAND_ANALYTICS` | `-a` / `--analytics` |  `true` or `false` | Toggles if analytics data is sent. |
-| `SERVERPOD_CLOUD_TOKEN` | `--token` |  `your-auth-token-here` | The authentication token to use for the current command. |
-| `SERVERPOD_CLOUD_DIR` | `--config-dir` |  `/path/to/config/dir` | Override the directory path where Serverpod Cloud cache/authentication files are stored. |
-| `SERVERPOD_CLOUD_PROJECT_DIR` | `-d` / `--project-dir` |  `/path/to/project/server` | The path to the Serverpod Cloud project server directory. |
-| `SERVERPOD_CLOUD_PROJECT_CONFIG_FILE` | `--project-config-file` |  `/path/to/scloud.yaml` | The path to the Serverpod Cloud project configuration file. |
-| `SERVERPOD_CLOUD_CONNECTION_TIMEOUT` | `--timeout` |  `60s` | The timeout for the connection to the Serverpod Cloud API (defaults to 60 seconds). |
+| Name                                  | In lieu of option       | Example value           | Description                                                                                           |
+| ------------------------------------- | ----------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------- |
+| `SERVERPOD_CLOUD_PROJECT_ID`          | `-p` / `--project`      | `my-project-id`         | The ID of the project.                                                                                |
+| `SERVERPOD_CLOUD_DISPLAY_UTC`         | `-u` / `--utc`          | `true` or `false`       | Display timestamps in UTC timezone instead of local.                                                  |
+| `SERVERPOD_CLOUD_COMMAND_ANALYTICS`   | `-a` / `--analytics`    | `true` or `false`       | Toggles if analytics data is sent.                                                                    |
+| `SERVERPOD_CLOUD_TOKEN`               | `--token`               | `your-auth-token-here`  | The authentication token to use for the current command.                                              |
+| `SERVERPOD_CLOUD_DIR`                 | `--config-dir`          | `/path/to/config/dir`   | Override the directory path where Serverpod Cloud cache/authentication files are stored.              |
+| `SERVERPOD_CLOUD_PROJECT_DIR`         | `-d` / `--project-dir`  | `/path/to/your/project` | The path to the directory containing `scloud.yaml` (typically your project root or server directory). |
+| `SERVERPOD_CLOUD_PROJECT_CONFIG_FILE` | `--project-config-file` | `/path/to/scloud.yaml`  | The path to the Serverpod Cloud project configuration file.                                           |
+| `SERVERPOD_CLOUD_CONNECTION_TIMEOUT`  | `--timeout`             | `60s`                   | The timeout for the connection to the Serverpod Cloud API (defaults to 60 seconds).                   |


### PR DESCRIPTION
PR 12 of the Cloud IA rollout. Brings the remaining 10 CLI command intros to the same terse meta-shape as #607: lead paragraph plus cross-link to the concept page. The auto-generated CLI help renders below each intro and covers flags, subcommands, and examples.

## Changes

- 10 CLI command intros cut, slimmed, rewritten, or polished.
- Passwords concept gets a sentence of concrete use cases so the cut from `_password.md` doesn't lose them.
- Redis guide: restructures *Before you start*, drops the onboarding line, and fixes 5 stale `scloud variable create` calls to `set`.
- `env_vars.md` and `_deploy.md` correct the `SERVERPOD_CLOUD_PROJECT_DIR` framing to point at `scloud.yaml` instead of the server directory.

## Test plan

- [ ] `npm run build` passes
- [ ] Render a few slimmed pages and confirm the intro flows into the auto-gen below
- [ ] Cross-links from slim intros land on the right concept-page sections