### PR TITLE
ci: Auto-approve CLI reference docs sync PRs

### DIFF
--- a/.github/workflows/auto-approve-docs-sync.yml
+++ b/.github/workflows/auto-approve-docs-sync.yml
@@ -1,0 +1,25 @@
+name: 'Auto-approve CLI docs sync PRs'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-approve:
+    name: Auto-approve
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.user.login == 'serverpod-cloud-docs-sync[bot]' &&
+      contains(fromJSON('["auto/cli-docs-sync", "auto/framework-cli-docs-sync"]'), github.event.pull_request.head.ref)
+    steps:
+      - name: Approve PR
+        run: gh pr review "$PR_URL" --approve --body 'Auto-approved CLI reference docs sync PR.'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Adds a workflow that automatically approves the CLI reference PRs opened by the `serverpod-cloud-docs-sync` GitHub App — both the Serverpod Cloud CLI reference (`auto/cli-docs-sync`) and the framework CLI command reference (`auto/framework-cli-docs-sync`).

- Runs on `pull_request_target` (opened/reopened/synchronize) so re-pushes get re-approved.
- Guarded on both the bot author and the two known head branches, so no other PRs can receive an approval.
- Approves with the built-in `GITHUB_TOKEN` scoped to `pull-requests: write`; the "Allow GitHub Actions to create and approve pull requests" repo setting is already enabled.