### PR TITLE
docs: Update Get started CLI pins to 4.0.0-beta.1

### DIFF
--- a/docs/04-get-started/01-installation.md
+++ b/docs/04-get-started/01-installation.md
@@ -24,7 +24,7 @@ $ flutter doctor
 Serverpod is installed using the Dart package manager. To install Serverpod, run the following command in your terminal:
 
 ```txt
-$ dart install serverpod_cli 4.0.0-beta.0
+$ dart install serverpod_cli 4.0.0-beta.1
 ```
 
 This command will install the Serverpod command-line interface (CLI) globally on your machine. You can verify the installation by running:

--- a/docs/04-get-started/02-quickstart.md
+++ b/docs/04-get-started/02-quickstart.md
@@ -31,7 +31,7 @@ $ flutter doctor
 Serverpod is installed using the Dart package manager. To install Serverpod, run the following command in your terminal:
 
 ```txt
-$ dart install serverpod_cli 4.0.0-beta.0
+$ dart install serverpod_cli 4.0.0-beta.1
 ```
 
 Verify the installation by running:


### PR DESCRIPTION
Bumps the `dart install serverpod_cli` pin from 4.0.0-beta.0 to 4.0.0-beta.1 on the two Get started pages (Installation and Quickstart), matching the latest published CLI on pub.dev.

Verified that nothing else on either page is affected by the beta.0 → beta.1 CLI changes: the `serverpod quickstart` flow (interactive editor picker) is unchanged, and the removed `serverpod create` mini option is not mentioned on these pages.

Remaining `4.0.0-beta.0` pins elsewhere (modules, shared-packages, auth setup, upgrade guide) are left for follow-ups; the auth ones are in the in-flight Concepts restructure's territory.