### PR TITLE
docs: Rename Facebook configuration page to customizations and fix UI API

### DIFF
--- a/docs/06-concepts/11-authentication/04-providers/05-facebook/01-setup.md
+++ b/docs/06-concepts/11-authentication/04-providers/05-facebook/01-setup.md
@@ -153,7 +153,7 @@ Finally, start the server with `serverpod start` to generate the client code, th
 - `appId`: Required. The App ID of your Facebook App.
 - `appSecret`: Required. The App secret of your Facebook App.
 
-For more details on configuration options, see the [configuration section](./configuration).
+For more details on configuration options, see the [customizations section](./customizations).
 
 ## Client-side configuration
 

--- a/docs/06-concepts/11-authentication/04-providers/05-facebook/02-customizations.md
+++ b/docs/06-concepts/11-authentication/04-providers/05-facebook/02-customizations.md
@@ -1,11 +1,11 @@
 ---
-sidebar_label: Configuration
-description: Facebook identity provider options include custom validation of account details before sign-in. Configure them beyond the basic setup.
+sidebar_label: Customizations
+description: Sign in with Facebook can be configured through FacebookIdpConfig, including how to load credentials and use the available callbacks.
 ---
 
-# Configure Facebook sign-in
+# Customize Facebook sign-in
 
-This page covers configuration options for the Facebook identity provider beyond the basic setup.
+This page covers additional configuration options for the Facebook identity provider beyond the basic setup.
 
 ## Configuration options
 
@@ -125,7 +125,7 @@ final facebookIdpConfig = FacebookIdpConfigFromPasswords(
 );
 ```
 
-### Reacting to account creation
+### Reacting to Facebook account creation
 
 You can use the `onAfterFacebookAccountCreated` callback to run logic after a new Facebook account has been created and linked to an auth user. This callback is only invoked for new accounts, not for returning users.
 
@@ -152,11 +152,11 @@ This callback runs inside the same database transaction as the account creation.
 If you need to assign Serverpod scopes based on provider account data, note that updating the database alone (via `AuthServices.instance.authUsers.update()`) is **not enough** for the current login session. The token issuance uses the in-memory `authUser.scopes`, which is already set before this callback runs. You would need to update `authUser.scopes` as well for the scopes to be reflected in the issued tokens. For assigning scopes at creation time, consider using `onBeforeAuthUserCreated` in combination with `getExtraFacebookInfoCallback` to fetch and store the data you need before the auth user is created.
 :::
 
-## Configuring Facebook Sign-In on the app
+### Configuring Facebook sign-in on the app
 
 When using the external `serverpod_auth_idp_flutter_facebook` package, you can configure the App ID in your Flutter application.
 
-### Passing configuration in code
+#### Passing configuration in code
 
 You can pass the App ID directly when initializing the Facebook Sign-In service:
 
@@ -168,7 +168,7 @@ await client.auth.initializeFacebookSignIn(
 
 If the `appId` value is not supplied when initializing the service, the provider will automatically fetch it from the `FACEBOOK_APP_ID` environment variable. This approach is useful for different configurations per platform or build environment.
 
-### Using environment variables
+#### Using environment variables
 
 Alternatively, you can pass the App ID during build time using the `--dart-define` option. The Facebook Sign-In provider supports the following environment variable:
 

--- a/docs/06-concepts/11-authentication/04-providers/05-facebook/03-customizing-the-ui.md
+++ b/docs/06-concepts/11-authentication/04-providers/05-facebook/03-customizing-the-ui.md
@@ -23,12 +23,12 @@ import 'package:serverpod_auth_idp_flutter_facebook/serverpod_auth_idp_flutter_f
 FacebookSignInWidget(
   client: client,
   // Button customization
-  text: FacebookButtonText.continueWith, // or signIn, signInWith, signUp
-  type: FacebookButtonType.standard, // or icon
+  type: FacebookButtonText.continueWith, // or signinWith, signupWith, signIn
   style: FacebookButtonStyle.blue, // or white
-  size: FacebookButtonSize.large, // or medium
-  shape: FacebookButtonShape.pill, // or rectangular, rounded
-  logoAlignment: FacebookButtonLogoAlignment.left, // or center
+  size: FacebookButtonSize.large, // or medium, small
+  shape: FacebookButtonShape.pill, // or rectangular
+  logoAlignment: FacebookButtonLogoAlignment.center, // or left
+  minimumWidth: 240, // in pixels, max 400
 
   // Permissions to request from Facebook
   // These are the default permissions.


### PR DESCRIPTION
## Summary

Aligns the Facebook sign-in docs with the other migrated providers (Google, Apple, GitHub) and corrects the UI customization API.

- Renames `02-configuration.md` to `02-customizations.md` and updates its title, `sidebar_label`, and description to match the Google/GitHub customizations pages. Updates the inbound link from the setup page.
- Aligns the customizations heading hierarchy with the other providers (provider-specific "Reacting to Facebook account creation", and the app-side config section nested correctly).
- Fixes the `FacebookSignInWidget` example on the UI customization page, which referenced an API that does not exist in `serverpod_auth_idp_flutter_facebook`:
  - The button label prop is `type` (a `FacebookButtonText`), not `text`.
  - Removes the non-existent `FacebookButtonType.standard` / `.icon` (there is no `FacebookButtonType` enum).
  - Corrects enum values to `signinWith` and `signupWith`.
  - `FacebookButtonSize` also has `small`; `FacebookButtonShape` only has `rectangular` and `pill`.
  - Documents the `minimumWidth` prop.

Part of #503, and a step toward #507.