### PR TITLE
docs(cloud): Establish Reference section by moving and renaming the three existing pages

### DIFF
--- a/cloud_docs/concepts/deployments.md
+++ b/cloud_docs/concepts/deployments.md
@@ -161,6 +161,6 @@ For a step-by-step walkthrough, see [Recover from a failed deploy](/cloud/guides
 ## Related
 
 - [Deployment hooks](/cloud/concepts/deployment-hooks) for pre- and post-deploy automation.
-- [Handling private dependencies](/cloud/reference/deployment/handling-private-dependencies) for private package access during the build.
+- [Private dependencies](/cloud/reference/private-dependencies) for private package access during the build.
 - [Ship non-Dart files with your server](/cloud/guides/ship-non-dart-files) for shipping static assets like configuration and templates.
 - [Deploy from CI with GitHub Actions](/cloud/guides/deploy-from-ci-with-github-actions) for shipping every push.

--- a/cloud_docs/guides/recover-from-a-failed-deploy.md
+++ b/cloud_docs/guides/recover-from-a-failed-deploy.md
@@ -67,7 +67,7 @@ scloud deploy --timeout 120s
 
 If the timeout keeps tripping at high values, the issue is likely upstream (network or Cloud-side); retry later.
 
-**Package resolution failure.** Cloud can't resolve your `pubspec.yaml`. Run `dart pub get` locally to reproduce the error, fix the pubspec (mismatched versions, missing packages, private dependencies that aren't configured), and redeploy. For private packages, see [Handling private dependencies](/cloud/reference/deployment/handling-private-dependencies).
+**Package resolution failure.** Cloud can't resolve your `pubspec.yaml`. Run `dart pub get` locally to reproduce the error, fix the pubspec (mismatched versions, missing packages, private dependencies that aren't configured), and redeploy. For private packages, see [Private dependencies](/cloud/reference/private-dependencies).
 
 **Build failure.** Lines beginning with `ERROR:` or `FAILED:` in the build log, usually pointing at a Dart compile error, a missing import, or a missing dependency. Fix the file in your project, commit, and redeploy.
 

--- a/cloud_docs/reference/cli/_category_.json
+++ b/cloud_docs/reference/cli/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "CLI",
   "collapsed": true,
-  "position": 3,
+  "position": 4,
   "className": "sidebar-icon-tools"
 }

--- a/cloud_docs/reference/dart-sdk-versions.md
+++ b/cloud_docs/reference/dart-sdk-versions.md
@@ -1,8 +1,10 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
+title: Dart SDK versions
+description: Which Dart SDK versions Serverpod Cloud supports, how the SDK version is selected for your build, and how to pin a version in pubspec.yaml.
 ---
 
-# Dart SDK version handling
+# Dart SDK versions
 
 Serverpod Cloud supports specific Dart SDK versions for building and deploying your applications. Understanding how SDK versions are determined and used is important for configuring your project correctly.
 
@@ -174,4 +176,4 @@ environment:
 ## Related documentation
 
 - [Deployments](/cloud/concepts/deployments) - Deploy operations, status checks, package validation, and `.scloudignore` configuration.
-- [Handling private dependencies](/cloud/reference/deployment/handling-private-dependencies) for managing workspace dependencies.
+- [Private dependencies](/cloud/reference/private-dependencies) for managing workspace dependencies.

--- a/cloud_docs/reference/deployment/_category_.json
+++ b/cloud_docs/reference/deployment/_category_.json
@@ -1,6 +1,0 @@
-{
-  "label": "Deployment",
-  "position": 1,
-  "collapsed": true,
-  "className": "sidebar-icon-deploying"
-}

--- a/cloud_docs/reference/private-dependencies.md
+++ b/cloud_docs/reference/private-dependencies.md
@@ -1,8 +1,10 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
+title: Private dependencies
+description: How to deploy a Serverpod Cloud project that depends on private packages, using Dart workspaces or build secrets for private git repositories.
 ---
 
-# Handling private dependencies
+# Private dependencies
 
 Serverpod Cloud supports deploying your project with private dependencies.
 The typical methods are:

--- a/cloud_docs/reference/project-id-rules.md
+++ b/cloud_docs/reference/project-id-rules.md
@@ -1,9 +1,10 @@
 ---
-sidebar_position: 2
-title: Project identifier
+sidebar_position: 3
+title: Project identifier rules
+description: "Naming rules for the Serverpod Cloud project identifier and how scloud picks which project to operate on: scloud.yaml, -p flag, or environment variable."
 ---
 
-# Project identifier
+# Project identifier rules
 
 The identifier given to a project in Serverpod Cloud must adhere to these rules:
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -253,6 +253,18 @@ const config = {
             from: ['/cloud/reference/deployment/github-automation'],
             to: '/cloud/guides/deploy-from-ci-with-github-actions',
           },
+          {
+            from: ['/cloud/reference/deployment/handling-private-dependencies'],
+            to: '/cloud/reference/private-dependencies',
+          },
+          {
+            from: ['/cloud/reference/deployment/dart-sdk-versions'],
+            to: '/cloud/reference/dart-sdk-versions',
+          },
+          {
+            from: ['/cloud/reference/project-id'],
+            to: '/cloud/reference/project-id-rules',
+          },
         ],
       },
     ],

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -466,7 +466,8 @@ a.navbar__link svg use[href="#theme-svg-external-link"] {
   --sidebar-icon-color: currentColor;
 }
 
-.theme-doc-sidebar-menu .sidebar-icon-overview .menu__link {
+.theme-doc-sidebar-menu .sidebar-icon-overview > .menu__link,
+.theme-doc-sidebar-menu .sidebar-icon-overview > div.menu__list-item-collapsible > a.menu__link--sublist {
   --sidebar-icon-mask: url('/img/sidebar-icon-compass.svg');
   --sidebar-icon-color: currentColor;
 }


### PR DESCRIPTION
PR 13 of the Cloud IA rollout. Moves the three existing reference pages out of `reference/deployment/` to top-level Reference, renames each to the IA target title, adds redirects for every old URL, and scopes the Concepts category icon so it stops cascading to every child page.

## Changes

- `reference/deployment/handling-private-dependencies.md` to `reference/private-dependencies.md`, title "Handling private dependencies" to "Private dependencies".
- `reference/deployment/dart-sdk-versions.md` to `reference/dart-sdk-versions.md`, title "Dart SDK version handling" to "Dart SDK versions".
- `reference/project-id.md` to `reference/project-id-rules.md`, title "Project identifier" to "Project identifier rules".
- Each renamed page got a description in frontmatter so the page surfaces well in SEO and link previews.
- Empty `reference/deployment/` folder removed.
- `cli/_category_.json` position set to 4. Reference now reads: Dart SDK versions, Private dependencies, Project identifier rules, CLI. Putting CLI last is curated (it is a complex folder; keeping the smaller reference pages visible first); switch to alphabetical if you prefer.
- Three redirects in `docusaurus.config.js` for the old URLs.
- Cross-doc references updated in the Deployments concept, the Recover from a failed deploy guide, and the Related section inside `dart-sdk-versions.md`.
- `sidebar-icon-overview` CSS selector was using a descendant match and was applying the compass icon to every Concepts child page. Scoped it to direct child (`>`) so the icon now only appears on the Concepts category header. The framework's `how-it-works.md` page that also uses this class still picks up the icon via the leaf branch of the selector.

## Test plan

- [ ] `npm run build` passes
- [ ] Reference sidebar renders as: Dart SDK versions, Private dependencies, Project identifier rules, CLI
- [ ] Open `/cloud/reference/deployment/handling-private-dependencies`, `/cloud/reference/deployment/dart-sdk-versions`, `/cloud/reference/project-id` and confirm each redirects to the new path
- [ ] Concepts sidebar shows the compass icon only on the Concepts category header, not on Deployments, Logs, etc.
- [ ] How it works page in framework docs still shows the compass icon
- [ ] Cross-doc links in the Deployments concept and Recover guide resolve