### PR TITLE
docs: Document sending custom Redis commands

### DIFF
--- a/docs/06-concepts/07-operations/01-caching.md
+++ b/docs/06-concepts/07-operations/01-caching.md
@@ -103,3 +103,21 @@ Future<UserData> getUserData(Session session, int userId) async {
 ```
 
 If the `CacheMissHandler` returns `null`, no object will be stored in the cache.
+
+## Sending custom Redis commands
+
+Redis supports operations that the global cache does not expose, such as atomic counters and sorted sets. If you want to use these operations, you can borrow the connection Serverpod already manages and send the command using `getConnection`:
+
+```dart
+Future<int?> incrementCounter(Session session, String counterName) async {
+  var command = await session.serverpod.redisController?.getConnection();
+  if (command == null) return null;
+
+  var result = await command.send_object(['INCR', 'my_app:$counterName']);
+  return result is int ? result : null;
+}
+```
+
+The connection is `null` when Redis is disabled or unreachable, including when the global cache is running on its in-memory development fallback. Responses come back in the shape Redis defines for the command, so check the result before casting it.
+
+The returned `RedisCommand` is Serverpod's own connection. Do not close it or replace `Serverpod.redisController`. It is also a good practice to namespace your keys so they cannot collide with Serverpod's cache entries.


### PR DESCRIPTION
## Summary

`RedisController.getConnection()` and the `RedisCommand` type are now exported, letting servers send Redis commands that the cache and server events APIs do not expose. The caching page had no coverage of this extension point.

## Changes

- Add a "Sending custom Redis commands" section at the end of the caching page.
- Show reading the controller from the session, requesting a connection, and sending a command.
- Explain that the connection is nullable when Redis is disabled or unreachable, including the development fallback case.
- State the ownership rules: the connection is borrowed, not owned, and must not be closed or replaced.
- Note that custom commands write directly to Redis, so keys need namespacing.
- Replace "makes it easy to" in the page intro, per the style guide.

## Reference

- serverpod/serverpod#5391
- serverpod/serverpod#5333