### PR TITLE
docs: Rework the Web server section for 4.0

### DIFF
--- a/docs/06-concepts/05-web-server/01-overview.md
+++ b/docs/06-concepts/05-web-server/01-overview.md
@@ -157,7 +157,7 @@ When you deploy, the web server ships with the rest of your project. On [Serverp
 
 - **[Routing](routing)** - Match requests to handlers by method and URL pattern
 - **[Request data](request-data)** - Access path parameters, query parameters, headers, and body
-- **[Middleware](./web-server-middleware)** - Intercept and transform requests and responses
+- **[Web server middleware](./web-server-middleware)** - Intercept and transform requests and responses
 - **[Static files](static-files)** - Serve static assets
 - **[Server-side HTML](server-side-html)** - Render HTML on the server with templates or Jaspr
 - **[Single-page apps](single-page-apps)** - Serve SPAs with client-side routing

--- a/docs/06-concepts/05-web-server/01-overview.md
+++ b/docs/06-concepts/05-web-server/01-overview.md
@@ -1,18 +1,20 @@
 ---
-description: Serverpod's built-in web server, built on the Relic framework, lets you serve web pages, REST APIs, webhooks, and static files alongside your application server.
+description: Serverpod's built-in web server serves REST APIs, webhooks, static files, server-rendered HTML, and Flutter web apps alongside the API server.
 ---
 
 # Overview
 
-In addition to the application server, Serverpod comes with a built-in web server. The web server allows you to access your database and business layer the same way you would from a method call from an app. This makes it simple to share data for applications that need both an app and traditional web pages. You can also use the web server to create webhooks or define custom REST APIs to communicate with third-party services.
+Serverpod comes with a built-in web server that runs beside the API server. It serves anything that speaks plain HTTP: REST APIs and webhooks, static files, server-rendered HTML with templates or [Jaspr](https://jaspr.site), and single-page apps including Flutter web. Web requests get the same [`Session`](../endpoints-and-apis/sessions) your endpoint methods receive, with full access to your database and business logic. The web server is built on the [Relic](https://github.com/serverpod/relic) framework, and its routing engine, middleware system, and typed headers are available directly.
 
-Serverpod's web server is built on the [Relic](https://github.com/serverpod/relic) framework, giving you access to its routing engine, middleware system, and typed headers. This means you get the benefits of Serverpod's database integration and business logic alongside Relic's web server capabilities.
+The web server and the API server answer different callers. [Endpoints](../endpoints-and-apis) are the typed methods your own app calls through the generated client. Web server **routes** serve everyone else: browsers, webhooks, third-party services, and anything that needs a URL. If you are building a feature for your Flutter app, write an endpoint. If something outside your app needs to reach your server over HTTP, write a route.
 
 ## Your first route
 
-When you create a new Serverpod project, it sets up a web server by default. Here's how to add a simple API endpoint:
+New Serverpod projects set up the web server by default, with working web code in `lib/src/web/` and assets in `web/`. Here's how to add a simple JSON route:
 
 ```dart
+import 'dart:convert';
+
 import 'package:serverpod/serverpod.dart';
 
 class HelloRoute extends Route {
@@ -35,13 +37,17 @@ pod.webServer.addRoute(HelloRoute(), '/api/hello');
 await pod.start();
 ```
 
-Visit `http://localhost:8082/api/hello` to see your API response.
+Visit `http://localhost:8082/api/hello` to see your response. Port 8082 is the web server's default development port, configured per run mode in the [server configuration](../server-fundamentals/configuration).
+
+:::info
+If your project was created with the "None" web server option, the first use of `pod.webServer` throws `Bad state: Web server is disabled`. To enable it, add the `webServer` section to your `config/<run mode>.yaml` files and register at least one route before `pod.start()`. With a configuration but no routes, the web server simply does not start.
+:::
 
 ## Core concepts
 
 ### Routes and handlers
 
-A **Route** is a destination in your web server that handles requests and generates responses. Routes extend the `Route` base class and implement the `handleCall()` method:
+A **route** is a destination in your web server that handles requests and generates responses. Routes extend the `Route` base class and implement the `handleCall()` method:
 
 ```dart
 class ApiRoute extends Route {
@@ -55,25 +61,41 @@ class ApiRoute extends Route {
 
 The `handleCall()` method receives:
 
-- **Session** - Access to your database, logging, and authenticated user
-- **Request** - The HTTP request with headers, body, and URL information
+- **Session** - Access to your database, logging, and authenticated user. The web server creates a `WebCallSession` for each request and closes it when the response is sent.
+- **Request** - The HTTP request with headers, body, and URL information.
+
+By default, a route answers GET requests only. Pass `methods:` to the constructor to accept others:
+
+```dart
+class FormRoute extends Route {
+  FormRoute() : super(methods: {Method.get, Method.post});
+  // ...
+}
+```
+
+A request with a method the route does not accept gets an automatic `405 Method Not Allowed` response.
 
 ### Response types
 
-Return different response types based on your needs:
+Each named `Response` constructor maps to an HTTP status code:
 
-```dart
-// Success responses
-return Response.ok(body: Body.fromString('Success'));
-return Response.created(body: Body.fromString('Created'));
-return Response.noContent();
+| Constructor | Status |
+| --- | --- |
+| `Response.ok` | 200 |
+| `Response.noContent` | 204 |
+| `Response.movedPermanently` | 301 |
+| `Response.found` | 302 |
+| `Response.seeOther` | 303 |
+| `Response.notModified` | 304 |
+| `Response.badRequest` | 400 |
+| `Response.unauthorized` | 401 |
+| `Response.forbidden` | 403 |
+| `Response.notFound` | 404 |
+| `Response.contentTooLarge` | 413 |
+| `Response.internalServerError` | 500 |
+| `Response.notImplemented` | 501 |
 
-// Error responses
-return Response.badRequest(body: Body.fromString('Invalid input'));
-return Response.unauthorized(body: Body.fromString('Not authenticated'));
-return Response.notFound(body: Body.fromString('Not found'));
-return Response.internalServerError(body: Body.fromString('Server error'));
-```
+Status codes without a named constructor, such as `201 Created`, use the generic form: `Response(201, body: ...)`.
 
 ### Adding routes
 
@@ -83,47 +105,25 @@ Routes are added with a path pattern:
 // Exact path
 pod.webServer.addRoute(UserRoute(), '/api/users');
 
-// Path with wildcard
+// Serve a directory (tail matching is automatic)
 pod.webServer.addRoute(StaticRoute.directory(Directory('web')), '/static/');
 ```
 
-Routes are matched in the order they were added.
+Paths can contain parameters and wildcards, and requests are matched by specificity rather than registration order. See [Routing](routing) for the matching rules.
+
+### Built-in routes
+
+Every web server automatically answers the health probe paths `/livez`, `/readyz`, and `/startupz`. A healthy server responds with an empty `200 OK`, and deployment platforms use these paths to check that the server is alive. These paths are reserved, so avoid registering your own routes on them.
 
 ## When to use what
 
-### REST APIs → custom routes
-
-For REST APIs, webhooks, or custom HTTP handlers, use custom `Route` classes:
-
-```dart
-class UsersApiRoute extends Route {
-  UsersApiRoute() : super(methods: {Method.get, Method.post});
-  
-  @override
-  Future<Result> handleCall(Session session, Request request) async {
-    if (request.method == Method.get) {
-      // List users
-    } else {
-      // Create user
-    }
-  }
-}
-```
-
-See [Routing](routing) for details.
-
-### Static files → `StaticRoute`
-
-For serving CSS, JavaScript, images, or other static assets:
-
-```dart
-pod.webServer.addRoute(
-  StaticRoute.directory(Directory('web/static')),
-  '/static/',
-);
-```
-
-See [Static Files](static-files) for cache-busting and optimization.
+| You want to serve | Route type | Page |
+| --- | --- | --- |
+| REST APIs, webhooks, custom HTTP handlers | Your own `Route` subclass | [Routing](routing) |
+| Static assets: CSS, JavaScript, images | `StaticRoute` | [Static files](static-files) |
+| Server-rendered HTML, with templates or Jaspr | `WidgetRoute`, or a route rendering Jaspr | [Server-side HTML](server-side-html) |
+| A single-page app with client-side routing | `SpaRoute` | [Single-page apps](single-page-apps) |
+| Your Flutter app compiled for the web | `FlutterRoute` | [Flutter web](flutter-web) |
 
 ## Database access
 
@@ -135,10 +135,10 @@ class UserRoute extends Route {
   Future<Result> handleCall(Session session, Request request) async {
     // Query database
     final users = await User.db.find(session);
-    
+
     // Use logging
     session.log('Retrieved ${users.length} users');
-    
+
     return Response.ok(
       body: Body.fromString(
         jsonEncode(users.map((u) => u.toJson()).toList()),
@@ -149,12 +149,16 @@ class UserRoute extends Route {
 }
 ```
 
+## Going to production
+
+When you deploy, the web server ships with the rest of your project. On [Serverpod Cloud](../../deployments/deploy-to-serverpod-cloud), it is served through a CDN that honors the cache headers your routes set. See [Content delivery and caching](/cloud/concepts/cdn) for how the two interact.
+
 ## Next steps
 
 - **[Routing](routing)** - Match requests to handlers by method and URL pattern
-- **[Request Data](request-data)** - Access path parameters, query parameters, headers, and body
+- **[Request data](request-data)** - Access path parameters, query parameters, headers, and body
 - **[Middleware](./web-server-middleware)** - Intercept and transform requests and responses
-- **[Static Files](static-files)** - Serve static assets
-- **[Server-side HTML](server-side-html)** - Render HTML dynamically on the server
-- **[Single Page Apps](single-page-apps)** - Serve SPAs with client-side routing
-- **[Flutter Web Apps](flutter-web)** - Serve Flutter web applications
+- **[Static files](static-files)** - Serve static assets
+- **[Server-side HTML](server-side-html)** - Render HTML on the server with templates or Jaspr
+- **[Single-page apps](single-page-apps)** - Serve SPAs with client-side routing
+- **[Flutter web](flutter-web)** - Serve Flutter web applications

--- a/docs/06-concepts/05-web-server/02-routing.md
+++ b/docs/06-concepts/05-web-server/02-routing.md
@@ -4,11 +4,7 @@ description: Routing in Serverpod's web server supports HTTP method filtering, p
 
 # Routing
 
-Routes are the foundation of your web server, directing incoming HTTP requests
-to the right handlers. While simple routes work well for basic APIs, Serverpod
-provides routing features for complex applications: HTTP method
-filtering, path parameters, wildcards, and fallback handling. Understanding
-these patterns helps you build clean, maintainable APIs.
+Routing decides which of your `Route` classes answers an incoming HTTP request. This page covers the matching rules, HTTP method filtering, path parameters, wildcards, fallback handling, and virtual hosts.
 
 ## Route classes
 
@@ -62,10 +58,13 @@ The examples in this documentation omit error handling for brevity.
 
 :::
 
+## How requests are matched
+
+Requests are matched by specificity, not by the order routes were registered. A literal path segment such as `/users/list` wins over a dynamic one such as `/users/:id` or a wildcard. Registering two routes with the same method and path throws at startup with `Invalid argument(s): Conflicting values`, so conflicts surface immediately rather than silently shadowing each other.
+
 ## HTTP methods
 
-Routes can specify which HTTP methods they respond to using the `methods`
-parameter.
+Routes answer GET requests only by default. Use the `methods` parameter to specify which HTTP methods a route responds to:
 
 ```dart
 class UserRoute extends Route {
@@ -75,6 +74,8 @@ class UserRoute extends Route {
   // ...
 }
 ```
+
+A request whose method is not in the set gets an automatic `405 Method Not Allowed` response with an `Allow` header listing the accepted methods.
 
 ## Path parameters
 
@@ -120,7 +121,7 @@ Future<Result> handleCall(Session session, Request request) async {
   final remainingPath = request.remainingPath;
 
   // Access query parameters
-  final query = request.url.queryParameters['query'];
+  final query = request.queryParameters.raw['query'];
 
   return Response.ok(
     body: Body.fromString('Path: $remainingPath, Query: $query'),
@@ -146,6 +147,8 @@ class NotFoundRoute extends Route {
 pod.webServer.fallbackRoute = NotFoundRoute();
 ```
 
+The fallback runs only when no route matches the request. If a route matches but its handler returns a 404, the fallback is not invoked. To rewrite those responses, use [`FallbackMiddleware`](single-page-apps#using-fallbackmiddleware-directly) instead.
+
 :::tip Advanced: Grouping routes into modules
 
 As your web server grows, managing dozens of individual route registrations can
@@ -165,9 +168,14 @@ class UserCrudModule extends Route {
       ..get('/:id', _get);
   }
 
+  // Not used when injectIn registers its own handlers.
+  @override
+  Future<Result> handleCall(Session session, Request request) =>
+      throw UnimplementedError();
+
   // Handler methods
   Future<Result> _list(Request request) async {
-    final session = request.session;
+    final session = await request.session;
     final users = await User.db.find(session);
 
     return Response.ok(
@@ -203,17 +211,15 @@ class UserCrudModule extends Route {
 pod.webServer.addRoute(UserCrudModule(), '/api/users');
 ```
 
-This creates `GET /api/users` and `GET /api/users/:id` endpoints.
+This creates `GET /api/users` and `GET /api/users/:id` routes.
 
-Handlers receive only a `Request` parameter. To access the `Session`,
-use `request.session` (unlike `Route.handleCall()` which receives both as
-explicit parameters).
+Handlers receive only a `Request` parameter. To access the `Session`, use `request.session`, which returns a `Future<Session>` that must be awaited. The `handleCall()` override is still required by the base class, but it is never called when `injectIn` registers its own handlers, so throwing `UnimplementedError` is the expected pattern. Typed path parameter accessors such as `IntPathParam` are covered in [Request data](request-data).
 
 :::
 
 ## Virtual host routing
 
-Virtual host routing allows you to serve different content based on the `Host` header of incoming requests. This is useful for multi-tenant applications or serving different front-ends from distinct subdomains using a single server instance - like an API on `api.example.com`, a web app on `www.example.com`, and an admin panel on `admin.example.com`.
+Virtual host routing allows you to serve different content based on the `Host` header of incoming requests. This is useful for multi-tenant applications, or for serving different front-ends from distinct subdomains with a single server instance, such as an API on `api.example.com`, a web app on `www.example.com`, and an admin panel on `admin.example.com`.
 
 ### How it works
 
@@ -262,7 +268,11 @@ pod.webServer.addRoute(ApiRoute(), '/v1');
 
 // Route that only responds to www.example.com
 pod.webServer.addRoute(
-  SpaRoute(webDir, fallback: index, host: 'www.example.com'),
+  SpaRoute(
+    Directory('web/app'),
+    fallback: File('web/app/index.html'),
+    host: 'www.example.com',
+  ),
   '/',
 );
 
@@ -276,8 +286,8 @@ All route types support virtual host routing:
 
 - **Custom routes** - Pass `host` to the `Route` constructor
 - **StaticRoute** - Use `host` parameter in `StaticRoute.directory()` or `StaticRoute.file()`
-- **SpaRoute** - Use `host` parameter in the `SpaRoute` constructor
-- **FlutterRoute** - Use `host` parameter in the `FlutterRoute` constructor
+- **[SpaRoute](single-page-apps)** - Use `host` parameter in the `SpaRoute` constructor
+- **[FlutterRoute](flutter-web)** - Use `host` parameter in the `FlutterRoute` constructor
 
 ```dart
 // Static files for a specific host
@@ -302,7 +312,7 @@ pod.webServer.addRoute(
 
 ## Next steps
 
-- **[Request Data](request-data)** - Access path parameters, query parameters, headers, and body
+- **[Request data](request-data)** - Access path parameters, query parameters, headers, and body
 - **[Middleware](./web-server-middleware)** - Intercept and transform requests and responses
-- **[Static Files](static-files)** - Serve static assets
-- **[Server-side HTML](server-side-html)** - Render HTML dynamically on the server
+- **[Static files](static-files)** - Serve static assets
+- **[Server-side HTML](server-side-html)** - Render HTML on the server

--- a/docs/06-concepts/05-web-server/03-request-data.md
+++ b/docs/06-concepts/05-web-server/03-request-data.md
@@ -2,7 +2,7 @@
 description: Request data in Serverpod's web server is accessible via Relic's type-safe accessors for path parameters, query parameters, headers, and the request body.
 ---
 
-# Request Data
+# Request data
 
 Once a route matches, you'll need to extract data from the request. Relic
 provides type-safe accessors for path parameters, query parameters, headers,
@@ -35,9 +35,7 @@ class UserRoute extends Route {
 }
 ```
 
-The `IntPathParam` combines the symbol (`#id`) with a parser, throwing if the
-parameter is missing or not a valid integer. You can also access raw unparsed
-values with `request.pathParameters.raw[#id]`.
+The `IntPathParam` combines a symbol with a parser, throwing if the parameter is missing or not a valid integer. The `#id` is a Dart Symbol literal naming the `:id` segment from the route's path pattern. You can also access raw unparsed values with `request.pathParameters.raw[#id]`.
 
 ## Query parameters
 
@@ -55,6 +53,8 @@ class SearchRoute extends Route {
   }
 }
 ```
+
+Like the path accessors, `get()` throws when the parameter is missing. Query parameters are often optional, so use raw access with a default for those, e.g. `int.tryParse(request.queryParameters.raw['page'] ?? '') ?? 1`.
 
 ## Headers
 
@@ -91,21 +91,13 @@ Relic also exposes typed setters for standard headers. See the [Relic documentat
 
 ## Body
 
-Read the request body using the appropriate method for your content type:
+Read the request body as a string for JSON or form data:
 
 ```dart
 @override
 Future<Result> handleCall(Session session, Request request) async {
-  // Read as string (for JSON, form data, etc.)
   final body = await request.readAsString();
   final data = jsonDecode(body);
-
-  // Or read as stream for large uploads
-  final stream = request.read();
-  await for (final chunk in stream) {
-    // Process chunk
-  }
-
   // ...
 }
 ```
@@ -115,11 +107,36 @@ The body can only be read once. Attempting to read it again will throw a
 `StateError`.
 :::
 
+### Streaming bodies
+
+For large payloads, stream instead of buffering the whole body in memory. On the request side, `request.read()` gives you the body as a stream of chunks, which suits large uploads:
+
+```dart
+final stream = request.read();
+await for (final chunk in stream) {
+  // Process chunk
+}
+```
+
+On the response side, `Body.fromDataStream` streams data to the client as it is produced, for example when serving a large file:
+
+```dart
+Stream<Uint8List> dataStream = getFileStream();
+
+return Response.ok(
+  body: Body.fromDataStream(
+    dataStream,
+    contentLength: fileSize,
+    mimeType: MimeType.octetStream,
+  ),
+);
+```
+
 For more details on typed parameters and headers, see the
 [Relic documentation](https://docs.dartrelic.dev/).
 
 ## Next steps
 
 - **[Middleware](./web-server-middleware)** - Intercept and transform requests and responses
-- **[Static Files](static-files)** - Serve static assets
-- **[Server-side HTML](server-side-html)** - Render HTML dynamically on the server
+- **[Static files](static-files)** - Serve static assets
+- **[Server-side HTML](server-side-html)** - Render HTML on the server

--- a/docs/06-concepts/05-web-server/04-web-server-middleware.md
+++ b/docs/06-concepts/05-web-server/04-web-server-middleware.md
@@ -2,7 +2,7 @@
 description: Middleware in Serverpod's web server lets you apply cross-cutting concerns like authentication, logging, and CORS globally or to specific path prefixes.
 ---
 
-# Middleware
+# Web server middleware
 
 Routes handle the core logic of your application, but many concerns cut across
 multiple routes: logging every request, validating API keys, handling CORS
@@ -11,9 +11,9 @@ middleware lets you apply it globally or to specific path prefixes.
 
 Middleware functions are wrappers that sit between the incoming request and your
 route handler. They can inspect or modify requests before they reach your
-routes, and transform responses before they're sent back to the client. This
-makes middleware perfect for authentication, logging, error handling, and any
-other cross-cutting concern in your web server.
+routes, and transform responses before they're sent back to the client.
+
+The middleware on this page applies only to web server routes. For middleware around your endpoint methods, see [Endpoint middleware](../endpoints-and-apis/endpoint-middleware).
 
 ## Adding middleware
 
@@ -76,22 +76,19 @@ pod.webServer.addMiddleware(apiKeyMiddleware, '/api');
 ```
 
 :::info
-For user authentication, use Serverpod's built-in authentication system which
-integrates with the `Session` object. The middleware examples here are for
+For user authentication, use Serverpod's built-in [authentication](../authentication/basics) system, which
+integrates with the `Session` object your route's `handleCall` receives. The middleware examples here are for
 additional web-specific validations like API keys, rate limiting, or request
 validation.
-
 :::
 
 ## Middleware execution order
 
-Middleware is applied based on path hierarchy, with more specific paths taking
-precedence. Within the same path, middleware executes in the order it was
-registered:
+Middleware wraps your routes in layers based on path hierarchy. Middleware registered on a broader path runs first, and middleware on a more specific path runs closer to the route handler. Within the same path, middleware executes in the order it was registered:
 
 ```dart
-pod.webServer.addMiddleware(rateLimitMiddleware, '/api/users'); // Executes last for /api (inner)
-pod.webServer.addMiddleware(apiKeyMiddleware, '/api');          // Executes first for /api (outer)
+pod.webServer.addMiddleware(rateLimitMiddleware, '/api/users'); // Runs second for /api/users/list
+pod.webServer.addMiddleware(apiKeyMiddleware, '/api');          // Runs first for /api/users/list
 ```
 
 For a request to `/api/users/list`, the execution order is:
@@ -129,11 +126,10 @@ subdomain, or a logging middleware might generate a request ID for tracing.
 Since `Request` objects are immutable, you can't just add properties to them.
 This is where `ContextProperty` comes in.
 
-`ContextProperty<T>` provides a type-safe way to attach data to a `Request`
+A `ContextProperty<T>` provides a type-safe way to attach data to a `Request`
 object without modifying it. Think of it as a side channel for request-scoped
 data that middleware can write to and routes can read from. The data is
-automatically cleaned up when the request completes, making it perfect for
-per-request state. For more details, see the [Relic documentation](https://docs.dartrelic.dev/).
+automatically cleaned up when the request completes. For more details, see the [Relic documentation](https://docs.dartrelic.dev/).
 
 :::info
 
@@ -154,8 +150,8 @@ final _tenantProperty = ContextProperty<String>('tenant');
 
 // Create a public getter extension to allow handlers and other middleware to
 // read, but not modify the context property.
-extension tenantPropertyEx on Request {
-  String get tenant => _tenantProperty.get(this); // get throw on null, [] doesn't  
+extension TenantRequestEx on Request {
+  String get tenant => _tenantProperty.get(this); // get() throws when unset; [] returns null instead.
 }
 ```
 
@@ -165,15 +161,13 @@ Middleware can set values on the context property, making them available to all
 downstream handlers:
 
 ```dart
-// in same file
- 
 // Tenant identification middleware (extracts from subdomain)
 Handler tenantMiddleware(Handler next) {
   return (Request request) async {
     final host = request.headers.host;
 
     // Validate tenant exists (implement your own logic)
-    final session = request.session;
+    final session = await request.session;
     final tenant = await extractAndValidateTenant(session, host);
 
     if (tenant == null) {
@@ -202,8 +196,9 @@ class TenantDataRoute extends Route {
     final tenant = request.tenant; // using the previously defined extension
 
     // Fetch tenant-specific data
-    final data = await session.db.find<Product>(
-      where: (p) => p.tenantId.equals(tenant),
+    final data = await Product.db.find(
+      session,
+      where: (t) => t.tenantId.equals(tenant),
     );
 
     return Response.ok(
@@ -218,6 +213,6 @@ class TenantDataRoute extends Route {
 
 ## Next steps
 
-- **[Request Data](request-data)** - Access path parameters, query parameters, headers, and body
-- **[Static Files](static-files)** - Serve static assets
-- **[Server-side HTML](server-side-html)** - Render HTML dynamically on the server
+- **[Request data](request-data)** - Access path parameters, query parameters, headers, and body
+- **[Static files](static-files)** - Serve static assets
+- **[Server-side HTML](server-side-html)** - Render HTML on the server

--- a/docs/06-concepts/05-web-server/05-static-files.md
+++ b/docs/06-concepts/05-web-server/05-static-files.md
@@ -4,9 +4,7 @@ description: Static file serving in Serverpod supports automatic content-type de
 
 # Static files
 
-Static assets like images, CSS, and JavaScript files are essential for web
-applications. The `StaticRoute.directory()` method makes it easy to serve entire
-directories with automatic content-type detection for common file formats.
+The `StaticRoute` class serves files from disk: images, CSS, JavaScript, fonts, or any other asset, with automatic content-type detection for common file formats. This page covers serving directories and single files, cache headers, and cache busting.
 
 ## Serving static files
 
@@ -24,35 +22,47 @@ pod.webServer.addRoute(
 This serves all files from the `web/static` directory at the `/static` path.
 For example, `web/static/logo.png` becomes accessible at `/static/logo.png`.
 
+To serve one specific file instead of a directory, use `StaticRoute.file(File('web/pages/landing.html'))`.
+
 :::info
-
-`StaticRoute.directory()` automatically handles tail matching, so you don't need
+The `StaticRoute.directory()` factory automatically handles tail matching, so you don't need
 to add `**` to the path. The route will serve all files under the given prefix.
-
 :::
 
 ## Cache control
 
-Control how browsers and CDNs cache your static files using the
-`cacheControlFactory` parameter:
+By default, `StaticRoute` sends no `Cache-Control` header at all. Responses still carry `ETag` and `Last-Modified` headers, so browsers revalidate with [conditional requests](#conditional-requests-etags-and-last-modified) and receive a `304 Not Modified` when the file is unchanged.
+
+To set a caching policy, pass one of the cache-control helpers as the `cacheControlFactory` parameter:
+
+| Helper | Resulting header | Use when |
+| --- | --- | --- |
+| `StaticRoute.public(maxAge: ...)` | `public, max-age=N` | Assets that change occasionally. Caches keep them for the given lifetime |
+| `StaticRoute.publicImmutable(maxAge: ...)` | `immutable, public, max-age=N` | Cache-busted assets whose URL changes with the content. Use a long lifetime |
+| `StaticRoute.privateNoCache()` | `no-cache, private` | Per-user content that must be revalidated on every request |
+| `StaticRoute.noStore()` | `no-store` | Content that must never be cached |
 
 ```dart
 pod.webServer.addRoute(
   StaticRoute.directory(
     staticDir,
-    cacheControlFactory: StaticRoute.publicImmutable(maxAge: const Duration(minutes: 5)),
+    cacheControlFactory: StaticRoute.public(maxAge: const Duration(minutes: 5)),
   ),
   '/static/',
 );
 ```
 
+Reserve `publicImmutable` for [cache-busted](#static-file-cache-busting) assets: `immutable` tells caches to never revalidate, which is only safe when a changed file also gets a new URL.
+
+On [Serverpod Cloud](/cloud/concepts/cdn), a CDN sits in front of the web server and honors these headers, and its cache is cleared on every deploy.
+
 ## Static file cache-busting
 
-When deploying static assets, browsers and CDNs (like CloudFront) cache files
+When deploying static assets, browsers and CDNs cache files
 aggressively for performance. This means updated files may not be served to
 users unless you implement a cache-busting strategy.
 
-Serverpod provides `CacheBustingConfig` to automatically version your static
+Relic provides `CacheBustingConfig` to automatically version your static
 files. For more details, see the [Relic documentation](https://docs.dartrelic.dev/).
 
 ```dart
@@ -68,11 +78,13 @@ pod.webServer.addRoute(
   StaticRoute.directory(
     staticDir,
     cacheBustingConfig: cacheBustingConfig,
-    cacheControlFactory: StaticRoute.publicImmutable(maxAge: const Duration(minutes: 5)),
+    cacheControlFactory: StaticRoute.publicImmutable(maxAge: const Duration(days: 365)),
   ),
   '/static/',
 );
 ```
+
+With cache busting, a changed file gets a new URL, so caches can safely keep each version for a long time. This is the setup where `publicImmutable` with a long lifetime belongs.
 
 ### Generating versioned URLs
 
@@ -95,10 +107,10 @@ The cache-busting system:
 - Works transparently - requesting `/static/logo@abc123.png` serves
   `/static/logo.png`
 
-## Conditional requests (`Etags` and `Last-Modified`)
+## Conditional requests (ETags and Last-Modified)
 
-`StaticRoute` automatically supports HTTP conditional requests through Relic's
-`StaticHandler`. This provides efficient caching without transferring file
+Every `StaticRoute` automatically supports HTTP conditional requests through Relic's
+`StaticHandler`, along with `Range` requests for partial downloads. This provides efficient caching without transferring file
 content when unchanged:
 
 **Supported features:**
@@ -139,8 +151,6 @@ ETag: "abc123"
 [no body - saves bandwidth]
 ```
 
-When combined with cache-busting, conditional requests provide a fallback
-validation mechanism even for cached assets, ensuring efficient delivery while
-maintaining correctness.
+Conditional requests do the caching work in the default setup and with `public(maxAge:)`, where clients revalidate once a file's lifetime expires. With cache-busted `immutable` assets, clients skip revalidation entirely by design, since a changed file gets a new URL instead.
 
 For dynamic content that changes per request, see [Server-side HTML](server-side-html).

--- a/docs/06-concepts/05-web-server/06-server-side-html.md
+++ b/docs/06-concepts/05-web-server/06-server-side-html.md
@@ -1,13 +1,12 @@
 ---
-description: Server-side HTML rendering in Serverpod uses WidgetRoute and Mustache templates, with full access to the database and caching.
+description: Server-side HTML rendering in Serverpod uses WidgetRoute with Mustache templates or Jaspr components, with full access to the database.
 ---
 
-# Server-Side HTML
+# Server-side HTML
 
-For simple HTML pages, you can use `WidgetRoute` and `TemplateWidget`. The
-`WidgetRoute` provides an entry point for handling requests and returns a
-`WebWidget`. The `TemplateWidget` (which extends `WebWidget`) renders web pages
-using Mustache templates.
+Server-rendered pages generate their HTML on the server for each request, with full access to your database through the `Session`. Choose this for content pages, dashboards, and landing pages. For client-rendered apps, see [Single-page apps](single-page-apps) instead.
+
+Serverpod's built-in mechanism for this is `WidgetRoute` with [Mustache](https://mustache.github.io/) templates. Beyond it, any route can return HTML that you produce with a tool of your choice. This page covers both, using [Jaspr](https://jaspr.site), which brings a Flutter-like component model to the web, as the worked example of the second approach.
 
 ## Creating a WidgetRoute
 
@@ -17,7 +16,7 @@ Create custom routes by extending the `WidgetRoute` class and implementing the
 ```dart
 class MyRoute extends WidgetRoute {
   @override
-  Future<TemplateWidget> build(Session session, Request request) async {
+  Future<WebWidget> build(Session session, Request request) async {
     return MyPageWidget(title: 'Home page');
   }
 }
@@ -26,10 +25,13 @@ class MyRoute extends WidgetRoute {
 pod.webServer.addRoute(MyRoute(), '/my/page/address');
 ```
 
+The `build` method returns the widget that renders the page. In this example, that widget is `MyPageWidget`, which the [next section](#creating-a-templatewidget) defines.
+
+Like other routes, a `WidgetRoute` answers GET requests by default. Pass `methods:` to handle form submissions too, e.g. `super(methods: {Method.get, Method.post})`. Rendered responses are sent with `Cache-Control: no-cache, private`, so browsers and CDNs revalidate them on every request. The exception is `RedirectWidget`, whose 303 response carries no cache header.
+
 ## Creating a TemplateWidget
 
-A `TemplateWidget` consists of a Dart class and a corresponding HTML template
-file. Create a custom widget by extending `TemplateWidget`:
+A `TemplateWidget` renders a Mustache template. It is a subclass of `WebWidget`, which is what allows `MyRoute`'s `build` method above to return one. A template widget consists of a Dart class and a corresponding HTML template file. Create one by extending `TemplateWidget`:
 
 ```dart
 class MyPageWidget extends TemplateWidget {
@@ -58,8 +60,11 @@ file uses the [Mustache](https://mustache.github.io/) template language:
 ```
 
 Template values are converted to `String` objects before being passed to the
-template. This makes it possible to nest widgets, similarly to how widgets work
-in Flutter.
+template. Mustache escapes HTML in `{{value}}` tags, so to embed HTML produced by a nested widget, use the unescaped `{{{value}}}` form.
+
+### How templates load
+
+Templates are loaded from `web/templates` when the server starts. Constructing a `TemplateWidget` whose template file is missing throws a `StateError` naming the widget class, e.g. `Template my_page.html missing for MyPageWidget`, and the request fails with a 500. While `serverpod start` runs, templates reload on save and the browser refreshes automatically. With a plain `dart run bin/main.dart`, restart the server to pick up template changes.
 
 ## Built-in widgets
 
@@ -68,7 +73,7 @@ Serverpod provides several built-in widgets for common use cases:
 - **`ListWidget`** - Concatenates multiple widgets into a single response
 
   ```dart
-  return ListWidget(children: [
+  return ListWidget(widgets: [
     HeaderWidget(),
     ContentWidget(),
     FooterWidget(),
@@ -78,13 +83,13 @@ Serverpod provides several built-in widgets for common use cases:
 - **`JsonWidget`** - Renders JSON documents from serializable data structures
 
   ```dart
-  return JsonWidget({'status': 'success', 'data': myData});
+  return JsonWidget(object: {'status': 'success', 'data': myData});
   ```
 
-- **`RedirectWidget`** - Creates HTTP redirects to other URLs
+- **`RedirectWidget`** - Redirects the browser to another URL with a `303 See Other` response
 
   ```dart
-  return RedirectWidget('/new/location');
+  return RedirectWidget(url: '/new/location');
   ```
 
 ## Database access and logging
@@ -97,7 +102,7 @@ same way you would in a method call:
 ```dart
 class DataRoute extends WidgetRoute {
   @override
-  Future<TemplateWidget> build(Session session, Request request) async {
+  Future<WebWidget> build(Session session, Request request) async {
     // Access the database
     final users = await User.db.find(session);
 
@@ -109,19 +114,69 @@ class DataRoute extends WidgetRoute {
 }
 ```
 
-:::info Alternative
+## Rendering with Jaspr
 
-[Jaspr](https://docs.page/schultek/jaspr) provides a Flutter-like API for
-building web applications. You can integrate it with Serverpod's web server
-using custom `Route` classes, giving you full control over request handling
-while using Jaspr's component model.
+[Jaspr](https://jaspr.site) lets you build server-rendered pages from components, with a `build` method and composition model much like Flutter's. It works with the web server through a plain `Route`: your route renders a component to HTML and returns it as the response.
 
+Add the dependency to your server package:
+
+```bash
+$ dart pub add jaspr
+```
+
+Then define a component and a route that renders it:
+
+```dart
+import 'dart:convert';
+
+import 'package:jaspr/dom.dart' as jaspr;
+import 'package:jaspr/server.dart' as jaspr;
+import 'package:serverpod/serverpod.dart';
+
+class HelloPage extends jaspr.StatelessComponent {
+  const HelloPage({required this.name, super.key});
+
+  final String name;
+
+  @override
+  jaspr.Component build(jaspr.BuildContext context) {
+    return jaspr.div([
+      jaspr.h1([jaspr.Component.text('Hello from Jaspr!')]),
+      jaspr.p([jaspr.Component.text('Rendered server-side for $name.')]),
+    ]);
+  }
+}
+
+class JasprHelloRoute extends Route {
+  @override
+  Future<Result> handleCall(Session session, Request request) async {
+    final result = await jaspr.renderComponent(HelloPage(name: 'Serverpod'));
+    return Response.ok(
+      body: Body.fromString(
+        utf8.decode(result.body),
+        mimeType: MimeType.html,
+      ),
+    );
+  }
+}
+```
+
+Register the route as usual, and initialize Jaspr once in your `run()` function before the server starts:
+
+```dart
+jaspr.Jaspr.initializeApp();
+
+pod.webServer.addRoute(JasprHelloRoute(), '/jaspr');
+```
+
+:::warning
+The `initializeApp()` call is required. Without it, the first render kills the whole server process instead of failing the single request.
 :::
+
+Two details make this example work. Both `package:jaspr/server.dart` and `package:jaspr/dom.dart` are imported under one alias, because `server.dart` exports names that collide with the web server's `Request` and `Response`, and the HTML components (`div`, `h1`, `p`) live in `dom.dart`. And `renderComponent` returns a result record whose `body` is bytes, which `utf8.decode` turns into the HTML string. The example was verified against jaspr 0.23.
 
 ## Next steps
 
-- For modern server-side rendering, explore
-  [Jaspr](https://docs.page/schultek/jaspr) integration
 - Use [custom routes](routing) for REST APIs and custom request handling
 - Serve [static files](static-files) for CSS, JavaScript, and images
 - Add [middleware](./web-server-middleware) for cross-cutting concerns like logging and

--- a/docs/06-concepts/05-web-server/06-server-side-html.md
+++ b/docs/06-concepts/05-web-server/06-server-side-html.md
@@ -118,7 +118,7 @@ class DataRoute extends WidgetRoute {
 
 [Jaspr](https://jaspr.site) lets you build server-rendered pages from components, with a `build` method and composition model much like Flutter's. It works with the web server through a plain `Route`: your route renders a component to HTML and returns it as the response.
 
-Add the dependency to your server package:
+Add the dependency to your server package (the example on this page uses jaspr 0.23):
 
 ```bash
 $ dart pub add jaspr
@@ -173,7 +173,7 @@ pod.webServer.addRoute(JasprHelloRoute(), '/jaspr');
 The `initializeApp()` call is required. Without it, the first render kills the whole server process instead of failing the single request.
 :::
 
-Two details make this example work. Both `package:jaspr/server.dart` and `package:jaspr/dom.dart` are imported under one alias, because `server.dart` exports names that collide with the web server's `Request` and `Response`, and the HTML components (`div`, `h1`, `p`) live in `dom.dart`. And `renderComponent` returns a result record whose `body` is bytes, which `utf8.decode` turns into the HTML string. The example was verified against jaspr 0.23.
+Two details make this example work. Both `package:jaspr/server.dart` and `package:jaspr/dom.dart` are imported under one alias, because `server.dart` exports names that collide with the web server's `Request` and `Response`, and the HTML components (`div`, `h1`, `p`) live in `dom.dart`. And `renderComponent` returns a result record whose `body` is bytes, which `utf8.decode` turns into the HTML string.
 
 ## Next steps
 

--- a/docs/06-concepts/05-web-server/07-single-page-apps.md
+++ b/docs/06-concepts/05-web-server/07-single-page-apps.md
@@ -1,10 +1,10 @@
 ---
-description: Single page apps in Serverpod use SpaRoute to serve static files and fall back to index.html for client-side routing.
+description: Single-page apps in Serverpod use SpaRoute to serve the app's static files and fall back to index.html so client-side routing works.
 ---
 
-# Single page apps
+# Single-page apps
 
-Single Page Applications (SPAs) handle routing on the client side, which requires special server configuration. When users navigate to a route like `/dashboard` or `/settings`, the browser requests that path from the server. Since these aren't real files, the server needs to return the main `index.html` file so the client-side router can handle the route.
+Single-page applications (SPAs) handle routing on the client side, which requires special server configuration. When users navigate to a route like `/dashboard` or `/settings`, the browser requests that path from the server. Since these aren't real files, the server needs to return the main `index.html` file so the client-side router can handle the route.
 
 Serverpod provides `SpaRoute` to handle this pattern automatically.
 
@@ -37,7 +37,7 @@ This configuration:
 
 When a request comes in:
 
-1. `SpaRoute` first tries to serve a matching static file from the directory
+1. The `SpaRoute` first tries to serve a matching static file from the directory
 2. If no file exists (404 response), it serves the fallback file instead
 3. The client-side JavaScript then handles routing based on the URL
 
@@ -52,14 +52,14 @@ pod.webServer.addRoute(
   SpaRoute(
     webDir,
     fallback: File('web/app/index.html'),
-    cacheControlFactory: StaticRoute.publicImmutable(
+    cacheControlFactory: StaticRoute.public(
       maxAge: const Duration(minutes: 5),
     ),
   ),
 );
 ```
 
-See [Static Files](static-files#cache-control) for more on cache control.
+See [Static files](static-files#cache-control) for more on cache control, including why `publicImmutable` belongs only with cache-busted assets.
 
 ## Cache busting
 
@@ -79,13 +79,13 @@ pod.webServer.addRoute(
     fallback: File('web/app/index.html'),
     cacheBustingConfig: cacheBustingConfig,
     cacheControlFactory: StaticRoute.publicImmutable(
-      maxAge: const Duration(minutes: 5),
+      maxAge: const Duration(days: 365),
     ),
   ),
 );
 ```
 
-See [Static Files](static-files#static-file-cache-busting) for more on cache busting.
+See [Static files](static-files#static-file-cache-busting) for more on cache busting.
 
 ## Using FallbackMiddleware directly
 
@@ -99,7 +99,8 @@ pod.webServer.addMiddleware(
   FallbackMiddleware(
     fallback: StaticRoute.file(indexFile),
     on: (response) => response.statusCode == 404,
-  ),
+  ).call,
+  '/',
 );
 
 pod.webServer.addRoute(StaticRoute.directory(webDir), '/');
@@ -111,7 +112,7 @@ This gives you flexibility to customize the fallback condition. For example, you
 FallbackMiddleware(
   fallback: StaticRoute.file(indexFile),
   on: (response) => response.statusCode >= 400 && response.statusCode < 500,
-)
+).call
 ```
 
 ## Serving from a sub-path

--- a/docs/06-concepts/05-web-server/08-flutter-web.md
+++ b/docs/06-concepts/05-web-server/08-flutter-web.md
@@ -1,10 +1,12 @@
 ---
-description: Flutter web app serving in Serverpod uses FlutterRoute to handle WASM multi-threading headers, SPA-style routing, and cache control.
+description: Flutter web app serving in Serverpod uses FlutterRoute with SPA-style fallback, revalidation-based caching, and optional WASM headers.
 ---
 
 # Flutter web apps
 
-Serverpod can serve your Flutter web application directly, allowing you to host both your API and web frontend from the same server. `FlutterRoute` handles the specifics of serving Flutter web apps, including WASM multi-threading headers and SPA-style routing.
+Serverpod can serve your Flutter web application directly, allowing you to host both your API and web frontend from the same server. The `FlutterRoute` class handles the specifics: serving the build output, SPA-style fallback to `index.html` for client-side routing, and cache headers that make redeploys take effect right away.
+
+New fullstack projects come with this already set up. The scaffolded `server.dart` serves your Flutter app at the root URL when a build exists in `web/app`, and shows a build-instructions page when it does not.
 
 ## Basic setup
 
@@ -24,27 +26,26 @@ This configuration:
 
 - Serves all static files from the Flutter build
 - Falls back to `index.html` for client-side routing
-- Adds WASM multi-threading headers automatically
-- Applies smart caching: critical files are never cached, other files are cached for 1 day
+- Serves every file with revalidation-based cache headers, so users get new versions on the next load after a deploy
 
 ## Building Flutter for web
 
-Build your Flutter app for web with WASM support for improved performance and multi-threading:
+New fullstack projects ship a build task. Run it from the server directory:
+
+```bash
+$ serverpod run flutter_build
+```
+
+It runs the underlying Flutter build and places the output where the server serves it:
 
 ```bash
 cd my_project_flutter
-flutter build web --wasm
+flutter build web --base-href / --output ../my_project_server/web/app
 ```
 
-:::info
+If you mount the app at a sub-path such as `/app`, pass that path as `--base-href /app/` so the app's own asset URLs resolve correctly.
 
-WASM builds automatically fall back to JavaScript in browsers that don't support WebAssembly Garbage Collection (WasmGC). Your app works everywhere while taking advantage of WASM performance where available.
-
-:::
-
-## Project structure
-
-Copy your Flutter build output to the server's `web` directory:
+The build output ends up next to your server code:
 
 ```text
 my_project/
@@ -57,78 +58,14 @@ my_project/
 │           ├── main.dart.js
 │           ├── flutter.js
 │           └── ...
-├── my_project_flutter/
-│   └── build/
-│       └── web/              # Flutter build output (source)
-└── my_project_client/
-```
-
-## WASM multi-threading
-
-Flutter WASM builds can use multi-threaded rendering for improved performance. This requires `SharedArrayBuffer`, which browsers only enable with specific security headers.
-
-`FlutterRoute` automatically adds these headers:
-
-- `Cross-Origin-Opener-Policy: same-origin`
-- `Cross-Origin-Embedder-Policy: require-corp`
-
-### Using WasmHeadersMiddleware directly
-
-If you're using `SpaRoute` or custom routes instead of `FlutterRoute`, add the headers manually with `WasmHeadersMiddleware`:
-
-```dart
-pod.webServer.addMiddleware(const WasmHeadersMiddleware());
-
-pod.webServer.addRoute(
-  SpaRoute(
-    Directory('web/app'),
-    fallback: File('web/app/index.html'),
-  ),
-  '/',
-);
+└── my_project_flutter/       # Build source
 ```
 
 ## Cache control
 
-`FlutterRoute` automatically applies smart caching to prevent issues with stale app versions:
+By default, `FlutterRoute` serves every file with `Cache-Control: no-cache, private`. The browser keeps a local copy but revalidates it on each load using `ETag` headers, and unchanged files answer with an empty `304 Not Modified`. The cost is one small round-trip per asset rather than a re-download, and the payoff is that a redeploy takes effect on the next page load with no stale-version tricks needed.
 
-### Default caching behavior
-
-By default, `FlutterRoute` uses different cache strategies for different file types:
-
-**Critical files (never cached):**
-
-- `index.html`
-- `flutter_service_worker.js`
-- `flutter_bootstrap.js`
-- `manifest.json`
-- `version.json`
-
-These files are served with `Cache-Control: private, no-cache, no-store` headers to ensure users always get the latest version after deployments.
-
-**All other files (cached for 1 day):**
-
-Static assets like JavaScript, WASM, images, and fonts are served with `Cache-Control: public, max-age=86400` headers, allowing browsers to cache them for better performance.
-
-### Invalidating cached assets
-
-When you deploy a new version of your Flutter app, cached assets need to be invalidated to ensure users get the latest version. To do this:
-
-1. Update the version in your Flutter app's `pubspec.yaml`:
-
-   ```yaml
-   version: 1.0.1+2  # Increment from previous version
-   ```
-
-1. Rebuild your Flutter web app:
-
-   ```bash
-   flutter build web --wasm
-   ```
-
-1. Deploy the new build to your server
-
-Flutter's build process includes the version in asset paths and metadata, which causes browsers to fetch the new assets instead of using cached versions.
+This design fits Flutter's build output, which uses fixed file names (such as `main.dart.js`) without content hashing, so longer-lived caching would risk serving a stale app.
 
 ### Custom cache control
 
@@ -138,7 +75,7 @@ Override the default behavior using `cacheControlFactory`:
 pod.webServer.addRoute(
   FlutterRoute(
     Directory('web/app'),
-    cacheControlFactory: StaticRoute.publicImmutable(
+    cacheControlFactory: StaticRoute.public(
       maxAge: const Duration(hours: 1),
     ),
   ),
@@ -146,16 +83,14 @@ pod.webServer.addRoute(
 ```
 
 :::warning
-
-Custom cache control applies to all files served from the directory, except for the fallback `index.html` which is always served with no-cache headers. Make sure your strategy prevents caching of service workers and manifests to avoid serving stale app versions.
-
+A custom factory applies to all files served from the directory. The fallback-served `index.html` (a client-side route like `/dashboard`) always gets no-cache headers, but a direct request to `/index.html` follows your factory, so exclude `index.html` from long-lived caching in a custom strategy.
 :::
 
-See [Static Files](static-files#cache-control) for more on cache control.
+See [Static files](static-files#cache-control) for more on cache control.
 
-## Cache busting
+### Cache busting
 
-Enable cache-busted URLs:
+For long-lived caching without stale versions, enable cache-busted URLs:
 
 ```dart
 final webDir = Directory('web/app');
@@ -170,17 +105,63 @@ pod.webServer.addRoute(
     webDir,
     cacheBustingConfig: cacheBustingConfig,
     cacheControlFactory: StaticRoute.publicImmutable(
-      maxAge: const Duration(minutes: 5),
+      maxAge: const Duration(days: 365),
     ),
   ),
 );
 ```
 
-See [Static Files](static-files#static-file-cache-busting) for more on cache busting.
+See [Static files](static-files#static-file-cache-busting) for more on cache busting.
+
+## WASM builds
+
+Flutter can compile to WebAssembly for improved performance, with multi-threaded rendering that requires `SharedArrayBuffer`. Browsers only enable `SharedArrayBuffer` on pages with cross-origin isolation headers:
+
+- `Cross-Origin-Opener-Policy: same-origin`
+- `Cross-Origin-Embedder-Policy: require-corp`
+
+The `enableWasmHeaders` parameter controls whether `FlutterRoute` sends them. The constructor defaults it to true, but generated projects pass `enableWasmHeaders: false` because the plain JavaScript build is the scaffolded default and cross-origin isolation has side effects: it blocks embedding cross-origin resources, such as images or iframes from other domains, unless they opt in.
+
+To serve a WASM build:
+
+1. Build with the WASM target:
+
+   ```bash
+   cd my_project_flutter
+   flutter build web --wasm --base-href / --output ../my_project_server/web/app
+   ```
+
+2. Turn the headers on:
+
+   ```dart
+   pod.webServer.addRoute(
+     FlutterRoute(Directory('web/app'), enableWasmHeaders: true),
+   );
+   ```
+
+:::info
+WASM builds automatically fall back to JavaScript in browsers that don't support WebAssembly Garbage Collection (WasmGC). Your app works everywhere while taking advantage of WASM performance where available.
+:::
+
+### Using WasmHeadersMiddleware directly
+
+If you're using `SpaRoute` or custom routes instead of `FlutterRoute`, add the headers with `WasmHeadersMiddleware`:
+
+```dart
+pod.webServer.addMiddleware(const WasmHeadersMiddleware().call, '/');
+
+pod.webServer.addRoute(
+  SpaRoute(
+    Directory('web/app'),
+    fallback: File('web/app/index.html'),
+  ),
+  '/',
+);
+```
 
 ## Complete example
 
-Here's a complete `server.dart` serving a Flutter web app:
+Here's a `server.dart` excerpt serving a Flutter web app, following the pattern generated projects use:
 
 ```dart
 import 'dart:io';
@@ -195,11 +176,14 @@ void run(List<String> args) async {
 
   final flutterAppDir = Directory('web/app');
 
-  if (!flutterAppDir.existsSync()) {
-    print('Warning: Flutter web app not found at ${flutterAppDir.path}');
-    print('Build your Flutter app and copy it to web/app/');
+  if (flutterAppDir.existsSync()) {
+    pod.webServer.addRoute(FlutterRoute(flutterAppDir, enableWasmHeaders: false));
   } else {
-    pod.webServer.addRoute(FlutterRoute(flutterAppDir));
+    // No build yet: show instructions instead of a 404.
+    pod.webServer.addRoute(
+      StaticRoute.file(File('web/pages/build_flutter_app.html')),
+      '/**',
+    );
   }
 
   await pod.start();

--- a/docs/08-deployments/custom-hosting/02-hosting-elsewhere.md
+++ b/docs/08-deployments/custom-hosting/02-hosting-elsewhere.md
@@ -24,7 +24,7 @@ It may be totally valid to run all servers with the same id. If you are using so
 
 :::
 
-By default, Serverpod will listen on ports 8080, 8081, and 8082. The ports are used by the API server, Serverpod Insights, and Relic (Serverpod's web server). You can configure the ports in the configuration files. Most often, you will want to place your server or servers behind a load balancer that handles the SSL certificates for your server and maps the traffic to different domain addresses and ports (typically 443 for HTTPS).
+By default, Serverpod will listen on ports 8080, 8081, and 8082. The ports are used by the API server, Serverpod Insights, and the [web server](../../06-concepts/05-web-server/01-overview.md). You can configure the ports in the configuration files. Most often, you will want to place your server or servers behind a load balancer that handles the SSL certificates for your server and maps the traffic to different domain addresses and ports (typically 443 for HTTPS).
 
 ## Server roles
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ sidebar_position: -1
 sidebar_label: Introduction
 sidebar_class_name: sidebar-introduction-icon
 title: Introduction
-description: Serverpod is an open-source backend framework for Flutter developers. Write your server in Dart and call it from your Flutter app through generated, type-safe code.
+description: Serverpod is an open-source backend framework for Flutter developers. Write your server in Dart and call it from your app through generated, type-safe code.
 ---
 
 # Introduction
@@ -52,4 +52,4 @@ Serverpod covers all common backend needs out of the box:
 - **File uploads:** Store in Amazon S3, Google Cloud Storage, or your database.
 - **Task scheduling:** Schedule a method to run later with type-safe future calls. They persist across server restarts.
 - **Caching:** Cache primitives and serializable models in-memory or in Redis.
-- **Web server:** Serve REST APIs, webhooks, and web pages with the built-in [Relic](https://docs.dartrelic.dev/) web server.
+- **Web server:** Serve REST APIs, webhooks, and web pages with the built-in [web server](./06-concepts/05-web-server/01-overview.md), based on [Relic](https://docs.dartrelic.dev/).


### PR DESCRIPTION
Part 4 of the section-by-section Concepts rework (after #687, #693, and #696). This pass covers the Web server section: all 8 pages plus two pages that link into it. No page moves; retitles only (Request data, Server-side HTML, Single-page apps, Web server middleware H1).

Every claim was verified against the framework at 4.0.0-beta.0 and relic 1.2.0, and the key behaviors were confirmed on a live project: route matching, all header defaults via curl, the widget constructors, the middleware and session APIs, and the Jaspr sample.

## Corrections

- **Flutter web** rewritten: the page described tiered caching and a version-bump invalidation procedure that the framework removed (#4842); the real default is `no-cache, private` with ETag revalidation on every file. WASM is now documented as opt-in with `enableWasmHeaders`, matching what `serverpod create` scaffolds (#5257), and building goes through the generated `serverpod run flutter_build` task.
- **Overview**: `Response.created` does not exist in relic 1.2.0 (replaced with a table of the 13 real constructors and the generic `Response(201, ...)` form); route matching is by specificity, not registration order; the first-route example now compiles.
- **Non-compiling examples fixed across the section**: `await request.session` (it returns a `Future<Session>`), the module-grouping example's missing `handleCall`, the widget constructors (`ListWidget(widgets:)`, `JsonWidget(object:)`, `RedirectWidget(url:)`), `addMiddleware`'s required path argument, and a `session.db.find` call using the wrong API shape.
- **Cache guidance made consistent**: `publicImmutable` was paired with 5-minute lifetimes throughout the section, which contradicts what `immutable` means; plain serving now uses `public(maxAge:)`, and `publicImmutable` with a long lifetime is reserved for cache-busted assets. The helpers are documented as `cacheControlFactory` values with their verbatim headers, including the no-header default.

## New coverage

- Routes vs endpoints framing and a five-row decision table on the overview.
- A verified Jaspr sample on Server-side HTML: component, route, the mandatory `Jaspr.initializeApp()`, and the import aliasing it needs (jaspr 0.23).
- Health probe paths (`/livez`, `/readyz`, `/startupz`), the template dev loop (startup loading, reload and browser auto-refresh under `serverpod start`), `WidgetRoute` methods/caching behavior, body streaming with `request.read()` and `Body.fromDataStream`, and the note for projects created without the web server.
- The static-files, single-page-apps, and Flutter-web pages now link the Cloud CDN page, which already linked to them.

## Issues

Closes #366. Closes #365.

Advances #626 (Jaspr is now named across the section with a working sample; the full how-to guide remains open) and #368 (the broken example is fixed and `await request.session` plus the `ContextProperty` pattern are documented; the typed route-composition API ask stays with the framework). A rate-limiting example (#658) was considered and deferred. Part of the plan in #671.