### PR TITLE
docs: Replace the global flag on postMessage with MessageScope

### DIFF
--- a/docs/06-concepts/02-endpoints-and-apis/04-streaming.md
+++ b/docs/06-concepts/02-endpoints-and-apis/04-streaming.md
@@ -189,7 +189,7 @@ messages.listen((message) {
 await client.chat.postToRoom(roomId, 'Hello, room!');
 ```
 
-Because the channel name includes the `roomId`, each client receives updates only for the room it is watching. The same pattern works for any filter: scope the channel by the id or query you care about, and post to it whenever the data changes. To fan the updates out across multiple server instances, post with `global: true` (see [Global messages](./server-events#global-messages)).
+Because the channel name includes the `roomId`, each client receives updates only for the room it is watching. The same pattern works for any filter: scope the channel by the id or query you care about, and post to it whenever the data changes. To fan the updates out across multiple server instances, enable Redis (see [Message scope](./server-events#message-scope)).
 
 ## Streaming endpoints (deprecated)
 

--- a/docs/06-concepts/02-endpoints-and-apis/05-server-events.md
+++ b/docs/06-concepts/02-endpoints-and-apis/05-server-events.md
@@ -17,22 +17,24 @@ await session.messages.postMessage('user_updates', message);
 
 In the example above, the message is published on the `user_updates` channel. Any subscriber to this channel in the server will receive the message.
 
-### Global messages
+### Message scope
 
-Serverpod uses Redis to pass messages between servers. To send a message to another server, [enable Redis](../server-fundamentals/configuration) and then set the `global` parameter to `true` when posting a message.
+Serverpod uses Redis to pass messages between servers. A message is sent to every server connected to the same Redis instance when [Redis is enabled](../server-fundamentals/configuration), and stays on the current server when it is not. Set the `scope` parameter to choose the delivery explicitly.
 
 ```dart
 var message = UserUpdate(); // Model that represents changes to user data.
-await session.messages.postMessage('user_updates', message, global: true);
+await session.messages.postMessage(
+  'user_updates',
+  message,
+  scope: MessageScope.global,
+);
 ```
 
-In the example above, the message is published to the `user_updates` channel and will be received by all servers connected to the same Redis instance.
-
-:::warning
-
-If Redis is not enabled, sending global messages throws a `StateError`.
-
-:::
+| Scope | Delivery |
+| --- | --- |
+| `MessageScope.auto` | Cluster-wide if Redis is enabled, otherwise local. This is the default. |
+| `MessageScope.global` | Cluster-wide. Throws a `StateError` if Redis is not enabled. |
+| `MessageScope.local` | Only to subscribers on the current server. |
 
 ## Receive messages
 

--- a/docs/06-concepts/02-endpoints-and-apis/05-server-events.md
+++ b/docs/06-concepts/02-endpoints-and-apis/05-server-events.md
@@ -78,7 +78,7 @@ session.messages.addListener('user_updates', (message) {
 });
 ```
 
-In the above example, the listener will be called whenever a message is posted to the `user_updates` channel. Listeners receive both local and global messages.
+In the above example, the listener will be called whenever a message is posted to the `user_updates` channel. Listeners receive every message that reaches this server, whatever its scope.
 
 #### Listener lifecycle
 

--- a/docs/06-concepts/02-endpoints-and-apis/05-server-events.md
+++ b/docs/06-concepts/02-endpoints-and-apis/05-server-events.md
@@ -21,20 +21,22 @@ In the example above, the message is published on the `user_updates` channel. An
 
 Serverpod uses Redis to pass messages between servers. A message is sent to every server connected to the same Redis instance when [Redis is enabled](../server-fundamentals/configuration), and stays on the current server when it is not. Set the `scope` parameter to choose the delivery explicitly.
 
-```dart
-var message = UserUpdate(); // Model that represents changes to user data.
-await session.messages.postMessage(
-  'user_updates',
-  message,
-  scope: MessageScope.global,
-);
-```
-
 | Scope | Delivery |
 | --- | --- |
 | `MessageScope.auto` | Cluster-wide if Redis is enabled, otherwise local. This is the default. |
 | `MessageScope.global` | Cluster-wide. Throws a `StateError` if Redis is not enabled. |
 | `MessageScope.local` | Only to subscribers on the current server. |
+
+The default already goes cluster-wide when Redis is enabled. Pass `MessageScope.local` to keep a message on the current server:
+
+```dart
+var message = UserUpdate(); // Model that represents changes to user data.
+await session.messages.postMessage(
+  'user_updates',
+  message,
+  scope: MessageScope.local,
+);
+```
 
 ## Receive messages
 


### PR DESCRIPTION
The `global` parameter on `postMessage` was replaced by `scope` in serverpod/serverpod#5553, and the default is now `MessageScope.auto`: cluster-wide when Redis is enabled, local otherwise.

Rewrites the section as **Message scope** with a table of the three values, and updates the inbound link from the streaming page.