### PR TITLE
docs: Fill future-call scheduling gaps and web-server response headers

### DIFF
--- a/docs/06-concepts/14-scheduling/01-setup.md
+++ b/docs/06-concepts/14-scheduling/01-setup.md
@@ -8,6 +8,10 @@ Serverpod supports scheduling future work with the `future call` feature. Future
 
 A future call is guaranteed to only execute once across all your instances that are running, but execution failures are not handled automatically. It is your responsibility to schedule a new future call if the work was not able to complete.
 
+:::info
+The future call feature is not enabled when running Serverpod in serverless mode.
+:::
+
 To create future calls, extend the `FutureCall` class and define the methods you wish to invoke at a later time.
 
 ```dart
@@ -134,7 +138,3 @@ class OrderEndpoint extends Endpoint {
 Scheduled future calls are stored in the `serverpod_future_call` database table. You can query it to see what is pending, which helps when debugging why a call did or did not run.
 
 Future calls do not have an execution timeout: a call runs until its method returns. If a call needs a time limit, enforce it inside the method yourself, for example with `Future.timeout` around the work.
-
-:::info
-The future call feature is not enabled when running Serverpod in serverless mode.
-:::

--- a/docs/06-concepts/14-scheduling/01-setup.md
+++ b/docs/06-concepts/14-scheduling/01-setup.md
@@ -1,5 +1,5 @@
 ---
-description: "Schedule future work in Serverpod using future calls: invoke methods after a delay, at a specific time, or on a recurring interval, with persistence across restarts."
+description: Future calls in Serverpod schedule work to run after a delay, at a specific time, or on a recurring interval, persisted across restarts.
 ---
 
 # Setup
@@ -108,6 +108,32 @@ This identifier can then be used to cancel all future calls scheduled with said 
 ```dart
 await pod.futureCalls.cancel('an-identifying-string');
 ```
+
+Calls that share an identifier still run independently; the identifier only groups them so you can cancel them together, and cancelling affects only calls that have not run yet.
+
+## Schedule from an endpoint
+
+The examples above use the `Serverpod` object directly. Inside an endpoint you reach it through `session.serverpod`, so you can schedule a future call in response to a request:
+
+```dart
+class OrderEndpoint extends Endpoint {
+  Future<void> placeOrder(Session session, Order order) async {
+    // ... store the order ...
+
+    // Send a follow-up an hour from now.
+    await session.serverpod.futureCalls
+        .callWithDelay(const Duration(hours: 1))
+        .example
+        .doWork();
+  }
+}
+```
+
+## Inspecting scheduled calls and timeouts
+
+Scheduled future calls are stored in the `serverpod_future_call` database table. You can query it to see what is pending, which helps when debugging why a call did or did not run.
+
+Future calls do not have an execution timeout: a call runs until its method returns. If a call needs a time limit, enforce it inside the method yourself, for example with `Future.timeout` around the work.
 
 :::info
 The future call feature is not enabled when running Serverpod in serverless mode.

--- a/docs/06-concepts/14-scheduling/02-recurring-task.md
+++ b/docs/06-concepts/14-scheduling/02-recurring-task.md
@@ -1,5 +1,5 @@
 ---
-description: Implement cron-like recurring tasks in Serverpod by scheduling a future call from within itself to re-run at a fixed interval.
+description: Recurring tasks in Serverpod re-run at a fixed interval by scheduling a future call from within itself, cron-style.
 ---
 
 # Recurring Task

--- a/docs/06-concepts/14-scheduling/02-recurring-task.md
+++ b/docs/06-concepts/14-scheduling/02-recurring-task.md
@@ -1,5 +1,5 @@
 ---
-description: Recurring tasks in Serverpod re-run at a fixed interval by scheduling a future call from within itself, cron-style.
+description: Recurring tasks in Serverpod re-run at a fixed interval by scheduling the next future call from within the current one, cron-style.
 ---
 
 # Recurring Task

--- a/docs/06-concepts/14-scheduling/03-inheritance.md
+++ b/docs/06-concepts/14-scheduling/03-inheritance.md
@@ -1,5 +1,5 @@
 ---
-description: Extend or override FutureCall classes from other Serverpod modules, including support for abstract base classes that expose their methods through subclasses.
+description: FutureCall inheritance extends or overrides future call classes from other Serverpod modules, including abstract base classes exposed through subclasses.
 ---
 
 # Inheritance

--- a/docs/06-concepts/14-scheduling/04-configuration.md
+++ b/docs/06-concepts/14-scheduling/04-configuration.md
@@ -1,5 +1,5 @@
 ---
-description: Configure future call execution, concurrency limits, scan interval, and broken call handling in Serverpod using YAML or environment variables.
+description: Future call configuration in Serverpod sets concurrency limits, the scan interval, and broken-call handling through YAML or environment variables.
 ---
 
 # Configuration
@@ -10,8 +10,8 @@ Future calls can be configured using options defined in the configuration files 
 futureCallExecutionEnabled: true
 
 futureCall:
-  concurrencyLimit: 5
-  scanInterval: 2000
+  concurrencyLimit: 1 # default
+  scanInterval: 5000 # default, in milliseconds
 ```
 
 ### Enable or disable future call execution

--- a/docs/06-concepts/18-webserver/03-request-data.md
+++ b/docs/06-concepts/18-webserver/03-request-data.md
@@ -76,6 +76,19 @@ Future<Result> handleCall(Session session, Request request) async {
 }
 ```
 
+The accessors above read headers from the incoming request. To set headers on the response, pass a `headers:` value built with `Headers.build` when you construct the `Response`:
+
+```dart
+return Response.ok(
+  body: Body.fromString(jsonEncode(data), mimeType: MimeType.json),
+  headers: Headers.build((h) {
+    h['X-Custom-Header'] = ['value'];
+  }),
+);
+```
+
+Relic also exposes typed setters for standard headers. See the [Relic documentation](https://docs.dartrelic.dev/) for the full header reference.
+
 ## Body
 
 Read the request body using the appropriate method for your content type:

--- a/docs/06-concepts/18-webserver/03-request-data.md
+++ b/docs/06-concepts/18-webserver/03-request-data.md
@@ -80,7 +80,7 @@ The accessors above read headers from the incoming request. To set headers on th
 
 ```dart
 return Response.ok(
-  body: Body.fromString(jsonEncode(data), mimeType: MimeType.json),
+  body: Body.fromString('ok'),
   headers: Headers.build((h) {
     h['X-Custom-Header'] = ['value'];
   }),


### PR DESCRIPTION
Phase 2 IA, PR 5 of 7 (tracked in #671): fills the mapped gaps in the Scheduling and Web server pages and conforms the scheduling descriptions. The web-server pages were already conformant, so the changes there are targeted.

## What changed

- **Scheduling — Setup (#655)**: added a "Schedule from an endpoint" example (`session.serverpod.futureCalls`), a note that scheduled calls live in the `serverpod_future_call` table and have no execution timeout, and a clarification that calls sharing an identifier run independently.
- **Web server — Request data (#367)**: added an example for setting response headers with `Headers.build`, alongside the existing request-header accessors.
- **Scheduling descriptions**: rewrote the four verb-first descriptions noun-first and unquoted `01-setup`'s.
- **Scheduling — Configuration**: aligned the intro example to the actual defaults (`concurrencyLimit: 1`, `scanInterval: 5000`), which the sections already state.

## Verification

Checked against the current beta (Serverpod `4.0.0-beta.0`, Relic `1.2.0`): `session.serverpod` (`session.dart`), `callWithDelay`/`callAtTime`/`cancel` (`future_call_dispatch.dart`), the `serverpod_future_call` table (`future_call_entry.spy.yaml`), the absence of an execution timeout (future-call manager), the `1`/`5000` defaults (`config.dart`), and the `Response` / `Headers.build` header API (`relic_core`). Build passes locally.

## Notes

- #365 (body streaming) was already satisfied by the existing Request data page, so no change was needed.
- Deferred to the final PR of this series: the Jaspr sample (#366), the web-server numbering gap, and archiving the legacy scheduling page. The `serverpod generate` references in Scheduling stay for the dedicated modernization pass (#538).

Closes #655
Closes #367
