### PR TITLE
docs: Add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,11 @@ The same person moves through all three stages. Write for the stage they're in r
 ## The governing principle
 
 Get the reader to a working outcome with minimum friction. Every sentence should either move them forward or be cut.
+
+## Cursor Cloud specific instructions
+
+This is a Docusaurus 3 documentation site (single service). Dependencies are refreshed automatically on startup by the environment update script (`npm ci` plus a `--no-save` install of `markdownlint-cli`), so you should not need to reinstall.
+
+- Run the dev server with `npm start` (Docusaurus at http://localhost:3000/). Most edits hot-reload; changes to `docusaurus.config.js` or `sidebars.js` require a restart. Do NOT run `npm run build` (see the Rules section); ask the user to verify builds instead.
+- `npm run lint` calls `markdownlint` directly. The repo does not list `markdownlint-cli` in `package.json`; the update script installs it into `node_modules/.bin` (`--no-save`) so `npm run lint` resolves it. If lint reports "markdownlint: not found", re-run `npm install --no-save markdownlint-cli`.
+- CI (`.github/workflows/test-build.yml`) installs the latest `markdownlint-cli` unpinned, so lint uses whatever version is current. Newer versions enable additional default rules (e.g. `MD060`, `MD025`) that surface pre-existing findings in `docs/`; a nonzero `npm run lint` exit from those existing files is expected and not an environment problem. Lint is only enforced on `docs/**/*.md`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for this Docusaurus documentation site and documents non-obvious run/lint caveats for future agents.

- Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering how to run the dev server, the `markdownlint-cli` requirement for `npm run lint`, and why lint reports pre-existing findings.
- The environment update script installs dependencies via `npm ci` and adds `markdownlint-cli` (`--no-save`) so `npm run lint` resolves the `markdownlint` binary.

## Environment verification

- `npm ci` — installs 1476 packages successfully.
- `npm run lint` — runs `markdownlint` over `docs/**/*.md` (exits nonzero on pre-existing content findings, expected).
- `npm start` — Docusaurus dev server serves the docs at http://localhost:3000/ (HTTP 200).

### Walkthrough

[serverpod_docs_dev_server_walkthrough.mp4](https://cursor.com/agents/bc-b93b9a59-78bd-47a2-91b3-0a882493f3a7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fserverpod_docs_dev_server_walkthrough.mp4)

Homepage, docs navigation, and Algolia search all render correctly in the running dev server.

[Homepage](https://cursor.com/agents/bc-b93b9a59-78bd-47a2-91b3-0a882493f3a7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_installation.webp)
[Docs page](https://cursor.com/agents/bc-b93b9a59-78bd-47a2-91b3-0a882493f3a7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_endpoint_methods.webp)
[Search](https://cursor.com/agents/bc-b93b9a59-78bd-47a2-91b3-0a882493f3a7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_endpoint.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b93b9a59-78bd-47a2-91b3-0a882493f3a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b93b9a59-78bd-47a2-91b3-0a882493f3a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

