### PR TITLE
docs: Add descriptions to token manager pages

### DIFF
--- a/docs/06-concepts/11-authentication/05-token-managers/01-managing-tokens.md
+++ b/docs/06-concepts/11-authentication/05-token-managers/01-managing-tokens.md
@@ -1,3 +1,7 @@
+---
+description: Token managers issue, validate, revoke, and list authentication tokens in Serverpod. Learn how they work and how to access them.
+---
+
 # Managing tokens
 
 The authentication system uses token managers to handle authentication tokens. Token managers are responsible for issuing, validating, revoking, and listing authentication tokens.

--- a/docs/06-concepts/11-authentication/05-token-managers/02-jwt-token-manager.md
+++ b/docs/06-concepts/11-authentication/05-token-managers/02-jwt-token-manager.md
@@ -1,3 +1,7 @@
+---
+description: The JwtTokenManager provides stateless JWT authentication with short-lived access tokens and refresh token rotation. Configure it on the server.
+---
+
 # JWT Token Manager
 
 The `JwtTokenManager` uses JWT (JSON Web Tokens) for stateless authentication. This token manager provides:

--- a/docs/06-concepts/11-authentication/05-token-managers/03-server-side-sessions-token-manager.md
+++ b/docs/06-concepts/11-authentication/05-token-managers/03-server-side-sessions-token-manager.md
@@ -1,3 +1,7 @@
+---
+description: The ServerSideSessionsTokenManager provides database-backed sessions with immediate revocation and inactivity timeouts. Configure it on the server.
+---
+
 # Server-side Sessions Token Manager
 
 The `ServerSideSessionsTokenManager` uses session-based tokens stored in the database. This token manager provides:


### PR DESCRIPTION
The token manager page headings are already descriptive, so this adds a `description` to the frontmatter of each page: Managing tokens, JWT Token Manager, and Server-side Sessions Token Manager. Each description leads with the page's topic.

Part of splitting the same heading and description change across the authentication section, following #635.