### PR TITLE
docs: Require nullable for scoped model fields and fix example

### DIFF
--- a/docs/06-concepts/02-models/01-models.md
+++ b/docs/06-concepts/02-models/01-models.md
@@ -53,7 +53,7 @@ fields:
   hiddenSecretKey: String
 ```
 
-It is also possible to set a `scope` on a per-field basis. By default all fields are visible to both the server and the client. The available scopes are `all`, `serverOnly`, `none`.
+It is also possible to set a `scope` on a per-field basis. By default all fields are visible to both the server and the client. The available scopes are `all`, `serverOnly`, `none`. A field with a scope other than `all` must be nullable.
 
 :::info
 **none** is not typically used in serverpod apps. It is intended for the serverpod framework, itself.
@@ -62,7 +62,7 @@ It is also possible to set a `scope` on a per-field basis. By default all fields
 ```yaml
 class: SelectivelyHiddenClass
 fields:
-  hiddenSecretKey: String, scope=serverOnly
+  hiddenSecretKey: String?, scope=serverOnly
   publicKey: String
 ```
 


### PR DESCRIPTION
The `SelectivelyHiddenClass` example on the models page declares a `scope=serverOnly` field with a non-nullable type, which fails code generation. On a non-`serverOnly` class, any field with a scope other than `all` (`serverOnly` or `none`) must be nullable — enforced by the model analyzer since Serverpod 1.2.3.

- Fix the example: `hiddenSecretKey: String` → `String?`.
- Document the rule: a field with a scope other than `all` must be nullable.

Reported in the docs channel (the published example does not generate). Scoped to the current dev version; the same example exists in the versioned docs and can be backported separately if wanted.