### PR TITLE
docs: Document using models on the client only

### DIFF
--- a/docs/06-concepts/03-data-and-the-database/01-models/01-working-with-models.md
+++ b/docs/06-concepts/03-data-and-the-database/01-models/01-working-with-models.md
@@ -104,23 +104,22 @@ Models can be saved to and read from the database. See the [Database](./database
 
 You can define models that you only use in the Flutter app, for example to hold local UI state or form data. Leave `serverOnly` unset so the class is generated for the client. There is no separate `clientOnly` flag.
 
-Place the `.spy.yaml` file anywhere in the server's `lib` directory, run code generation, and import the class from the client package.
+Place the `.spy.yaml` file anywhere in the server's `lib` directory. With `serverpod start` running, saving the file regenerates the code; otherwise run `serverpod generate`. Then import the class from the client package.
 
 ```yaml
 class: CartItem
-immutable: true
 fields:
   productId: String
   quantity: int
 ```
 
 ```dart
-import 'package:my_project_client/my_project_client.dart';
+import 'package:your_client/your_client.dart';
 
 var item = CartItem(productId: 'sku-1', quantity: 2);
 ```
 
-The class is also generated on the server. That is harmless: omit the `table` key so no database table is created, and you do not need to use the class in any endpoint. Set `immutable: true` if you want value equality for Flutter state management. See [Immutable classes](#immutable-classes).
+The class is also generated on the server, which is harmless: without a `table` key no database table is created, and nothing requires you to use the class in an endpoint. Set `immutable: true` if you want value equality for Flutter state management. See [Immutable classes](#immutable-classes).
 
 If you want the YAML and generated classes in a package that both the server and the app depend on, use a [shared package](./models/shared-packages).
 

--- a/docs/06-concepts/03-data-and-the-database/01-models/01-working-with-models.md
+++ b/docs/06-concepts/03-data-and-the-database/01-models/01-working-with-models.md
@@ -6,7 +6,7 @@ description: Serverpod model files define serializable classes, exceptions, and 
 
 # Working with models
 
-A data model is a YAML definition that becomes a typed Dart class on both the server and the client, and, with a [table](./database/tables) key, a database table as well. Models are the unit of data your endpoints pass and your database stores.
+A data model is a YAML definition that becomes a typed Dart class on both the server and the client, and, with a [table](./database/tables) key, a database table as well. Models are the unit of data your endpoints pass and your database stores. You can also [define models that you only use in Flutter](#using-models-on-the-client-only).
 
 The recommended file extension is `.spy.yaml` (.spy stands for "Serverpod YAML"), with `.spy` and `.spy.yml` accepted as well. These files can be placed anywhere in your server's `lib` directory, and the extension enables syntax highlighting through the [Serverpod Extension](https://marketplace.visualstudio.com/items?itemName=serverpod.serverpod) for VS Code. Regular `.yaml` files are also supported, but only within `lib/src/models` (or the legacy `lib/src/protocol` directory).
 
@@ -99,6 +99,30 @@ fields:
 :::info
 Models can be saved to and read from the database. See the [Database](./database/tables) section.
 :::
+
+### Using models on the client only
+
+You can define models that you only use in the Flutter app, for example to hold local UI state or form data. Leave `serverOnly` unset so the class is generated for the client. There is no separate `clientOnly` flag.
+
+Place the `.spy.yaml` file anywhere in the server's `lib` directory, run code generation, and import the class from the client package.
+
+```yaml
+class: CartItem
+immutable: true
+fields:
+  productId: String
+  quantity: int
+```
+
+```dart
+import 'package:my_project_client/my_project_client.dart';
+
+var item = CartItem(productId: 'sku-1', quantity: 2);
+```
+
+The class is also generated on the server. That is harmless: omit the `table` key so no database table is created, and you do not need to use the class in any endpoint. Set `immutable: true` if you want value equality for Flutter state management. See [Immutable classes](#immutable-classes).
+
+If you want the YAML and generated classes in a package that both the server and the app depend on, use a [shared package](./models/shared-packages).
 
 ### JSON key aliasing
 


### PR DESCRIPTION
## Summary

Working with models covered `serverOnly` and field `scope`, but not that you can define models you only use in Flutter. There is no `clientOnly` flag. Place the YAML in the server package as usual; generating the class on the server as well is harmless.

Fixes https://github.com/serverpod/serverpod/issues/3670

## Changes

- Add a "Using models on the client only" section after the visibility examples.
- Show placing the `.spy.yaml` file in the server package, running code generation, and importing the class from the client package.
- Note that omitting `table` avoids creating a database table, and point to `immutable: true` and shared packages.

## Reference

- serverpod/serverpod#3670