### PR TITLE
docs: Document the `enableLogging` option on `withSession`

### DIFF
--- a/docs/06-concepts/02-endpoints-and-apis/02-sessions.md
+++ b/docs/06-concepts/02-endpoints-and-apis/02-sessions.md
@@ -53,7 +53,7 @@ class ExampleEndpoint extends Endpoint {
 
 ## Session lifecycle
 
-Serverpod creates the session when the request or task starts and closes it when the work completes. Closing finalizes the session's log and releases its resources. The exception is `InternalSession`: you [create it yourself](#create-a-session-for-background-work), so you close it yourself.
+Serverpod creates the session when the request or task starts and closes it when the work completes. Closing finalizes the session's log and releases its resources. The exception is `InternalSession`, which you [create yourself](#create-a-session-for-background-work) for background work and which stays open until something closes it.
 
 ### Run cleanup when a session closes
 
@@ -90,6 +90,15 @@ await pod.withSession((session) async {
 ```
 
 If the callback throws, the session is closed with the error and stack trace attached, so they reach the logs, and the error is rethrown.
+
+Session logging is on by default. Pass `enableLogging: false` for work that does not need a session log entry of its own, such as a refresh that runs on a short interval:
+
+```dart
+await pod.withSession(
+  (session) => refreshInMemoryState(session),
+  enableLogging: false,
+);
+```
 
 If you need to manage the lifetime yourself, create the session manually and close it when done. An unclosed session is never finalized and its resources are not released, so pair `createSession` with a `finally`:
 


### PR DESCRIPTION
## Summary

This branch started as full coverage for `Serverpod.withSession`. #693 landed first and already covers the method, its automatic close on success and failure, and the contrast with a session the caller already has, so this is now the remainder.

## Changes

- Document `enableLogging: false` on `withSession`, and when to reach for it.
- Reword the lifecycle sentence about `InternalSession`, which read as if the caller always has to close it by hand even though `withSession` does that.

## Reference

- serverpod/serverpod#5364
- serverpod/serverpod#3881