### PR TITLE
fix: Fact-check of webserver

### DIFF
--- a/docs/06-concepts/18-webserver/01-overview.md
+++ b/docs/06-concepts/18-webserver/01-overview.md
@@ -1,3 +1,7 @@
+---
+description: Serverpod's built-in web server, built on the Relic framework, lets you serve web pages, REST APIs, webhooks, and static files alongside your application server.
+---
+
 # Overview
 
 In addition to the application server, Serverpod comes with a built-in web server. The web server allows you to access your database and business layer the same way you would from a method call from an app. This makes it simple to share data for applications that need both an app and traditional web pages. You can also use the web server to create webhooks or define custom REST APIs to communicate with third-party services.
@@ -31,7 +35,7 @@ pod.webServer.addRoute(HelloRoute(), '/api/hello');
 await pod.start();
 ```
 
-Visit `http://localhost:8080/api/hello` to see your API response.
+Visit `http://localhost:8082/api/hello` to see your API response.
 
 ## Core concepts
 
@@ -87,7 +91,7 @@ Routes are matched in the order they were added.
 
 ## When to use what
 
-### Rest apis → custom routes
+### REST APIs → custom routes
 
 For REST APIs, webhooks, or custom HTTP handlers, use custom `Route` classes:
 

--- a/docs/06-concepts/18-webserver/02-routing.md
+++ b/docs/06-concepts/18-webserver/02-routing.md
@@ -1,8 +1,12 @@
+---
+description: Routing in Serverpod's web server supports HTTP method filtering, path parameters, wildcards, fallback handling, and virtual host routing.
+---
+
 # Routing
 
 Routes are the foundation of your web server, directing incoming HTTP requests
 to the right handlers. While simple routes work well for basic APIs, Serverpod
-provides powerful routing features for complex applications: HTTP method
+provides routing features for complex applications: HTTP method
 filtering, path parameters, wildcards, and fallback handling. Understanding
 these patterns helps you build clean, maintainable APIs.
 
@@ -58,7 +62,7 @@ The examples in this documentation omit error handling for brevity.
 
 :::
 
-## Http methods
+## HTTP methods
 
 Routes can specify which HTTP methods they respond to using the `methods`
 parameter.
@@ -201,7 +205,7 @@ pod.webServer.addRoute(UserCrudModule(), '/api/users');
 
 This creates `GET /api/users` and `GET /api/users/:id` endpoints.
 
-Note that handlers receive only a `Request` parameter. To access the `Session`,
+Handlers receive only a `Request` parameter. To access the `Session`,
 use `request.session` (unlike `Route.handleCall()` which receives both as
 explicit parameters).
 

--- a/docs/06-concepts/18-webserver/03-request-data.md
+++ b/docs/06-concepts/18-webserver/03-request-data.md
@@ -1,3 +1,7 @@
+---
+description: Request data in Serverpod's web server is accessible via Relic's type-safe accessors for path parameters, query parameters, headers, and the request body.
+---
+
 # Request Data
 
 Once a route matches, you'll need to extract data from the request. Relic

--- a/docs/06-concepts/18-webserver/04-middleware.md
+++ b/docs/06-concepts/18-webserver/04-middleware.md
@@ -1,3 +1,7 @@
+---
+description: Middleware in Serverpod's web server lets you apply cross-cutting concerns like authentication, logging, and CORS globally or to specific path prefixes.
+---
+
 # Middleware
 
 Routes handle the core logic of your application, but many concerns cut across
@@ -133,7 +137,7 @@ per-request state. For more details, see the [Relic documentation](https://docs.
 
 :::info
 
-Note that Serverpod's `Route.handleCall()` already receives a `Session` parameter
+Serverpod's `Route.handleCall()` already receives a `Session` parameter
 which includes authenticated user information if available. Use `ContextProperty`
 for web-specific request data that isn't part of the standard Session, such as
 request IDs, feature flags, or API version information extracted from headers.

--- a/docs/06-concepts/18-webserver/05-static-files.md
+++ b/docs/06-concepts/18-webserver/05-static-files.md
@@ -1,3 +1,7 @@
+---
+description: Static file serving in Serverpod supports automatic content-type detection, cache control headers, cache-busting, and conditional request handling.
+---
+
 # Static files
 
 Static assets like images, CSS, and JavaScript files are essential for web
@@ -70,7 +74,7 @@ pod.webServer.addRoute(
 );
 ```
 
-### Generating versioned urls
+### Generating versioned URLs
 
 Use the `assetPath()` method to generate cache-busted URLs for your assets:
 

--- a/docs/06-concepts/18-webserver/07-server-side-html.md
+++ b/docs/06-concepts/18-webserver/07-server-side-html.md
@@ -1,3 +1,7 @@
+---
+description: Server-side HTML rendering in Serverpod uses WidgetRoute and Mustache templates, with full access to the database and caching.
+---
+
 # Server-Side HTML
 
 For simple HTML pages, you can use `WidgetRoute` and `TemplateWidget`. The
@@ -107,10 +111,10 @@ class DataRoute extends WidgetRoute {
 
 :::info Alternative
 
-If you prefer [Jaspr](https://docs.page/schultek/jaspr), which provides a
-Flutter-like API for building web applications. You can integrate Jaspr with
-Serverpod's web server using custom `Route` classes, giving you full control
-over request handling while leveraging Jaspr's component model.
+[Jaspr](https://docs.page/schultek/jaspr) provides a Flutter-like API for
+building web applications. You can integrate it with Serverpod's web server
+using custom `Route` classes, giving you full control over request handling
+while using Jaspr's component model.
 
 :::
 

--- a/docs/06-concepts/18-webserver/08-single-page-apps.md
+++ b/docs/06-concepts/18-webserver/08-single-page-apps.md
@@ -1,3 +1,7 @@
+---
+description: Single page apps in Serverpod use SpaRoute to serve static files and fall back to index.html for client-side routing.
+---
+
 # Single page apps
 
 Single Page Applications (SPAs) handle routing on the client side, which requires special server configuration. When users navigate to a route like `/dashboard` or `/settings`, the browser requests that path from the server. Since these aren't real files, the server needs to return the main `index.html` file so the client-side router can handle the route.

--- a/docs/06-concepts/18-webserver/09-flutter-web.md
+++ b/docs/06-concepts/18-webserver/09-flutter-web.md
@@ -1,3 +1,7 @@
+---
+description: Flutter web app serving in Serverpod uses FlutterRoute to handle WASM multi-threading headers, SPA-style routing, and cache control.
+---
+
 # Flutter web apps
 
 Serverpod can serve your Flutter web application directly, allowing you to host both your API and web frontend from the same server. `FlutterRoute` handles the specifics of serving Flutter web apps, including WASM multi-threading headers and SPA-style routing.


### PR DESCRIPTION
## Summary

Fact-checked, removed noise, and added frontmatter to 8 webserver pages.

**All 8 files:**
- Added missing `description` frontmatter, with primary keyword leading each description for SEO

`01-overview`:
- `localhost:8080` → `localhost:8082` — web server routes are served on the web server port, not the API port (factual fix)
- "Rest apis" → "REST APIs"

`02-routing`:
- "Http methods" → "HTTP methods"

`04-middleware`:
- Removed "Note that" weak lead-in from info callout

`05-static-files`:
- "versioned urls" → "versioned URLs"

`07-server-side-html`:
- Fixed "If you prefer [Jaspr]..." sentence fragment in the Alternative callout

`03-request-data`, `08-single-page-apps`, `09-flutter-web`:
- Frontmatter only