### PR TITLE
docs: Make auth provider headings descriptive

### DIFF
--- a/docs/06-concepts/11-authentication/04-providers/01-anonymous/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/01-anonymous/01-setup.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Setup
-description: Anonymous authentication lets users access your app without an account. Enable it in your Serverpod auth configuration.
+description: Anonymous authentication lets users access your app without creating an account. Enable it in your Serverpod auth configuration to get started.
 ---
 
 # Set up anonymous sign-in

--- a/docs/06-concepts/11-authentication/04-providers/01-anonymous/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/01-anonymous/01-setup.md
@@ -1,4 +1,9 @@
-# Setup
+---
+sidebar_label: Setup
+description: Anonymous authentication lets users access your app without an account. Enable it in your Serverpod auth configuration.
+---
+
+# Set up anonymous sign-in
 
 :::warning
 The Anonymous identity provider is **experimental** and can not be completely used yet due to the missing support for account linking. The missing parts will be added in the next releases.

--- a/docs/06-concepts/11-authentication/04-providers/01-anonymous/02-configuration.md
+++ b/docs/06-concepts/11-authentication/04-providers/01-anonymous/02-configuration.md
@@ -1,4 +1,9 @@
-# Configuration
+---
+sidebar_label: Configuration
+description: Anonymous authentication can take an app attestation token to protect sign-in from abuse. Configure this and other options for the provider.
+---
+
+# Configure anonymous sign-in
 
 This page covers configuration options for the anonymous identity provider beyond the basic setup.
 

--- a/docs/06-concepts/11-authentication/04-providers/01-anonymous/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/01-anonymous/03-customizing-the-ui.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Customizing the UI
-description: Anonymous sign-in UI can be customized with the AnonymousSignInWidget and AnonymousAuthController to fit your app.
+description: Anonymous sign-in UI can be customized with the AnonymousSignInWidget and AnonymousAuthController to match the rest of your app's design.
 ---
 
 # Customize the anonymous sign-in UI

--- a/docs/06-concepts/11-authentication/04-providers/01-anonymous/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/01-anonymous/03-customizing-the-ui.md
@@ -1,4 +1,9 @@
-# Customizing the UI
+---
+sidebar_label: Customizing the UI
+description: Anonymous sign-in UI can be customized with the AnonymousSignInWidget and AnonymousAuthController to fit your app.
+---
+
+# Customize the anonymous sign-in UI
 
 When using the anonymous identity provider, you can customize the UI to your liking. You can use the `AnonymousSignInWidget` to display the anonymous sign-in button in your own layout, or you can use the `AnonymousAuthController` to build a completely custom authentication interface.
 

--- a/docs/06-concepts/11-authentication/04-providers/02-email/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/02-email/01-setup.md
@@ -3,7 +3,7 @@ sidebar_label: Setup
 description: Sign in with Email lets users authenticate with an email and password. Connect Serverpod to an SMTP service and configure the email identity provider.
 ---
 
-# Set up Sign in with Email
+# Set up email sign-in
 
 To properly configure Sign in with Email, you must connect your Serverpod to an external service that can send the emails. One convenient option is the [mailer](https://pub.dev/packages/mailer) package, which can send emails through any SMTP service. Most email providers, such as Resend, Sendgrid or Mandrill, support SMTP.
 

--- a/docs/06-concepts/11-authentication/04-providers/02-email/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/02-email/01-setup.md
@@ -1,4 +1,9 @@
-# Setup
+---
+sidebar_label: Setup
+description: Sign in with Email lets users authenticate with an email and password. Connect Serverpod to an SMTP service and configure the email identity provider.
+---
+
+# Set up Sign in with Email
 
 To properly configure Sign in with Email, you must connect your Serverpod to an external service that can send the emails. One convenient option is the [mailer](https://pub.dev/packages/mailer) package, which can send emails through any SMTP service. Most email providers, such as Resend, Sendgrid or Mandrill, support SMTP.
 

--- a/docs/06-concepts/11-authentication/04-providers/02-email/02-configuration.md
+++ b/docs/06-concepts/11-authentication/04-providers/02-email/02-configuration.md
@@ -1,4 +1,9 @@
-# Configuration
+---
+sidebar_label: Configuration
+description: Email identity provider options include password peppering and other security settings. Configure them beyond the basic setup.
+---
+
+# Configure Sign in with Email
 
 This page covers configuration options for the email identity provider beyond the basic setup.
 

--- a/docs/06-concepts/11-authentication/04-providers/02-email/02-configuration.md
+++ b/docs/06-concepts/11-authentication/04-providers/02-email/02-configuration.md
@@ -3,7 +3,7 @@ sidebar_label: Configuration
 description: Email identity provider options include password peppering and other security settings. Configure them beyond the basic setup.
 ---
 
-# Configure Sign in with Email
+# Configure email sign-in
 
 This page covers configuration options for the email identity provider beyond the basic setup.
 

--- a/docs/06-concepts/11-authentication/04-providers/02-email/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/02-email/03-customizing-the-ui.md
@@ -1,4 +1,9 @@
-# Customizing the UI
+---
+sidebar_label: Customizing the UI
+description: Email sign-in UI can be customized with the EmailSignInWidget and EmailAuthController to build a custom authentication flow.
+---
+
+# Customize the Sign in with Email UI
 
 When using the email identity provider, you can customize the UI to your liking. You can use the `EmailSignInWidget` to display the email authentication flow in your own custom UI, or you can use the `EmailAuthController` to build a completely custom authentication interface.
 

--- a/docs/06-concepts/11-authentication/04-providers/02-email/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/02-email/03-customizing-the-ui.md
@@ -3,7 +3,7 @@ sidebar_label: Customizing the UI
 description: Email sign-in UI can be customized with the EmailSignInWidget and EmailAuthController to build a custom authentication flow.
 ---
 
-# Customize the Sign in with Email UI
+# Customize the email sign-in UI
 
 When using the email identity provider, you can customize the UI to your liking. You can use the `EmailSignInWidget` to display the email authentication flow in your own custom UI, or you can use the `EmailAuthController` to build a completely custom authentication interface.
 

--- a/docs/06-concepts/11-authentication/04-providers/02-email/04-admin-operations.md
+++ b/docs/06-concepts/11-authentication/04-providers/02-email/04-admin-operations.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Admin Operations
-description: Email admin operations manage email accounts and clean up expired or dangling requests through the EmailIdpAdmin.
+description: Email admin operations manage email accounts and clean up expired or dangling verification requests through the EmailIdpAdmin server-side API.
 ---
 
 # Email admin operations

--- a/docs/06-concepts/11-authentication/04-providers/02-email/04-admin-operations.md
+++ b/docs/06-concepts/11-authentication/04-providers/02-email/04-admin-operations.md
@@ -1,4 +1,9 @@
-# Admin Operations
+---
+sidebar_label: Admin Operations
+description: Email admin operations manage email accounts and clean up expired or dangling requests through the EmailIdpAdmin.
+---
+
+# Email admin operations
 
 The email identity provider provides admin operations through `EmailIdpAdmin` for managing email accounts and cleaning up expired or dangling requests. These operations are useful for administrative tasks, maintenance, and preventing database bloat.
 

--- a/docs/06-concepts/11-authentication/04-providers/03-google/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/03-google/01-setup.md
@@ -1,4 +1,9 @@
-# Setup
+---
+sidebar_label: Setup
+description: Sign in with Google requires Google Cloud OAuth credentials. Create them for your platforms and add the provider to your Serverpod app.
+---
+
+# Set up Sign in with Google
 
 Sign in with Google requires a Google Cloud project. You also need platform-specific OAuth credentials depending on which platforms you target.
 

--- a/docs/06-concepts/11-authentication/04-providers/03-google/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/03-google/01-setup.md
@@ -3,7 +3,7 @@ sidebar_label: Setup
 description: Sign in with Google requires Google Cloud OAuth credentials. Create them for your platforms and add the provider to your Serverpod app.
 ---
 
-# Set up Sign in with Google
+# Set up Google sign-in
 
 Sign in with Google requires a Google Cloud project. You also need platform-specific OAuth credentials depending on which platforms you target.
 

--- a/docs/06-concepts/11-authentication/04-providers/03-google/02-customizations.md
+++ b/docs/06-concepts/11-authentication/04-providers/03-google/02-customizations.md
@@ -3,7 +3,7 @@ sidebar_label: Customizations
 description: Sign in with Google can be configured through GoogleIdpConfig, including how to load client secrets and use the available callbacks.
 ---
 
-# Customize Sign in with Google
+# Customize Google sign-in
 
 This page covers additional configuration options for the Google identity provider beyond the basic setup.
 

--- a/docs/06-concepts/11-authentication/04-providers/03-google/02-customizations.md
+++ b/docs/06-concepts/11-authentication/04-providers/03-google/02-customizations.md
@@ -1,4 +1,9 @@
-# Customizations
+---
+sidebar_label: Customizations
+description: Sign in with Google can be configured through GoogleIdpConfig, including how to load client secrets and use the available callbacks.
+---
+
+# Customize Sign in with Google
 
 This page covers additional configuration options for the Google identity provider beyond the basic setup.
 

--- a/docs/06-concepts/11-authentication/04-providers/03-google/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/03-google/03-customizing-the-ui.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Customizing the UI
-description: Google sign-in UI can be customized with the GoogleSignInWidget and GoogleAuthController to build a custom flow.
+description: Google sign-in UI can be customized with the GoogleSignInWidget and GoogleAuthController to build a custom authentication flow in your app.
 ---
 
 # Customize the Google sign-in UI

--- a/docs/06-concepts/11-authentication/04-providers/03-google/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/03-google/03-customizing-the-ui.md
@@ -1,4 +1,9 @@
-# Customizing the UI
+---
+sidebar_label: Customizing the UI
+description: Google sign-in UI can be customized with the GoogleSignInWidget and GoogleAuthController to build a custom flow.
+---
+
+# Customize the Google sign-in UI
 
 When using the Google identity provider, you can customize the UI to your liking. You can use the `GoogleSignInWidget` to display the Google Sign-In flow in your own custom UI, or you can use the `GoogleAuthController` to build a completely custom authentication interface.
 

--- a/docs/06-concepts/11-authentication/04-providers/03-google/04-troubleshooting.md
+++ b/docs/06-concepts/11-authentication/04-providers/03-google/04-troubleshooting.md
@@ -1,4 +1,9 @@
-# Troubleshooting
+---
+sidebar_label: Troubleshooting
+description: Sign in with Google failures, from setup mistakes to platform-specific errors, and how to diagnose and fix them.
+---
+
+# Troubleshoot Sign in with Google
 
 This page helps you identify common Sign in with Google failures, explains why they occur, and shows how to resolve them. For platform-specific issues with the underlying Flutter package, see the [google_sign_in_android troubleshooting guide](https://pub.dev/packages/google_sign_in_android#troubleshooting).
 

--- a/docs/06-concepts/11-authentication/04-providers/03-google/04-troubleshooting.md
+++ b/docs/06-concepts/11-authentication/04-providers/03-google/04-troubleshooting.md
@@ -1,9 +1,9 @@
 ---
 sidebar_label: Troubleshooting
-description: Sign in with Google failures, from setup mistakes to platform-specific errors, and how to diagnose and fix them.
+description: Sign in with Google failures, from setup mistakes to platform-specific errors, and how to diagnose and resolve each one in your Serverpod app.
 ---
 
-# Troubleshoot Sign in with Google
+# Troubleshoot Google sign-in
 
 This page helps you identify common Sign in with Google failures, explains why they occur, and shows how to resolve them. For platform-specific issues with the underlying Flutter package, see the [google_sign_in_android troubleshooting guide](https://pub.dev/packages/google_sign_in_android#troubleshooting).
 

--- a/docs/06-concepts/11-authentication/04-providers/04-apple/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/04-apple/01-setup.md
@@ -3,7 +3,7 @@ sidebar_label: Setup
 description: Sign in with Apple requires Apple credentials and platform setup. Register them and add the provider to your Serverpod app across iOS, macOS, Android, and Web.
 ---
 
-# Set up Sign in with Apple
+# Set up Apple sign-in
 
 ## Prerequisites
 

--- a/docs/06-concepts/11-authentication/04-providers/04-apple/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/04-apple/01-setup.md
@@ -1,4 +1,9 @@
-# Setup
+---
+sidebar_label: Setup
+description: Sign in with Apple requires Apple credentials and platform setup. Register them and add the provider to your Serverpod app across iOS, macOS, Android, and Web.
+---
+
+# Set up Sign in with Apple
 
 ## Prerequisites
 

--- a/docs/06-concepts/11-authentication/04-providers/04-apple/02-customizations.md
+++ b/docs/06-concepts/11-authentication/04-providers/04-apple/02-customizations.md
@@ -1,4 +1,9 @@
-# Customizations
+---
+sidebar_label: Customizations
+description: Sign in with Apple can be configured through AppleIdpConfig, including how to load credentials and use the available options.
+---
+
+# Customize Sign in with Apple
 
 This page covers additional configuration options for the Apple identity provider beyond the basic setup.
 

--- a/docs/06-concepts/11-authentication/04-providers/04-apple/02-customizations.md
+++ b/docs/06-concepts/11-authentication/04-providers/04-apple/02-customizations.md
@@ -3,7 +3,7 @@ sidebar_label: Customizations
 description: Sign in with Apple can be configured through AppleIdpConfig, including how to load credentials and use the available options.
 ---
 
-# Customize Sign in with Apple
+# Customize Apple sign-in
 
 This page covers additional configuration options for the Apple identity provider beyond the basic setup.
 

--- a/docs/06-concepts/11-authentication/04-providers/04-apple/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/04-apple/03-customizing-the-ui.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Customizing the UI
-description: Apple sign-in UI can be customized with the AppleSignInWidget and AppleAuthController to build a custom flow.
+description: Apple sign-in UI can be customized with the AppleSignInWidget and AppleAuthController to build a custom authentication flow in your app.
 ---
 
 # Customize the Apple sign-in UI

--- a/docs/06-concepts/11-authentication/04-providers/04-apple/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/04-apple/03-customizing-the-ui.md
@@ -1,4 +1,9 @@
-# Customizing the UI
+---
+sidebar_label: Customizing the UI
+description: Apple sign-in UI can be customized with the AppleSignInWidget and AppleAuthController to build a custom flow.
+---
+
+# Customize the Apple sign-in UI
 
 When using the Apple identity provider, you can customize the UI to your liking. You can use the `AppleSignInWidget` to display the Apple Sign-In flow in your own custom UI, or you can use the `AppleAuthController` to build a completely custom authentication interface.
 

--- a/docs/06-concepts/11-authentication/04-providers/04-apple/04-troubleshooting.md
+++ b/docs/06-concepts/11-authentication/04-providers/04-apple/04-troubleshooting.md
@@ -1,4 +1,9 @@
-# Troubleshooting
+---
+sidebar_label: Troubleshooting
+description: Sign in with Apple failures, from setup mistakes to OAuth response errors, and how to diagnose and fix them.
+---
+
+# Troubleshoot Sign in with Apple
 
 This page helps you identify common Sign in with Apple failures, explains why they occur, and shows how to resolve them. For Apple's full list of OAuth error codes, see [TN3107: Resolving Sign in with Apple response errors](https://developer.apple.com/documentation/technotes/tn3107-resolving-sign-in-with-apple-response-errors).
 

--- a/docs/06-concepts/11-authentication/04-providers/04-apple/04-troubleshooting.md
+++ b/docs/06-concepts/11-authentication/04-providers/04-apple/04-troubleshooting.md
@@ -1,9 +1,9 @@
 ---
 sidebar_label: Troubleshooting
-description: Sign in with Apple failures, from setup mistakes to OAuth response errors, and how to diagnose and fix them.
+description: Sign in with Apple failures, from setup mistakes to OAuth response errors, and how to diagnose and resolve each one in your Serverpod app.
 ---
 
-# Troubleshoot Sign in with Apple
+# Troubleshoot Apple sign-in
 
 This page helps you identify common Sign in with Apple failures, explains why they occur, and shows how to resolve them. For Apple's full list of OAuth error codes, see [TN3107: Resolving Sign in with Apple response errors](https://developer.apple.com/documentation/technotes/tn3107-resolving-sign-in-with-apple-response-errors).
 

--- a/docs/06-concepts/11-authentication/04-providers/05-facebook/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/05-facebook/01-setup.md
@@ -3,7 +3,7 @@ sidebar_label: Setup
 description: Sign in with Facebook uses a Facebook Login app and an extra provider package. Create the app and add the provider to your Serverpod app.
 ---
 
-# Set up Sign in with Facebook
+# Set up Facebook sign-in
 
 Facebook authentication in Serverpod is provided through an external package that handles the complete sign-in flow on iOS, Android, Web, and macOS. Unlike other providers built into the core auth module, Facebook Sign-In requires an additional package installation.
 

--- a/docs/06-concepts/11-authentication/04-providers/05-facebook/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/05-facebook/01-setup.md
@@ -1,4 +1,9 @@
-# Setup
+---
+sidebar_label: Setup
+description: Sign in with Facebook uses a Facebook Login app and an extra provider package. Create the app and add the provider to your Serverpod app.
+---
+
+# Set up Sign in with Facebook
 
 Facebook authentication in Serverpod is provided through an external package that handles the complete sign-in flow on iOS, Android, Web, and macOS. Unlike other providers built into the core auth module, Facebook Sign-In requires an additional package installation.
 

--- a/docs/06-concepts/11-authentication/04-providers/05-facebook/02-configuration.md
+++ b/docs/06-concepts/11-authentication/04-providers/05-facebook/02-configuration.md
@@ -3,7 +3,7 @@ sidebar_label: Configuration
 description: Facebook identity provider options include custom validation of account details before sign-in. Configure them beyond the basic setup.
 ---
 
-# Configure Sign in with Facebook
+# Configure Facebook sign-in
 
 This page covers configuration options for the Facebook identity provider beyond the basic setup.
 

--- a/docs/06-concepts/11-authentication/04-providers/05-facebook/02-configuration.md
+++ b/docs/06-concepts/11-authentication/04-providers/05-facebook/02-configuration.md
@@ -1,4 +1,9 @@
-# Configuration
+---
+sidebar_label: Configuration
+description: Facebook identity provider options include custom validation of account details before sign-in. Configure them beyond the basic setup.
+---
+
+# Configure Sign in with Facebook
 
 This page covers configuration options for the Facebook identity provider beyond the basic setup.
 

--- a/docs/06-concepts/11-authentication/04-providers/05-facebook/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/05-facebook/03-customizing-the-ui.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Customizing the UI
-description: Facebook sign-in UI can be customized with the FacebookSignInWidget and FacebookAuthController to build a custom flow.
+description: Facebook sign-in UI can be customized with the FacebookSignInWidget and FacebookAuthController to build a custom authentication flow in your app.
 ---
 
 # Customize the Facebook sign-in UI

--- a/docs/06-concepts/11-authentication/04-providers/05-facebook/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/05-facebook/03-customizing-the-ui.md
@@ -1,4 +1,9 @@
-# Customizing the UI
+---
+sidebar_label: Customizing the UI
+description: Facebook sign-in UI can be customized with the FacebookSignInWidget and FacebookAuthController to build a custom flow.
+---
+
+# Customize the Facebook sign-in UI
 
 When using the Facebook identity provider, you can customize the UI to your liking. You can use the `FacebookSignInWidget` to display the Facebook Sign-In flow in your own custom UI, or you can use the `FacebookAuthController` to build a completely custom authentication interface.
 

--- a/docs/06-concepts/11-authentication/04-providers/06-firebase/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/06-firebase/01-setup.md
@@ -1,4 +1,9 @@
-# Setup
+---
+sidebar_label: Setup
+description: Firebase authentication connects any Firebase sign-in method to your Serverpod backend and syncs the authenticated user with a server-side session.
+---
+
+# Set up Firebase authentication
 
 Firebase authentication lets you use any Firebase sign-in method (email/password, phone, Google, Apple, Facebook, etc.) with your Serverpod backend. Firebase handles the sign-in flow through its own SDKs, while Serverpod syncs the authenticated user and manages the server-side session.
 

--- a/docs/06-concepts/11-authentication/04-providers/06-firebase/02-customizations.md
+++ b/docs/06-concepts/11-authentication/04-providers/06-firebase/02-customizations.md
@@ -1,4 +1,9 @@
-# Customizations
+---
+sidebar_label: Customizations
+description: Firebase identity provider credentials can be loaded from different sources with FirebaseIdpConfig. Configure the provider beyond the basic setup.
+---
+
+# Customize Firebase authentication
 
 This page covers additional configuration options for the Firebase identity provider beyond the basic setup.
 

--- a/docs/06-concepts/11-authentication/04-providers/06-firebase/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/06-firebase/03-customizing-the-ui.md
@@ -1,4 +1,9 @@
-# Customizing the UI
+---
+sidebar_label: Customizing the UI
+description: Firebase authentication UI is built on firebase_auth and synced with Serverpod through the FirebaseAuthController.
+---
+
+# Customize the Firebase authentication UI
 
 When using the Firebase identity provider, you build your authentication UI on top of [`firebase_auth`](https://pub.dev/packages/firebase_auth), optionally with [`firebase_ui_auth`](https://pub.dev/packages/firebase_ui_auth) for the pre-built sign-in screens. The [`FirebaseAuthController`](https://pub.dev/documentation/serverpod_auth_idp_flutter_firebase/latest/serverpod_auth_idp_flutter_firebase/FirebaseAuthController-class.html) handles syncing the authenticated Firebase user with your Serverpod backend. This page breaks down the gate widget shown in the [setup guide](./setup#present-the-authentication-ui) and then covers building a fully custom UI with `firebase_auth` directly.
 

--- a/docs/06-concepts/11-authentication/04-providers/06-firebase/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/06-firebase/03-customizing-the-ui.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Customizing the UI
-description: Firebase authentication UI is built on firebase_auth and synced with Serverpod through the FirebaseAuthController.
+description: Firebase authentication UI is built on the firebase_auth package and synced with your Serverpod backend through the FirebaseAuthController.
 ---
 
 # Customize the Firebase authentication UI

--- a/docs/06-concepts/11-authentication/04-providers/06-firebase/04-admin-operations.md
+++ b/docs/06-concepts/11-authentication/04-providers/06-firebase/04-admin-operations.md
@@ -1,4 +1,9 @@
-# Admin operations
+---
+sidebar_label: Admin operations
+description: Firebase admin operations manage Firebase-authenticated accounts from secure server-side code through the FirebaseIdpAdmin.
+---
+
+# Firebase admin operations
 
 The Firebase identity provider provides admin operations through `FirebaseIdpAdmin` for managing Firebase-authenticated accounts on the server. Common use cases include linking an existing Serverpod user to a Firebase account, looking up accounts for support tools, and cleaning up orphaned accounts.
 

--- a/docs/06-concepts/11-authentication/04-providers/06-firebase/05-troubleshooting.md
+++ b/docs/06-concepts/11-authentication/04-providers/06-firebase/05-troubleshooting.md
@@ -1,4 +1,9 @@
-# Troubleshooting
+---
+sidebar_label: Troubleshooting
+description: Firebase authentication failures with Serverpod, and how to diagnose and fix them.
+---
+
+# Troubleshoot Firebase authentication
 
 This page helps you identify common Firebase authentication failures with Serverpod, explains why they occur, and shows how to resolve them. For issues with Firebase itself, see the [Firebase Auth documentation](https://firebase.google.com/docs/auth).
 

--- a/docs/06-concepts/11-authentication/04-providers/06-firebase/05-troubleshooting.md
+++ b/docs/06-concepts/11-authentication/04-providers/06-firebase/05-troubleshooting.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Troubleshooting
-description: Firebase authentication failures with Serverpod, and how to diagnose and fix them.
+description: Firebase authentication failures when using Firebase with Serverpod, with the cause of each one and the steps to diagnose and resolve it.
 ---
 
 # Troubleshoot Firebase authentication

--- a/docs/06-concepts/11-authentication/04-providers/07-github/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/07-github/01-setup.md
@@ -1,4 +1,9 @@
-# Setup
+---
+sidebar_label: Setup
+description: Sign in with GitHub uses OAuth2 credentials from a GitHub App. Register the app and add the provider to your Serverpod app.
+---
+
+# Set up Sign in with GitHub
 
 Sign in with GitHub uses OAuth2 credentials from a **GitHub App** registered on GitHub.
 

--- a/docs/06-concepts/11-authentication/04-providers/07-github/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/07-github/01-setup.md
@@ -3,7 +3,7 @@ sidebar_label: Setup
 description: Sign in with GitHub uses OAuth2 credentials from a GitHub App. Register the app and add the provider to your Serverpod app.
 ---
 
-# Set up Sign in with GitHub
+# Set up GitHub sign-in
 
 Sign in with GitHub uses OAuth2 credentials from a **GitHub App** registered on GitHub.
 

--- a/docs/06-concepts/11-authentication/04-providers/07-github/02-customizations.md
+++ b/docs/06-concepts/11-authentication/04-providers/07-github/02-customizations.md
@@ -3,7 +3,7 @@ sidebar_label: Customizations
 description: Sign in with GitHub can be configured through GitHubIdpConfig, including how to load credentials and use the available callbacks.
 ---
 
-# Customize Sign in with GitHub
+# Customize GitHub sign-in
 
 This page covers additional configuration options for the GitHub identity provider beyond the basic setup.
 

--- a/docs/06-concepts/11-authentication/04-providers/07-github/02-customizations.md
+++ b/docs/06-concepts/11-authentication/04-providers/07-github/02-customizations.md
@@ -1,4 +1,9 @@
-# Customizations
+---
+sidebar_label: Customizations
+description: Sign in with GitHub can be configured through GitHubIdpConfig, including how to load credentials and use the available callbacks.
+---
+
+# Customize Sign in with GitHub
 
 This page covers additional configuration options for the GitHub identity provider beyond the basic setup.
 

--- a/docs/06-concepts/11-authentication/04-providers/07-github/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/07-github/03-customizing-the-ui.md
@@ -1,4 +1,9 @@
-# Customizing the UI
+---
+sidebar_label: Customizing the UI
+description: GitHub sign-in UI can be customized with the GitHubSignInWidget and GitHubAuthController to build a custom flow.
+---
+
+# Customize the GitHub sign-in UI
 
 When using the GitHub identity provider, you can customize the UI to your liking. You can use the `GitHubSignInWidget` to display the GitHub Sign-In flow in your own custom UI, or you can use the `GitHubAuthController` to build a completely custom authentication interface.
 

--- a/docs/06-concepts/11-authentication/04-providers/07-github/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/07-github/03-customizing-the-ui.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Customizing the UI
-description: GitHub sign-in UI can be customized with the GitHubSignInWidget and GitHubAuthController to build a custom flow.
+description: GitHub sign-in UI can be customized with the GitHubSignInWidget and GitHubAuthController to build a custom authentication flow in your app.
 ---
 
 # Customize the GitHub sign-in UI

--- a/docs/06-concepts/11-authentication/04-providers/07-github/04-troubleshooting.md
+++ b/docs/06-concepts/11-authentication/04-providers/07-github/04-troubleshooting.md
@@ -1,9 +1,9 @@
 ---
 sidebar_label: Troubleshooting
-description: Sign in with GitHub failures, from setup mistakes to OAuth callback errors, and how to diagnose and fix them.
+description: Sign in with GitHub failures, from setup mistakes to OAuth callback errors, and how to diagnose and resolve each one in your Serverpod app.
 ---
 
-# Troubleshoot Sign in with GitHub
+# Troubleshoot GitHub sign-in
 
 This page helps you identify common Sign in with GitHub failures, explains why they occur, and shows how to resolve them. For underlying issues with the OAuth callback library, see the [flutter_web_auth_2 documentation](https://pub.dev/packages/flutter_web_auth_2).
 

--- a/docs/06-concepts/11-authentication/04-providers/07-github/04-troubleshooting.md
+++ b/docs/06-concepts/11-authentication/04-providers/07-github/04-troubleshooting.md
@@ -1,4 +1,9 @@
-# Troubleshooting
+---
+sidebar_label: Troubleshooting
+description: Sign in with GitHub failures, from setup mistakes to OAuth callback errors, and how to diagnose and fix them.
+---
+
+# Troubleshoot Sign in with GitHub
 
 This page helps you identify common Sign in with GitHub failures, explains why they occur, and shows how to resolve them. For underlying issues with the OAuth callback library, see the [flutter_web_auth_2 documentation](https://pub.dev/packages/flutter_web_auth_2).
 

--- a/docs/06-concepts/11-authentication/04-providers/08-microsoft/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/08-microsoft/01-setup.md
@@ -3,7 +3,7 @@ sidebar_label: Setup
 description: Sign in with Microsoft uses a Microsoft Entra ID app registration. Create it and add the provider to your Serverpod app.
 ---
 
-# Set up Sign in with Microsoft
+# Set up Microsoft sign-in
 
 To set up **Sign in with Microsoft**, you must create an app registration on [Microsoft Entra ID (formerly Azure AD)](https://portal.azure.com/) and configure your Serverpod application accordingly.
 

--- a/docs/06-concepts/11-authentication/04-providers/08-microsoft/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/08-microsoft/01-setup.md
@@ -1,4 +1,9 @@
-# Setup
+---
+sidebar_label: Setup
+description: Sign in with Microsoft uses a Microsoft Entra ID app registration. Create it and add the provider to your Serverpod app.
+---
+
+# Set up Sign in with Microsoft
 
 To set up **Sign in with Microsoft**, you must create an app registration on [Microsoft Entra ID (formerly Azure AD)](https://portal.azure.com/) and configure your Serverpod application accordingly.
 

--- a/docs/06-concepts/11-authentication/04-providers/08-microsoft/02-configuration.md
+++ b/docs/06-concepts/11-authentication/04-providers/08-microsoft/02-configuration.md
@@ -1,4 +1,9 @@
-# Configuration
+---
+sidebar_label: Configuration
+description: Microsoft identity provider options include which account types can sign in through the tenant setting. Configure them beyond the basic setup.
+---
+
+# Configure Sign in with Microsoft
 
 This page covers configuration options for the Microsoft identity provider beyond the basic setup.
 

--- a/docs/06-concepts/11-authentication/04-providers/08-microsoft/02-configuration.md
+++ b/docs/06-concepts/11-authentication/04-providers/08-microsoft/02-configuration.md
@@ -3,7 +3,7 @@ sidebar_label: Configuration
 description: Microsoft identity provider options include which account types can sign in through the tenant setting. Configure them beyond the basic setup.
 ---
 
-# Configure Sign in with Microsoft
+# Configure Microsoft sign-in
 
 This page covers configuration options for the Microsoft identity provider beyond the basic setup.
 

--- a/docs/06-concepts/11-authentication/04-providers/08-microsoft/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/08-microsoft/03-customizing-the-ui.md
@@ -1,4 +1,9 @@
-# Customizing the UI
+---
+sidebar_label: Customizing the UI
+description: Microsoft sign-in UI can be customized with the MicrosoftSignInWidget and MicrosoftAuthController to build a custom flow.
+---
+
+# Customize the Microsoft sign-in UI
 
 When using the Microsoft identity provider, you can customize the UI to your liking. You can use the `MicrosoftSignInWidget` to display the Microsoft Sign-In flow in your own custom UI, or you can use the `MicrosoftAuthController` to build a completely custom authentication interface.
 

--- a/docs/06-concepts/11-authentication/04-providers/09-passkey/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/09-passkey/01-setup.md
@@ -1,9 +1,9 @@
 ---
 sidebar_label: Setup
-description: Passkey authentication adds passwordless sign-in to your Serverpod backend using the WebAuthn and FIDO2 standards.
+description: Passkey sign-in adds passwordless authentication to your Serverpod backend using the WebAuthn and FIDO2 standards for phishing-resistant logins.
 ---
 
-# Set up passkey authentication
+# Set up passkey sign-in
 
 Passkeys provide a passwordless authentication method using WebAuthn/FIDO2 standards. They offer a secure, phishing-resistant way for users to sign in using biometric authentication, security keys, or device PINs.
 

--- a/docs/06-concepts/11-authentication/04-providers/09-passkey/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/09-passkey/01-setup.md
@@ -1,4 +1,9 @@
-# Setup
+---
+sidebar_label: Setup
+description: Passkey authentication adds passwordless sign-in to your Serverpod backend using the WebAuthn and FIDO2 standards.
+---
+
+# Set up passkey authentication
 
 Passkeys provide a passwordless authentication method using WebAuthn/FIDO2 standards. They offer a secure, phishing-resistant way for users to sign in using biometric authentication, security keys, or device PINs.
 

--- a/docs/06-concepts/11-authentication/04-providers/09-passkey/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/09-passkey/03-customizing-the-ui.md
@@ -1,4 +1,9 @@
-# Customizing the UI
+---
+sidebar_label: Customizing the UI
+description: Passkey sign-in UI can be built with the generated client endpoints and WebAuthn APIs while official Flutter widgets are pending.
+---
+
+# Customize the passkey sign-in UI
 
 :::warning
 Flutter UI components for passkeys are not yet available. This section will be updated once official Flutter widgets are released. For now, you'll need to build custom UI using the generated client endpoints and WebAuthn APIs.

--- a/docs/06-concepts/11-authentication/04-providers/10-custom-providers/01-overview.md
+++ b/docs/06-concepts/11-authentication/04-providers/10-custom-providers/01-overview.md
@@ -1,3 +1,7 @@
+---
+description: Custom providers extend Serverpod's authentication module with your own identity providers alongside the built-in ones.
+---
+
 # Custom providers
 
 Serverpod's authentication module makes it easy to implement custom authentication providers. This allows you to leverage all the existing providers supplied by the module along with the specific providers your project requires.

--- a/docs/06-concepts/11-authentication/04-providers/10-custom-providers/01-overview.md
+++ b/docs/06-concepts/11-authentication/04-providers/10-custom-providers/01-overview.md
@@ -1,5 +1,5 @@
 ---
-description: Custom providers extend Serverpod's authentication module with your own identity providers alongside the built-in ones.
+description: Custom providers extend Serverpod's authentication module with your own identity providers, alongside all the built-in ones the module ships with.
 ---
 
 # Custom providers

--- a/docs/06-concepts/11-authentication/04-providers/10-custom-providers/02-oauth2-utility/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/10-custom-providers/02-oauth2-utility/01-setup.md
@@ -1,4 +1,9 @@
-# Setup
+---
+sidebar_label: Setup
+description: The OAuth2 utility provides PKCE helpers to integrate any OAuth2-compliant provider without handling the low-level protocol yourself.
+---
+
+# Set up the OAuth2 utility
 
 The Serverpod Auth module provides generic OAuth2 utilities that simplify implementing custom identity providers. These utilities handle the complex OAuth2 authorization code flow with PKCE (Proof Key for Code Exchange), allowing you to integrate any OAuth2-compliant provider without dealing with low-level protocol details.
 

--- a/docs/06-concepts/11-authentication/04-providers/10-custom-providers/02-oauth2-utility/02-creating-an-oauth2-based-identity-provider.md
+++ b/docs/06-concepts/11-authentication/04-providers/10-custom-providers/02-oauth2-utility/02-creating-an-oauth2-based-identity-provider.md
@@ -1,3 +1,7 @@
+---
+description: Building a custom OAuth2 identity provider with Serverpod's OAuth2 utility, shown through a complete, working example.
+---
+
 # Creating an OAuth2-based Identity Provider
 
 This page provides a complete, working implementation of a custom OAuth2 provider. The [GitHub IDP](../../github/setup) is built the same way, using the same OAuth2 utility shown here, so this example illustrates the general pattern you can follow when creating your own IDP.

--- a/docs/06-concepts/11-authentication/04-providers/10-custom-providers/02-oauth2-utility/02-creating-an-oauth2-based-identity-provider.md
+++ b/docs/06-concepts/11-authentication/04-providers/10-custom-providers/02-oauth2-utility/02-creating-an-oauth2-based-identity-provider.md
@@ -1,5 +1,5 @@
 ---
-description: Building a custom OAuth2 identity provider with Serverpod's OAuth2 utility, shown through a complete, working example.
+description: Building a custom OAuth2 identity provider with Serverpod's OAuth2 utility, shown through a complete, working example you can adapt for your own.
 ---
 
 # Creating an OAuth2-based Identity Provider


### PR DESCRIPTION
Makes the first heading on each authentication provider page more descriptive so each page reads clearly out of context (for example, "Setup" becomes "Set up Sign in with Google"), and adds a `description` to the frontmatter of every page. Where a heading was lengthened, a `sidebar_label` keeps the sidebar name short. Each description leads with the page's topic.

Covers the anonymous, email, Google, Apple, Facebook, Firebase, GitHub, Microsoft, and passkey providers, plus the custom providers and OAuth2 utility pages.

Part of splitting the same heading and description change across the authentication section, following #635.