### PR TITLE
fix: Fact-check of configuration, caching, logging, and modules

### DIFF
--- a/docs/06-concepts/07-configuration.md
+++ b/docs/06-concepts/07-configuration.md
@@ -1,4 +1,8 @@
-# Configurations
+---
+description: Configure Serverpod using YAML files, environment variables, or a Dart config object, with full reference tables for all available options.
+---
+
+# Configuration
 
 Serverpod can be configured in a few different ways. The minimum required settings to provide is the configuration for the API server. If no settings are provided at all, the default settings for the API server are used.
 
@@ -141,8 +145,6 @@ You can also define custom passwords using environment variables with the `SERVE
 | Environment variable format | Description                                                                                                                               |
 | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | SERVERPOD_PASSWORD\_\*      | Custom password that will be available in the Session.passwords map. The prefix `SERVERPOD_PASSWORD_` will be stripped from the key name. |
-
-**Example:**
 
 To define a custom password through an environment variable:
 

--- a/docs/06-concepts/08-caching.md
+++ b/docs/06-concepts/08-caching.md
@@ -1,3 +1,7 @@
+---
+description: Cache frequently requested objects in Serverpod using local server memory or a distributed Redis cache to reduce expensive database queries.
+---
+
 # Caching
 
 Accessing the database can be expensive for complex queries or if you need to run many different queries for a specific task. Serverpod makes it easy to cache frequently requested objects in the memory of your server. Any object can be cached, including primitive types (`int`, `String`, `DateTime`, `Duration`, `ByteData`, `UuidValue`), lists, maps, and serializable models. Objects can be stored in the Redis cache if your Serverpod is hosted across multiple servers in a cluster.
@@ -21,7 +25,7 @@ Future<UserData> getUserData(Session session, int userId) async {
   // If the object wasn't found in the cache, load it from the database and
   // save it in the cache. Make it valid for 5 minutes.
   if (userData == null) {
-    userData = UserData.db.findById(session, userId);
+    userData = await UserData.db.findById(session, userId);
     await session.caches.local.put(cacheKey, userData!, lifetime: Duration(minutes: 5));
   }
 
@@ -30,7 +34,7 @@ Future<UserData> getUserData(Session session, int userId) async {
 }
 ```
 
-In total, there are three caches where you can store your objects. Two caches are local to the server handling the current session, and one is distributed across the server cluster through Redis. There are two variants for the local cache: one regular cache, and a priority cache. Place objects that are frequently accessed in the priority cache.
+There are three caches where you can store your objects. Two caches are local to the server handling the current session, and one is distributed across the server cluster through Redis. There are two variants for the local cache: one regular cache, and a priority cache. Place objects that are frequently accessed in the priority cache.
 
 Depending on the type and number of objects that are cached in the global cache, you may want to specify custom caching rules in Redis. This is currently not handled automatically by Serverpod.
 
@@ -40,7 +44,7 @@ During development, you can run code that uses the global cache without a runnin
 
 ### Caching primitive objects
 
-To cache primitive objects, simply call the `put` method with the object. For the `get`, specify the object type as the generic parameter, just like for `SerializableModel` objects:
+To cache primitive objects, call the `put` method with the object. For the `get`, specify the object type as the generic parameter, just like for `SerializableModel` objects:
 
 ```dart
 await session.caches.local.put('userCount', 17, lifetime: Duration(minutes: 5));

--- a/docs/06-concepts/09-logging.md
+++ b/docs/06-concepts/09-logging.md
@@ -1,3 +1,7 @@
+---
+description: Log custom messages, exceptions, and queries in Serverpod using the session log method, with configurable retention, console output, and database storage.
+---
+
 # Logging
 
 Serverpod uses the database for storing logs; this makes it easy to search for errors, slow queries, or debug messages. To log custom messages during the execution of a session, use the `log` method of the `session` object. When the session is closed, either from successful execution or by failing from throwing an exception, the messages are written to the log. By default, session log entries are written for every completed session.
@@ -75,7 +79,7 @@ You can use the companion app  **[Serverpod Insights](../tools/insights)** to re
 
 Since log entries are stored in the database when persistent logging is enabled, the logs table can grow without bound if not purged. Serverpod can automatically purge logs based on configurable retention policies to prevent unchecked storage growth.
 
-##### Defaults values
+##### Default values
 
 - **Cleanup interval**: 24 hours — the cleanup job runs once per day.
 - **Retention period**: 90 days — removes entries older than this.

--- a/docs/06-concepts/10-modules.md
+++ b/docs/06-concepts/10-modules.md
@@ -1,5 +1,5 @@
 ---
-description: Add, reference, and create Serverpod modules — reusable packages that bundle server, client, and Flutter code with their own endpoints and database tables.
+description: Add, reference, and create Serverpod modules, reusable packages that bundle server, client, and Flutter code with their own endpoints and database tables.
 ---
 
 # Modules

--- a/docs/06-concepts/10-modules.md
+++ b/docs/06-concepts/10-modules.md
@@ -1,3 +1,7 @@
+---
+description: Add, reference, and create Serverpod modules — reusable packages that bundle server, client, and Flutter code with their own endpoints and database tables.
+---
+
 # Modules
 
 Serverpod is built around the concept of modules. A Serverpod module is similar to a Dart package but contains both server, client, and Flutter code. A module contains its own namespace for endpoints and methods to minimize the risk of conflicts.


### PR DESCRIPTION
## Summary

Fact-checked, removed noise, and added frontmatter to 4 pages.

**All 4 files:**
- Added missing `description` frontmatter

`07-configuration`:
- Title "Configurations" → "Configuration" (singular concept page)
- Removed redundant `**Example:**` label

`08-caching`:
- Fixed missing `await` on `UserData.db.findById` call (bug — assigns a `Future` not the resolved value)
- Removed "In total," filler
- Removed "simply" filler

`09-logging`:
- Fixed typo "Defaults values" → "Default values"

`10-modules`:
- No content changes beyond frontmatter