### PR TITLE
docs: Make legacy authentication headings descriptive

### DIFF
--- a/docs/06-concepts/11-authentication/11-legacy/01-setup.md
+++ b/docs/06-concepts/11-authentication/11-legacy/01-setup.md
@@ -1,4 +1,9 @@
-# Setup
+---
+sidebar_label: Setup
+description: The legacy serverpod_auth module adds email and social sign-in to older Serverpod projects. Install and configure it on the server and client.
+---
+
+# Set up the legacy auth module
 
 Serverpod comes with built-in user management and authentication. It is possible to build a [custom authentication implementation](custom-overrides), but the recommended way to authenticate users is to use the `serverpod_auth` module. The module makes it easy to authenticate with email or social sign-ins and currently supports signing in with email, Google, Apple, and Firebase.
 

--- a/docs/06-concepts/11-authentication/11-legacy/02-basics.md
+++ b/docs/06-concepts/11-authentication/11-legacy/02-basics.md
@@ -1,4 +1,9 @@
-# The basics
+---
+sidebar_label: The basics
+description: Authentication tokens in the legacy serverpod_auth module are handled automatically. Learn how to access the signed-in user from the Session object.
+---
+
+# Legacy authentication basics
 
 Serverpod automatically checks if the user is logged in and if the user has the right privileges to access the endpoint. When using the `serverpod_auth` module you will not have to worry about keeping track of tokens, refreshing them or, even including them in requests as this all happens automatically under the hood.
 

--- a/docs/06-concepts/11-authentication/11-legacy/03-working-with-users.md
+++ b/docs/06-concepts/11-authentication/11-legacy/03-working-with-users.md
@@ -1,3 +1,7 @@
+---
+description: User information in the legacy serverpod_auth module is read and updated through the Users class. Learn how to work with signed-in users.
+---
+
 # Working with users
 
 It's a common task to read or update user information on your server. You can always retrieve the id of a signed-in user through the session object.

--- a/docs/06-concepts/11-authentication/11-legacy/04-providers/01-email.md
+++ b/docs/06-concepts/11-authentication/11-legacy/04-providers/01-email.md
@@ -3,7 +3,7 @@ sidebar_label: Email
 description: Sign in with Email in the legacy serverpod_auth module connects Serverpod to an SMTP service for email and password sign-in.
 ---
 
-# Sign in with Email
+# Email sign-in
 
 To properly configure Sign in with Email, you must connect your Serverpod to an external service that can send the emails. One convenient option is the [mailer](https://pub.dev/packages/mailer) package, which can send emails through any SMTP service. Most email providers, such as Sendgrid or Mandrill, support SMTP.
 

--- a/docs/06-concepts/11-authentication/11-legacy/04-providers/01-email.md
+++ b/docs/06-concepts/11-authentication/11-legacy/04-providers/01-email.md
@@ -1,4 +1,9 @@
-# Email
+---
+sidebar_label: Email
+description: Sign in with Email in the legacy serverpod_auth module connects Serverpod to an SMTP service for email and password sign-in.
+---
+
+# Sign in with Email
 
 To properly configure Sign in with Email, you must connect your Serverpod to an external service that can send the emails. One convenient option is the [mailer](https://pub.dev/packages/mailer) package, which can send emails through any SMTP service. Most email providers, such as Sendgrid or Mandrill, support SMTP.
 

--- a/docs/06-concepts/11-authentication/11-legacy/04-providers/02-google.md
+++ b/docs/06-concepts/11-authentication/11-legacy/04-providers/02-google.md
@@ -1,4 +1,9 @@
-# Google
+---
+sidebar_label: Google
+description: Sign in with Google in the legacy serverpod_auth module uses Google credentials added to your app and server.
+---
+
+# Sign in with Google
 
 To set up Sign in with Google, you will need a Google account for your organization and set up a new project. For the project, you need to set up _Credentials_ and _Oauth consent screen_. You will also need to add the `serverpod_auth_google_flutter` package to your app and do some additional setup depending on each platform.
 

--- a/docs/06-concepts/11-authentication/11-legacy/04-providers/02-google.md
+++ b/docs/06-concepts/11-authentication/11-legacy/04-providers/02-google.md
@@ -1,9 +1,9 @@
 ---
 sidebar_label: Google
-description: Sign in with Google in the legacy serverpod_auth module uses Google credentials added to your app and server.
+description: Sign in with Google in the legacy serverpod_auth module uses Google credentials added to your app and server across iOS, Android, and Web.
 ---
 
-# Sign in with Google
+# Google sign-in
 
 To set up Sign in with Google, you will need a Google account for your organization and set up a new project. For the project, you need to set up _Credentials_ and _Oauth consent screen_. You will also need to add the `serverpod_auth_google_flutter` package to your app and do some additional setup depending on each platform.
 

--- a/docs/06-concepts/11-authentication/11-legacy/04-providers/03-apple.md
+++ b/docs/06-concepts/11-authentication/11-legacy/04-providers/03-apple.md
@@ -1,4 +1,9 @@
-# Apple
+---
+sidebar_label: Apple
+description: Sign in with Apple in the legacy serverpod_auth module is supported on iOS and macOS.
+---
+
+# Sign in with Apple
 
 Sign-in with Apple, requires that you have a subscription to the [Apple developer program](https://developer.apple.com/programs/), even if you only want to test the feature in development mode.
 

--- a/docs/06-concepts/11-authentication/11-legacy/04-providers/03-apple.md
+++ b/docs/06-concepts/11-authentication/11-legacy/04-providers/03-apple.md
@@ -1,9 +1,9 @@
 ---
 sidebar_label: Apple
-description: Sign in with Apple in the legacy serverpod_auth module is supported on iOS and macOS.
+description: Sign in with Apple in the legacy serverpod_auth module is supported on iOS and macOS, including in development with an Apple Developer subscription.
 ---
 
-# Sign in with Apple
+# Apple sign-in
 
 Sign-in with Apple, requires that you have a subscription to the [Apple developer program](https://developer.apple.com/programs/), even if you only want to test the feature in development mode.
 

--- a/docs/06-concepts/11-authentication/11-legacy/04-providers/05-firebase.md
+++ b/docs/06-concepts/11-authentication/11-legacy/04-providers/05-firebase.md
@@ -1,6 +1,6 @@
 ---
 sidebar_label: Firebase
-description: Firebase authentication in the legacy serverpod_auth module uses Firebase UI auth to add social sign-in methods.
+description: Firebase authentication in the legacy serverpod_auth module uses Firebase UI auth to add social sign-in methods Serverpod does not support directly.
 ---
 
 # Firebase authentication

--- a/docs/06-concepts/11-authentication/11-legacy/04-providers/05-firebase.md
+++ b/docs/06-concepts/11-authentication/11-legacy/04-providers/05-firebase.md
@@ -1,4 +1,9 @@
-# Firebase
+---
+sidebar_label: Firebase
+description: Firebase authentication in the legacy serverpod_auth module uses Firebase UI auth to add social sign-in methods.
+---
+
+# Firebase authentication
 
 Serverpod uses [Firebase UI auth](https://pub.dev/packages/firebase_ui_auth) to handle authentication through Firebase. It allows you to add social sign-in types that Serverpod doesn't directly support.
 

--- a/docs/06-concepts/11-authentication/11-legacy/04-providers/06-custom-providers.md
+++ b/docs/06-concepts/11-authentication/11-legacy/04-providers/06-custom-providers.md
@@ -1,3 +1,7 @@
+---
+description: Custom providers in the legacy serverpod_auth module let you implement your own authentication and connect users with auth tokens.
+---
+
 # Custom providers
 
 Serverpod's authentication module makes it easy to implement custom authentication providers. This allows you to leverage all the existing providers supplied by the module along with the specific providers your project requires.

--- a/docs/06-concepts/11-authentication/11-legacy/05-custom-overrides.md
+++ b/docs/06-concepts/11-authentication/11-legacy/05-custom-overrides.md
@@ -1,4 +1,9 @@
-# Custom overrides
+---
+sidebar_label: Custom overrides
+description: Custom authentication overrides in the legacy serverpod_auth module let you implement your own handling when its providers do not fit your needs.
+---
+
+# Custom authentication overrides
 
 It is recommended to use the `serverpod_auth` package but if you have special requirements not fulfilled by it, you can implement your authentication module. Serverpod is designed to make it easy to add custom authentication overrides.
 


### PR DESCRIPTION
Makes the first heading on each legacy authentication page more descriptive so each page reads clearly out of context (for example, the provider pages titled "Google" and "Apple" become "Sign in with Google" and "Sign in with Apple"), and adds a `description` to the frontmatter of every page. Where a heading was lengthened, a `sidebar_label` keeps the sidebar name short. Each description leads with the page's topic.

Part of splitting the same heading and description change across the authentication section, following #635.