### PR TITLE
docs: Make authentication overview headings descriptive

### DIFF
--- a/docs/06-concepts/11-authentication/01-get-started.md
+++ b/docs/06-concepts/11-authentication/01-get-started.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Get started
-description: Turn on the built-in sign-in screen, run your Serverpod app, and test signing up and signing in.
+description: Authentication is built into every new Serverpod project. Turn on the sign-in screen, run your app, and test signing up and signing in.
 ---
 
 # Get started with authentication

--- a/docs/06-concepts/11-authentication/01-get-started.md
+++ b/docs/06-concepts/11-authentication/01-get-started.md
@@ -1,5 +1,6 @@
 ---
 sidebar_label: Get started
+description: Turn on the built-in sign-in screen, run your Serverpod app, and test signing up and signing in.
 ---
 
 # Get started with authentication

--- a/docs/06-concepts/11-authentication/01-setup.md
+++ b/docs/06-concepts/11-authentication/01-setup.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Setup
-description: Install and configure the serverpod_auth_idp module to add user management and authentication to your Serverpod project.
+description: Authentication in Serverpod is provided by the serverpod_auth_idp module. Install and configure it to add user management and sign-in to your project.
 ---
 
 # Set up the authentication module

--- a/docs/06-concepts/11-authentication/01-setup.md
+++ b/docs/06-concepts/11-authentication/01-setup.md
@@ -1,4 +1,9 @@
-# Setup
+---
+sidebar_label: Setup
+description: Install and configure the serverpod_auth_idp module to add user management and authentication to your Serverpod project.
+---
+
+# Set up the authentication module
 
 Serverpod comes with built-in user management and authentication. It is possible to build a [custom authentication implementation](custom-overrides), but the recommended way to authenticate users is to use the `serverpod_auth_idp` module. The module makes it easy to authenticate with email, social sign-ins and more.
 

--- a/docs/06-concepts/11-authentication/02-basics.md
+++ b/docs/06-concepts/11-authentication/02-basics.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: The basics
-description: Learn how Serverpod handles authentication tokens automatically and how to access the signed-in user from the Session object.
+description: Authentication tokens are handled automatically by Serverpod. Learn how to access the signed-in user from the Session object.
 ---
 
 # Authentication basics

--- a/docs/06-concepts/11-authentication/02-basics.md
+++ b/docs/06-concepts/11-authentication/02-basics.md
@@ -1,4 +1,9 @@
-# The basics
+---
+sidebar_label: The basics
+description: Learn how Serverpod handles authentication tokens automatically and how to access the signed-in user from the Session object.
+---
+
+# Authentication basics
 
 Serverpod automatically checks if the user is logged in and if the user has the right privileges to access each endpoint. When using the Serverpod Authentication modules, you will not have to worry about keeping track of tokens, refreshing them or even including them in requests as this all happens automatically under the hood.
 

--- a/docs/06-concepts/11-authentication/03-working-with-users.md
+++ b/docs/06-concepts/11-authentication/03-working-with-users.md
@@ -1,5 +1,5 @@
 ---
-description: Access authenticated users and their profile data, and learn how user identifiers work across your Serverpod server.
+description: Authenticated users have a stable identifier across your server. Access them and their profile data from the Session object.
 ---
 
 # Working with users

--- a/docs/06-concepts/11-authentication/03-working-with-users.md
+++ b/docs/06-concepts/11-authentication/03-working-with-users.md
@@ -1,3 +1,7 @@
+---
+description: Access authenticated users and their profile data, and learn how user identifiers work across your Serverpod server.
+---
+
 # Working with users
 
 The authentication module provides convenient ways to work with your authenticated users and their related profile data.

--- a/docs/06-concepts/11-authentication/06-ui-components.md
+++ b/docs/06-concepts/11-authentication/06-ui-components.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: UI Components
-description: Build authentication interfaces with Serverpod's ready-made widgets and controllers, including the all-in-one SignInWidget.
+description: Authentication UI components and controllers let you build sign-in, registration, and password flows, including the all-in-one SignInWidget.
 ---
 
 # Authentication UI components

--- a/docs/06-concepts/11-authentication/06-ui-components.md
+++ b/docs/06-concepts/11-authentication/06-ui-components.md
@@ -1,4 +1,9 @@
-# UI Components
+---
+sidebar_label: UI Components
+description: Build authentication interfaces with Serverpod's ready-made widgets and controllers, including the all-in-one SignInWidget.
+---
+
+# Authentication UI components
 
 The authentication system provides a comprehensive set of UI components and controllers for building authentication interfaces. These components handle the complete authentication flow, including sign-in, registration, and password management.
 

--- a/docs/06-concepts/11-authentication/10-custom-overrides.md
+++ b/docs/06-concepts/11-authentication/10-custom-overrides.md
@@ -1,4 +1,9 @@
-# Custom overrides
+---
+sidebar_label: Custom overrides
+description: Implement your own authentication handling in Serverpod when the serverpod_auth_idp module does not fit your requirements.
+---
+
+# Custom authentication overrides
 
 It is recommended to use the `serverpod_auth_idp` package but if you have special requirements not fulfilled by it, you can implement your authentication module. Serverpod is designed to make it easy to add custom authentication overrides.
 

--- a/docs/06-concepts/11-authentication/10-custom-overrides.md
+++ b/docs/06-concepts/11-authentication/10-custom-overrides.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Custom overrides
-description: Implement your own authentication handling in Serverpod when the serverpod_auth_idp module does not fit your requirements.
+description: Custom authentication overrides let you implement your own handling when the serverpod_auth_idp module does not fit your requirements.
 ---
 
 # Custom authentication overrides


### PR DESCRIPTION
Makes the first heading on each top-level authentication page more descriptive so each page reads clearly out of context (for example, "Setup" becomes "Set up the authentication module"), and adds a `description` to the frontmatter of every page. Where a heading was lengthened, a `sidebar_label` keeps the sidebar name short.

Pages updated: Get started, Setup, The basics, Working with users, UI components, and Custom overrides.

First of four PRs splitting the same heading and description change across the authentication section. The providers, token managers, and legacy sections follow in separate PRs once this one is reviewed.

Part of #610