### PR TITLE
docs: Add intro for the serverpod database command

### DIFF
--- a/docs/06-concepts/cli/commands/database/_database.md
+++ b/docs/06-concepts/cli/commands/database/_database.md
@@ -1,0 +1,5 @@
+# serverpod database
+
+The `serverpod database` command manages the embedded PostgreSQL database of a Serverpod project. Use `serverpod database start` to boot the database on its own, without starting the server, and keep it running until you stop it with Ctrl+C. This is useful for connecting external database tools while the server is stopped.
+
+The database configuration comes from the run mode selected with `--mode`, which must have `database.dataPath` set. For that option and its default, see the [Configuration reference](../../../lookups/configuration-reference.md).


### PR DESCRIPTION
Follow-up to #690, which added the generated reference for the new `serverpod database` command with an empty curated intro (the generator scaffolds `_<command>.md` empty and preserves it across regenerations).

This adds the intro so the page gets its heading and a short description, matching the other command pages. It also covers the one requirement the generated usage text doesn't surface: the selected run mode must configure `database.dataPath` (verified against the command implementation in serverpod/serverpod@9fc0b8f).

The Configuration reference link uses a relative file path rather than an absolute `/concepts/...` slug: the target page only exists in `next` so far, and the absolute form fails the build's broken-link check against the released version.