### PR TITLE
docs: Updates Quickstart page and installation to the Serverpod 4 beta.

### DIFF
--- a/docs/04-get-started/01-installation.md
+++ b/docs/04-get-started/01-installation.md
@@ -10,34 +10,34 @@ slug: /installation
 
 Serverpod is tested on Mac, Windows, and Linux. Before you can install Serverpod, you need to have **[Flutter](https://flutter.dev/docs/get-started/install)** installed.
 
-::::info
+:::info
 Check your Flutter installation by running the following command in your terminal:
 
 ```bash
 $ flutter doctor
 ```
 
-::::
+:::
 
 ### Install Serverpod
 
 Serverpod is installed using the Dart package manager. To install Serverpod, run the following command in your terminal:
 
 ```txt
-$ dart install serverpod_cli 3.5.0-beta.9
+$ dart install serverpod_cli 4.0.0-beta.0
 ```
 
 This command will install the Serverpod command-line interface (CLI) globally on your machine. You can verify the installation by running:
 
 ```bash
-$ serverpod version
+$ serverpod
 ```
 
 If everything is correctly configured, the help for the `serverpod` command is now displayed.
 
 :::warning
 
-If the Serverpod CLI is already installed globally, deactivate it before installing or upgrading:
+If a previous version of Serverpod is already installed with `dart pub global activate`, deactivate it before installing or upgrading:
 
 ```txt
 $ dart pub global deactivate serverpod_cli

--- a/docs/04-get-started/02-quickstart.md
+++ b/docs/04-get-started/02-quickstart.md
@@ -108,6 +108,10 @@ The agent will start building your app. It will manage your database and perform
 
 If your app uses authentication, the verification code will be displayed as an alert in Serverpod's command line interface. Press the `C` key to copy the code.
 
+:::
+
+:::tip
+
 If the agent fails to reload the app, you can always hit the `R` key to force a restart of the server and the app.
 
 :::

--- a/docs/04-get-started/02-quickstart.md
+++ b/docs/04-get-started/02-quickstart.md
@@ -106,7 +106,7 @@ The agent will start building your app. It will manage your database and perform
 
 :::tip
 
-If your app uses authentication, the verfication code will be displayed as an alert in Serverpod's command line interface. Press the `C` key to copy the code.
+If your app uses authentication, the verification code will be displayed as an alert in Serverpod's command line interface. Press the `C` key to copy the code.
 
 If the agent fails to reload the app, you can always hit the `R` key to force a restart of the server and the app.
 

--- a/docs/04-get-started/02-quickstart.md
+++ b/docs/04-get-started/02-quickstart.md
@@ -11,25 +11,56 @@ import TabItem from '@theme/TabItem';
 
 # Quickstart
 
-Build and deploy a full-stack Flutter and Serverpod app, hosted on the web, in 10–15 minutes. We have tested the default setup with Antigravity, Cursor, and Claude Code, but most agentic editors will work.
+Try out the **Serverpod 4 public beta**. Build and deploy a full-stack Flutter and Serverpod app, hosted on the web, in 10–15 minutes. We have tested the default setup with Antigravity, Cursor, and Claude Code, but most agentic editors will work.
+
+## Prerequisites
+
+Serverpod is tested on Mac, Windows, and Linux. Before you can install Serverpod, you need to have **[Flutter](https://flutter.dev/docs/get-started/install)** installed.
 
 :::info
+Check your Flutter installation by running the following command in your terminal:
 
-Before we start, make sure that you have [Serverpod installed](./installation).
+```bash
+$ flutter doctor
+```
+
+:::
+
+## Install Serverpod
+
+Serverpod is installed using the Dart package manager. To install Serverpod, run the following command in your terminal:
+
+```txt
+$ dart install serverpod_cli 4.0.0-beta.0
+```
+
+Verify the installation by running:
+
+```bash
+$ serverpod
+```
+
+:::warning
+
+If a previous version of Serverpod is already installed with `dart pub global activate`, deactivate it before installing or upgrading:
+
+```txt
+$ dart pub global deactivate serverpod_cli
+```
 
 :::
 
 ## Create the project
 
-Use Serverpod's `create` command to create a new project. The `create` command is interactive and will guide you through the setup process.
+Use Serverpod's `quickstart` command to create a new project.
 
 ```bash
-$ serverpod create my_project
+$ serverpod quickstart my_project
 ```
 
-The command opens an interactive screen with sensible defaults already selected. Leave the defaults as they are, but make sure to select the editor or agent you plan to use, since the rest of this guide relies on it to build your app. Navigate with the arrow keys, press `Space` to select it, then press `Enter` to create the project.
+The command opens an interactive screen where you select the editor or agent you plan to use. Navigate with your mouse or use the arrow keys to move around, press `Space` to select your editor, then press `Enter` to create the project.
 
-Next, open your newly created project with your favorite AI powered editor. Open the root folder of the full project, for example, `my_project`, which includes the server, client, and Flutter app.
+Next, open your newly created project with your favorite AI powered editor. Open the _root_ folder of the full project, for example, `my_project`, which includes the server, client, and Flutter app.
 
 :::important
 
@@ -45,26 +76,26 @@ Start the server and the Flutter app by opening up a terminal window and running
 $ serverpod start
 ```
 
-After the server has started and your app has finished building, it will open in a new window. Try it out by entering your name and clicking the send button.
+After the server has started and your app has finished building, the app will open in a new browser window. Try it out by entering your name and clicking the send button.
 
 ## Build your app
 
-Instruct the agent to build your app. Here are a few simple prompts that you can try:
+Instruct your AI agent to build your app. Here are a few simple prompts that you can try:
 
 <Tabs>
-  <TabItem value="expense-tracker" label="Personal expense tracker" default>
+  <TabItem value="jobs" label="Job board">
 
-> _Build a personal expense tracker with a Serverpod backend. Include a frontend form to log expenses (amount, category, description), a list displaying past entries, and a header calculating the running total._
-
-  </TabItem>
-  <TabItem value="flashcards" label="Digital flashcard maker">
-
-> _Build a digital flashcard app with a Serverpod backend. The UI should have a form to create cards (question and answer) and a 'Study Mode' view that shows one card at a time, featuring a 'Flip' button to reveal the answer and a 'Next' button._
+> _Build a professional job marketplace where employers post openings and manage applications, while job seekers browse listings. Use an editorial-inspired design with bold typography._
 
   </TabItem>
-  <TabItem value="journal" label="Daily journal">
+  <TabItem value="crm" label="CRM" default>
 
-> _Build a journal app with a Serverpod backend. Include a simple UI with a large text area to save plain-text entries, and display a chronological feed of past entries below it (newest first)._
+> _Build a modern CRM for a B2B sales team. Users can manage companies, contacts, and deals. Use a sleek dark theme with vibrant accent colors, compact layouts, and data-rich dashboards._
+
+  </TabItem>
+  <TabItem value="journal" label="Social network">
+
+> _Build a modern social network where users share posts, follow each other, comment, and react. Give it a bold consumer-app style with colorful gradients, large avatars, and playful animations._
 
   </TabItem>
 </Tabs>
@@ -75,36 +106,28 @@ The agent will start building your app. It will manage your database and perform
 
 :::tip
 
+If your app uses authentication, the verfication code will be displayed as an alert in Serverpod's command line interface. Press the `C` key to copy the code.
+
 If the agent fails to reload the app, you can always hit the `R` key to force a restart of the server and the app.
 
 :::
 
 ## Deploy the app to the cloud
 
-Deploy your app to **[Serverpod Cloud](/cloud)**, a fully managed platform built by the Serverpod team. Your first project includes a one-month free trial, with no credit card required.
+Deploy your web app and backend to **[Serverpod Cloud](/cloud)**, a fully managed platform built by the Serverpod team. Your first project includes a one-month free trial, with no credit card required.
 
-Create your Cloud account on the **[Serverpod Cloud Console](https://console.serverpod.cloud/)**, then install the Serverpod Cloud command line tools:
-
-```bash
-$ dart pub global activate serverpod_cloud_cli
-```
-
-From your project's root folder, launch your app:
+Create your Cloud account and create a project on the **[Serverpod Cloud Console](https://console.serverpod.dev/)**, then launch your app:
 
 ```bash
-$ scloud launch
+$ serverpod cloud launch
 ```
 
-This creates the Cloud project, provisions a database, and deploys your backend along with the web build of your app.
+This configures your project, provisions a database, and deploys your backend along with the web build of your app.
 
-After the first launch, redeploy changes with:
-
-```bash
-$ scloud deploy
-```
+After the first launch, you redeploy any changes by running `serverpod cloud launch` again.
 
 :::tip
 
-In the **[Serverpod Cloud Console](https://console.serverpod.cloud/)**, open Serverpod Insights to view server logs, CPU usage, and other information.
+In the **[Serverpod Cloud Console](https://console.serverpod.dev/)**, open Serverpod Insights to view your server logs, CPU usage, and other information.
 
 :::


### PR DESCRIPTION
Updates the Quickstart page to be up-to-date with the Serverpod 4 public beta.

It also moves (duplicates) some installation instructions into the Quickstart page, making the Quickstart guide completely self-sustaining.