### PR TITLE
fix: Fact-check of database docs

### DIFF
--- a/docs/06-concepts/06-database/01-connection.md
+++ b/docs/06-concepts/06-database/01-connection.md
@@ -1,3 +1,7 @@
+---
+description: Configure Serverpod's database connection details, passwords, and connect to custom Postgres or SQLite instances.
+---
+
 # Connection
 
 In Serverpod the connection details and password for the database are stored inside the `config` directory in your server package. Serverpod automatically establishes a connection to the database instance by using these configuration details when you start the server.
@@ -8,8 +12,6 @@ If using Postgres, the easiest way to get started is to use a Docker container t
 
 Each environment configuration contains a `database` keyword that specifies the connection details.
 For your development build you can find the connection details in the `config/development.yaml` file.
-
-Below is an example for Postgres:
 
 ```yaml
 ...
@@ -96,8 +98,6 @@ On SQLite, this configuration sets the number of read-only transactions that can
 ### Database password
 
 The database password is stored in a separate file called `passwords.yaml` in the same `config` directory. The password for each environment is stored under the `database` keyword in the file.
-
-An example of this could look like this:
 
 ```yaml
 ...

--- a/docs/06-concepts/06-database/02-models.md
+++ b/docs/06-concepts/06-database/02-models.md
@@ -1,3 +1,7 @@
+---
+description: Map serializable models to database tables, with support for custom ID types, non-persistent fields, JSONB storage, and column name overrides.
+---
+
 # Models
 
 It's possible to map serializable models to tables in your database. To do this, add the `table` key to your yaml file:
@@ -123,7 +127,7 @@ If you change the `serializationDataType` between `json` and `jsonb` at any leve
 
 ## Change ID type
 
-Changing the type of the `id` field allows you to customize the identifier type for your database tables. This is done by declaring the `id` field on table models with one of the supported types. If the field is omitted, the id field will still be created with type `int`, as have always been.
+Changing the type of the `id` field allows you to customize the identifier type for your database tables. This is done by declaring the `id` field on table models with one of the supported types. If the field is omitted, the id field will still be created with type `int` by default.
 
 The following types are supported for the `id` field:
 
@@ -147,7 +151,7 @@ fields:
 class: IntIdTable
 table: int_id_table
 fields:
-  id: int?, defaultPersist=serial  // The default keyword for 'int' is optional.
+  id: int?, defaultPersist=serial  # The default keyword for 'int' is optional.
 ```
 
 #### Default Uuid model value

--- a/docs/06-concepts/06-database/03-relations/01-one-to-one.md
+++ b/docs/06-concepts/06-database/03-relations/01-one-to-one.md
@@ -1,3 +1,7 @@
+---
+description: Define one-to-one relationships between database tables using Serverpod's relation keyword, with support for object fields, ID fields, and bidirectional relations.
+---
+
 # One-to-one
 
 One-to-one (1:1) relationships represent a unique association between two entities, there is at most one model that can be connected on either side of the relation. This means we have to set a **unique index** on the foreign key in the database. Without the unique index the relation would be considered a one-to-many (1:n) relation.
@@ -160,7 +164,7 @@ Both relations operate independently of each other, resulting in two distinct re
 
 ## Bidirectional relations
 
-If access to the same relation is desired from both sided, a bidirectional relation can be defined.
+If access to the same relation is desired from both sides, a bidirectional relation can be defined.
 
 ```yaml
 # user.yaml

--- a/docs/06-concepts/06-database/03-relations/02-one-to-many.md
+++ b/docs/06-concepts/06-database/03-relations/02-one-to-many.md
@@ -1,3 +1,7 @@
+---
+description: Define one-to-many relationships between database tables using Serverpod's relation keyword, with implicit and explicit definition options.
+---
+
 # One-to-many
 
 One-to-many (1:n) relationships describes a scenario where multiple records from one table can relate to a single record in another table. An example of this would the relationship between a company and its employees, where multiple employees can be employed at a single company.
@@ -113,4 +117,4 @@ fields:
   companyId: int, relation(name=company_employees, parent=company)
 ```
 
-Just as in the 1:1 examples, the `name` parameter with a unique string that links both sides together.
+Just as in the 1:1 examples, the `name` parameter takes a unique string that links both sides together.

--- a/docs/06-concepts/06-database/03-relations/03-many-to-many.md
+++ b/docs/06-concepts/06-database/03-relations/03-many-to-many.md
@@ -1,3 +1,7 @@
+---
+description: Define many-to-many relationships between database tables using a junction model that holds foreign keys to both sides of the relation.
+---
+
 # Many-to-many
 
 Many-to-many (n:m) relationships describes a scenario where multiple records from a table can relate to multiple records in another table. An example of this would be the relationship between students and courses, where a single student can enroll in multiple courses, and a single course can have multiple students.

--- a/docs/06-concepts/06-database/03-relations/04-self-relations.md
+++ b/docs/06-concepts/06-database/03-relations/04-self-relations.md
@@ -1,3 +1,7 @@
+---
+description: Define self-referential relationships where a table has a foreign key pointing to its own primary key, supporting one-to-one, one-to-many, and many-to-many patterns.
+---
+
 # Self-relations
 
 A self-referential or self-relation occurs when a table has a foreign key that references its own primary key within the same table. This creates a relationship between different rows within the same table.
@@ -39,7 +43,7 @@ The field `motherId: int?` is injected into the dart class, the field is nullabl
 
 ## Many-to-many
 
-Let's imagine we have a system where we have members that can block other members. We would like to be able to query who I'm blocking and who is blocking me. This can be achieved by modeling the data as a many-to-many relation ship.
+Let's imagine we have a system where we have members that can block other members. We would like to be able to query who I'm blocking and who is blocking me. This can be achieved by modeling the data as a many-to-many relationship.
 
 Each member has a list of all other members they are blocking and another list of all members that are blocking them. But since the list side needs to point to a foreign key and cannot point to another list directly, we have to define a junction table that holds the connection between the rows.
 

--- a/docs/06-concepts/06-database/03-relations/05-referential-actions.md
+++ b/docs/06-concepts/06-database/03-relations/05-referential-actions.md
@@ -1,6 +1,10 @@
+---
+description: Control how updates and deletes propagate across related tables using the onUpdate and onDelete referential action properties.
+---
+
 # Referential actions
 
-In Serverpod, the behavior of update and delete for relations can be precisely defined using the onUpdate and onDelete properties. These properties map directly to the corresponding referential actions in the database.
+In Serverpod, the behavior of update and delete for relations can be precisely defined using the `onUpdate` and `onDelete` properties. These properties map directly to the corresponding referential actions in the database.
 
 ## Available referential actions
 
@@ -14,7 +18,7 @@ In Serverpod, the behavior of update and delete for relations can be precisely d
 
 ## Syntax
 
-Use the following syntax to apply referential actions
+Use the following syntax to apply referential actions:
 
 ```yaml
 relation(onUpdate=<ACTION>, onDelete=<ACTION>)

--- a/docs/06-concepts/06-database/03-relations/06-modules.md
+++ b/docs/06-concepts/06-database/03-relations/06-modules.md
@@ -1,3 +1,7 @@
+---
+description: Create relations between your own database tables and tables from Serverpod modules using a bridge table approach.
+---
+
 # Relations with modules
 
 Serverpod [modules](../../modules) usually come with predefined tables and data structures. Sometimes it can be useful to extend them with your data structures by creating a relation to the module tables. Relations to modules come with some restrictions since you do not own the definition of the table, you cannot change the table structure of a module table.

--- a/docs/06-concepts/06-database/04-indexing.md
+++ b/docs/06-concepts/06-database/04-indexing.md
@@ -1,3 +1,7 @@
+---
+description: Add indexes to Serverpod database tables to improve query performance, including unique, GIN, HNSW, and IVFFLAT vector indexes.
+---
+
 # Indexing
 
 For performance reasons, you may want to add indexes to your database tables. These are added in the YAML-files defining the serializable objects.

--- a/docs/06-concepts/06-database/05-crud.md
+++ b/docs/06-concepts/06-database/05-crud.md
@@ -1,3 +1,7 @@
+---
+description: Create, read, update, and delete database rows in Serverpod using the generated static db methods on your model classes.
+---
+
 # CRUD
 
 To interact with the database you need a [`Session`](../sessions) object as this object holds the connection to the database. All CRUD operations are accessible via the session object and the generated models. The methods can be found under the static `db` field in your generated models.
@@ -39,10 +43,6 @@ var rows = [Company(name: 'Serverpod'), Company(name: 'Google')];
 var companies = await Company.db.insert(session, rows);
 ```
 
-:::info
-In previous versions of Serverpod the `insert` method mutated the input object by setting the `id` field. In the example above the input variable remains unmodified after the `insert`/`insertRow` call.
-:::
-
 ### Ignoring conflicts
 
 When inserting rows that might violate a unique or exclusion constraint, you can set `ignoreConflicts` to `true` on the `insert` method. Rows that would cause a unique or exclusion constraint violation are silently skipped, and only the non-conflicting rows are inserted.
@@ -54,11 +54,7 @@ var inserted = await Company.db.insert(session, rows, ignoreConflicts: true);
 
 The method returns only the rows that were successfully inserted. If all rows conflict, an empty list is returned. Unlike a regular `insert`, which fails entirely if any row violates a constraint, `ignoreConflicts` allows partial inserts where only the non-conflicting rows are written.
 
-This is useful for idempotent operations where you want to insert data without failing on duplicates.
-
-:::note
-Under the hood, this uses an `ON CONFLICT DO NOTHING` SQL clause. Only unique and exclusion constraint violations are ignored. Other errors such as `NOT NULL`, `CHECK`, or foreign key violations will still throw an exception.
-:::
+This is useful for idempotent operations where you want to insert data without failing on duplicates. Only unique and exclusion constraint violations are ignored — other violations such as `NOT NULL`, `CHECK`, or foreign key constraints still throw an exception.
 
 :::warning
 When using `ignoreConflicts` with models that have [non-persistent fields](models#non-persistent-fields), each row is inserted individually instead of in a single batch. This is necessary because the database cannot report which rows were skipped in a batch insert, making it impossible to correctly match non-persistent field values back to inserted rows. For large numbers of rows, this can cause performance issues. Consider removing non-persistent fields from the model or inserting in smaller batches.

--- a/docs/06-concepts/06-database/05-crud.md
+++ b/docs/06-concepts/06-database/05-crud.md
@@ -54,7 +54,7 @@ var inserted = await Company.db.insert(session, rows, ignoreConflicts: true);
 
 The method returns only the rows that were successfully inserted. If all rows conflict, an empty list is returned. Unlike a regular `insert`, which fails entirely if any row violates a constraint, `ignoreConflicts` allows partial inserts where only the non-conflicting rows are written.
 
-This is useful for idempotent operations where you want to insert data without failing on duplicates. Only unique and exclusion constraint violations are ignored — other violations such as `NOT NULL`, `CHECK`, or foreign key constraints still throw an exception.
+This is useful for idempotent operations where you want to insert data without failing on duplicates. Only unique and exclusion constraint violations are ignored. Other violations such as `NOT NULL`, `CHECK`, or foreign key constraints still throw an exception.
 
 :::warning
 When using `ignoreConflicts` with models that have [non-persistent fields](models#non-persistent-fields), each row is inserted individually instead of in a single batch. This is necessary because the database cannot report which rows were skipped in a batch insert, making it impossible to correctly match non-persistent field values back to inserted rows. For large numbers of rows, this can cause performance issues. Consider removing non-persistent fields from the model or inserting in smaller batches.

--- a/docs/06-concepts/06-database/06-filter.md
+++ b/docs/06-concepts/06-database/06-filter.md
@@ -1,3 +1,7 @@
+---
+description: Build type-safe database filter expressions in Serverpod using column operations, logical operators, and relation filters.
+---
+
 # Filter
 
 Serverpod makes it easy to build expressions that are statically type-checked. Columns and relational fields are referenced using table descriptor objects. The table descriptors, `t`, are accessible from each model and are passed as an argument to a model specific expression builder function. A callback is then used as argument to the `where` parameter when fetching data from the database.
@@ -16,7 +20,8 @@ Compare a column to an exact value, meaning only rows that match exactly will re
 
 ```dart
 await User.db.find(
-  where: (t) => t.name.equals('Alice')
+  session,
+  where: (t) => t.name.equals('Alice'),
 );
 ```
 

--- a/docs/06-concepts/06-database/07-relation-queries.md
+++ b/docs/06-concepts/06-database/07-relation-queries.md
@@ -1,3 +1,7 @@
+---
+description: Query, filter, sort, and paginate relational data in Serverpod using include, includeList, attach, and detach methods.
+---
+
 # Relation queries (Joins)
 
 The Serverpod query framework supports filtering on, sorting on, and including relational data structures. In SQL this is often achieved using a join operation. The functionality is available if there exists any [one-to-one](relations/one-to-one) or [one-to-many](relations/one-to-many) object relations between two models.
@@ -16,7 +20,7 @@ var employee = await Employee.db.findById(
 );
 ```
 
-The example above return a employee including the related address object.
+The example above returns an employee including the related address object.
 
 ### Nested includes
 

--- a/docs/06-concepts/06-database/08-sort.md
+++ b/docs/06-concepts/06-database/08-sort.md
@@ -1,3 +1,7 @@
+---
+description: Sort database query results by one or more columns in Serverpod using orderBy and orderByList, with support for relational fields and aggregated counts.
+---
+
 # Sort
 
 It is often desirable to order the results of a database query. The 'find' method has an `orderBy` parameter where you can specify a column for sorting. The parameter takes a callback as an argument that passes a model-specific table descriptor, also accessible through the `t` field on the model. The table descriptor represents the database table associated with the model and includes fields for each corresponding column. The callback is then used to specify the column to sort by.
@@ -11,7 +15,7 @@ var companies = await Company.db.find(
 
 In the example we fetch all companies and sort them by their name.
 
-By default the order is set to ascending, this can be changed to descending by setting the param `orderDecending: true`.
+By default, results are sorted in ascending order. To sort in descending order, call `.desc()` on the column:
 
 ```dart
 var companies = await Company.db.find(

--- a/docs/06-concepts/06-database/08-transactions.md
+++ b/docs/06-concepts/06-database/08-transactions.md
@@ -1,3 +1,7 @@
+---
+description: Group database operations into atomic transactions in Serverpod, with support for isolation levels, savepoints, and rollback.
+---
+
 # Transactions
 
 The essential point of a database transaction is that it bundles multiple steps into a single, all-or-nothing operation. The intermediate states between the steps are not visible to other concurrent transactions, and if some failure occurs that prevents the transaction from completing, then none of the steps affect the database at all.
@@ -26,7 +30,7 @@ In the example we insert a company and an employee in the same transaction. If a
 The transaction isolation level can be configured when initiating a transaction. The isolation level determines how the transaction interacts with concurrent database operations. If no isolation level is supplied, the level is determined by the database engine.
 
 :::info
-At the time of writing, the default isolation level for the Postgres database engine is `IsolationLevel.readCommitted`.
+The default isolation level for the Postgres database engine is `IsolationLevel.readCommitted`.
 :::
 
 :::info
@@ -49,8 +53,8 @@ In the example the isolation level is set to `IsolationLevel.serializable`.
 
 The available isolation levels are:
 
-| Isolation Level | Constant              | Description |
-|-----------------|-----------------------|-------------|
+| Isolation Level | Constant | Description |
+| --- | --- | --- |
 | Read uncommitted | `IsolationLevel.readUncommitted` | Exhibits the same behavior as `IsolationLevel.readCommitted` in PostgresSQL |
 | Read committed | `IsolationLevel.readCommitted` | Each statement in the transaction sees a snapshot of the database as of the beginning of that statement. |
 | Repeatable read | `IsolationLevel.repeatableRead` | The transaction only observes rows committed before the first statement in the transaction was executed giving a consistent view of the database. If any conflicting writes among concurrent transactions occur, an exception is thrown. |

--- a/docs/06-concepts/06-database/09-pagination.md
+++ b/docs/06-concepts/06-database/09-pagination.md
@@ -1,3 +1,7 @@
+---
+description: Paginate database query results in Serverpod using limit and offset, or implement cursor-based pagination for frequently updated datasets.
+---
+
 # Pagination
 
 Serverpod provides built-in support for pagination to help manage large datasets, allowing you to retrieve data in smaller chunks. Pagination is achieved using the `limit` and `offset` parameters.

--- a/docs/06-concepts/06-database/10-raw-access.md
+++ b/docs/06-concepts/06-database/10-raw-access.md
@@ -1,3 +1,7 @@
+---
+description: Execute raw SQL queries directly against the database using Serverpod's unsafe query methods with support for named and positional parameter binding.
+---
+
 # Raw access
 
 The library provides methods to execute raw SQL queries directly on the database for advanced scenarios.
@@ -34,9 +38,9 @@ Simple query mode is suitable for:
 * Situations where the extended query protocol is not available (e.g., replication mode or with proxies like PGBouncer).
 
 ```dart
-  DatabaseResult result = await session.db.unsafeSimpleQuery(
-      r'SELECT * FROM mytable WHERE id = 1; SELECT * FROM othertable;'
-  );
+DatabaseResult result = await session.db.unsafeSimpleQuery(
+  r'SELECT * FROM mytable WHERE id = 1; SELECT * FROM othertable;',
+);
 ```
 
 ## `unsafeSimpleExecute`
@@ -46,9 +50,9 @@ Similar to `unsafeExecute`, but uses the simple query protocol. It does not retu
 Simple query mode is suitable for the same scenarios as `unsafeSimpleQuery`.
 
 ```dart
-  int result = await session.db.unsafeSimpleExecute(
-      r'DELETE FROM mytable WHERE id = 1; DELETE FROM othertable;'
-  );
+int result = await session.db.unsafeSimpleExecute(
+  r'DELETE FROM mytable WHERE id = 1; DELETE FROM othertable;',
+);
 ```
 
 ## Query parameters

--- a/docs/06-concepts/06-database/11-migrations.md
+++ b/docs/06-concepts/06-database/11-migrations.md
@@ -1,3 +1,7 @@
+---
+description: Create and apply database migrations in Serverpod to keep your schema in sync as your models evolve, including repair migrations for out-of-sync databases.
+---
+
 # Migrations
 
 Serverpod comes bundled with a simple-to-use but powerful migration system that helps you keep your database schema up to date as your project evolves. Database migrations provide a structured way of upgrading your database while maintaining existing data.

--- a/docs/06-concepts/06-database/12-runtime-parameters.md
+++ b/docs/06-concepts/06-database/12-runtime-parameters.md
@@ -1,3 +1,7 @@
+---
+description: Fine-tune PostgreSQL query behavior per transaction or globally using Serverpod's runtime parameters, particularly for vector similarity search optimization.
+---
+
 # Runtime parameters
 
 Runtime parameters in Serverpod allow you to fine-tune the behavior of the database engine for specific queries or workloads. This can significantly improve performance, especially for complex queries or large datasets.

--- a/docs/06-concepts/06-database/13-row-locking.md
+++ b/docs/06-concepts/06-database/13-row-locking.md
@@ -1,3 +1,7 @@
+---
+description: Lock specific database rows within a transaction in Serverpod to safely handle concurrent updates and prevent conflicting writes.
+---
+
 # Row locking
 
 Row-level locking allows you to lock specific rows in the database to prevent other transactions from modifying them while you work. This is essential for safely handling concurrent updates, such as processing payments, managing inventory, or any scenario where two transactions might conflict.
@@ -78,7 +82,7 @@ await session.db.transaction((transaction) async {
 The `lockMode` parameter determines the type of lock acquired. Different lock modes allow varying levels of concurrent access.
 
 | Lock Mode | Constant | Description |
-|---|---|---|
+| --- | --- | --- |
 | For update | `LockMode.forUpdate` | Exclusive lock that blocks all other locks. Use when you intend to update or delete the locked rows. |
 | For no key update | `LockMode.forNoKeyUpdate` | Exclusive lock that allows `forKeyShare` locks. Use when updating non-key columns only. |
 | For share | `LockMode.forShare` | Shared lock that blocks exclusive locks but allows other shared locks. Use when you need to ensure rows don't change while reading. |
@@ -91,7 +95,7 @@ For a detailed explanation of how lock modes interact, see the [PostgreSQL docum
 The `lockBehavior` parameter controls what happens when a requested row is already locked by another transaction. If not specified, the default behavior is to wait.
 
 | Behavior | Constant | Description |
-|---|---|---|
+| --- | --- | --- |
 | Wait | `LockBehavior.wait` | Wait until the lock becomes available. This is the default. |
 | No wait | `LockBehavior.noWait` | Throw an exception immediately if any row is already locked. |
 | Skip locked | `LockBehavior.skipLocked` | Skip rows that are currently locked and return only the unlocked rows. |

--- a/docs/06-concepts/06-database/14-client-side-database.md
+++ b/docs/06-concepts/06-database/14-client-side-database.md
@@ -1,3 +1,7 @@
+---
+description: Use a SQLite database on the Flutter client with the same ORM interface as the server, including CRUD, relations, and transactions.
+---
+
 # Client-side database
 
 When at least one table model has `database: client` or `database: all`, the generated `Client` class gets a `createSession` method that returns a `ClientDatabaseSession` for a SQLite database file.
@@ -52,7 +56,7 @@ void main() async {
   // Create the session to use in database operations.
   final session = await client.createSession(path, isDebugMode: kDebugMode);
 
-  // Store the session in your state manager to use it all database operations.
+  // Store the session in your state manager to use it for all database operations.
   // Since the session opens and closes the database when created, it is not
   // recommended to create a new session for each database operation.
 }


### PR DESCRIPTION
## Summary

Fact-checked, removed noise, and added frontmatter to all 20 database pages.

**All 20 files:**
- Added missing `description` frontmatter

**Code bugs fixed:**
- `02-models`: `//` comment in YAML block → `#` (invalid YAML syntax)
- `06-filter`: first `equals` example was missing `session` argument
- `08-sort`: prose described a non-existent `orderDecending: true` parameter → corrected to `.desc()` (also misspelled)

**Grammar & typos:**
- `01-one-to-one`: "both sided" → "both sides"
- `02-one-to-many`: missing verb "the `name` parameter with a unique string" → "takes a unique string"
- `04-self-relations`: "relation ship" → "relationship"
- `07-relation-queries`: "return a employee" → "returns an employee"
- `02-models`: "as have always been" → "by default"
- `14-client-side-database`: "to use it all database operations" → "to use it for all" (in code comment)

**Noise removed:**
- `05-crud`: version history `:::info` about previous `insert` mutation behavior (#12)
- `05-crud`: `:::note` exposing `ON CONFLICT DO NOTHING` SQL internals — replaced with prose keeping the useful constraint behavior info
- `05-crud`: "At least one column must be specified…otherwise an `ArgumentError`" (#14)
- `08-transactions`: "At the time of writing" from isolation level `:::info`
- `01-connection`: two redundant lead-in sentences
- `03-referential-actions`: `onUpdate`/`onDelete` wrapped in backticks; added missing period

**Formatting:**
- `10-raw-access`: removed extra indentation from two code blocks
- `08-transactions` / `13-row-locking`: fixed MD060 table column style lint errors