### PR TITLE
docs: Correct the migrate shortcut in the serverpod start terminal

### DIFF
--- a/docs/04-get-started/03-how-it-works.md
+++ b/docs/04-get-started/03-how-it-works.md
@@ -102,7 +102,7 @@ final company = await Company.db.insertRow(session, Company(name: 'Serverpod'));
 final stored = await Company.db.findById(session, company.id);
 ```
 
-These run on the same `session` your endpoint method receives. When you change a table model, press `M` in the `serverpod start` terminal to create a migration, then `A` to apply it. Pending migrations also apply on startup.
+These run on the same `session` your endpoint method receives. When you change a table model, press `M` in the `serverpod start` terminal to create the migration and apply it. Pending migrations also apply on startup.
 
 That database runs without setup on your part: Serverpod manages an embedded Postgres for you, with no Docker to configure. If you would rather manage Postgres yourself, you can change the configuration in the server's `config` directory.
 

--- a/docs/05-build-your-first-app/03-working-with-the-database.md
+++ b/docs/05-build-your-first-app/03-working-with-the-database.md
@@ -45,8 +45,7 @@ Changing the schema requires a [migration](../concepts/data-and-the-database/dat
 
 ![serverpod start tui](/img/getting-started/tui-logs.png)
 
-- Press **M** to create the migration from your model change.
-- Press **A** to apply it, which creates the `recipes` table in your database.
+- Press **M** to create the migration and apply it, which creates the `recipes` table in your database.
 
 ## Save recipes to the database
 

--- a/docs/06-concepts/01-server-fundamentals/02-running-your-server.md
+++ b/docs/06-concepts/01-server-fundamentals/02-running-your-server.md
@@ -32,7 +32,7 @@ On the first boot of a session, `serverpod start` applies any pending migrations
 
 - **M** creates a migration from your current model changes and applies it.
 - **P** creates a repair migration to reconcile a database that has drifted from your migrations, and applies it. This shortcut is not shown in the bottom bar; press **H** to see it listed.
-- **A** applies pending migrations, to retry after a failed apply.
+- **A** applies pending migrations. Use it to retry after a failed apply.
 
 Hold **Shift** with **M** or **P** to force the migration: it is created even when there are no changes to record, and even when Serverpod warns that information may be destroyed, so force deliberately. For how migrations work, see [Migrations](../data-and-the-database/database/migrations).
 

--- a/docs/06-concepts/01-server-fundamentals/02-running-your-server.md
+++ b/docs/06-concepts/01-server-fundamentals/02-running-your-server.md
@@ -30,9 +30,9 @@ To start without watching, pass `--no-watch`. Nothing reloads on save; there, **
 
 On the first boot of a session, `serverpod start` applies any pending migrations. While it runs, you handle further schema changes from the terminal without leaving the session:
 
-- **M** creates a migration from your current model changes.
-- **A** applies pending migrations to the database.
-- **P** creates a repair migration to reconcile a database that has drifted from your migrations. This shortcut is not shown in the bottom bar; press **H** to see it listed.
+- **M** creates a migration from your current model changes and applies it.
+- **P** creates a repair migration to reconcile a database that has drifted from your migrations, and applies it. This shortcut is not shown in the bottom bar; press **H** to see it listed.
+- **A** applies pending migrations, to retry after a failed apply.
 
 Hold **Shift** with **M** or **P** to force the migration: it is created even when there are no changes to record, and even when Serverpod warns that information may be destroyed, so force deliberately. For how migrations work, see [Migrations](../data-and-the-database/database/migrations).
 

--- a/docs/06-concepts/01-server-fundamentals/04-modules.md
+++ b/docs/06-concepts/01-server-fundamentals/04-modules.md
@@ -47,7 +47,7 @@ Start the server, which regenerates your code so the module's endpoints and mode
 serverpod start
 ```
 
-The module adds tables to your database, so create and apply a migration: in the `serverpod start` terminal, press **M** to create the migration, then **A** to apply it.
+The module adds tables to your database, so create and apply a migration: in the `serverpod start` terminal, press **M**.
 
 ### Add the client package
 

--- a/docs/06-concepts/03-data-and-the-database/02-database/01-tables.md
+++ b/docs/06-concepts/03-data-and-the-database/02-database/01-tables.md
@@ -4,7 +4,7 @@ description: Table models map serializable classes to database tables in Serverp
 
 # Tables
 
-Storing a [data model](../models) in the database takes one line: add the `table` key to its model file, and the class gains a generated `db` field with typed methods for reading and writing rows. From there the path is short: create and apply a [migration](migrations) (press **M** then **A** in the `serverpod start` terminal), then call the [CRUD methods](crud) from your endpoints. The rest of this page covers what the table definition itself can do.
+Storing a [data model](../models) in the database takes one line: add the `table` key to its model file, and the class gains a generated `db` field with typed methods for reading and writing rows. From there the path is short: create and apply a [migration](migrations) (press **M** in the `serverpod start` terminal), then call the [CRUD methods](crud) from your endpoints. The rest of this page covers what the table definition itself can do.
 
 ```yaml
 class: Company

--- a/docs/06-concepts/03-data-and-the-database/02-database/13-migrations.md
+++ b/docs/06-concepts/03-data-and-the-database/02-database/13-migrations.md
@@ -112,7 +112,7 @@ The `serverpod start` command handles migrations for you. Pending migrations are
 
 - Press **M** to create a migration from your model changes and apply it.
 - Press **P** to create a repair migration and apply it.
-- Press **A** to retry applying pending migrations, if applying them failed.
+- Press **A** to retry when applying a migration fails.
 
 Hold **Shift** with **M** or **P** to force the migration. See [Running your server](../../server-fundamentals/running-your-server#manage-migrations-from-the-terminal) for the full set of shortcuts.
 

--- a/docs/06-concepts/03-data-and-the-database/02-database/13-migrations.md
+++ b/docs/06-concepts/03-data-and-the-database/02-database/13-migrations.md
@@ -110,9 +110,9 @@ For each migration, five files are created:
 
 The `serverpod start` command handles migrations for you. Pending migrations are applied automatically on the first boot of a session. While the session runs, with its terminal focused:
 
-- Press **M** to create a migration from your model changes.
-- Press **A** to apply pending migrations.
-- Press **P** to create a repair migration.
+- Press **M** to create a migration from your model changes and apply it.
+- Press **P** to create a repair migration and apply it.
+- Press **A** to retry applying pending migrations, if applying them failed.
 
 Hold **Shift** with **M** or **P** to force the migration. See [Running your server](../../server-fundamentals/running-your-server#manage-migrations-from-the-terminal) for the full set of shortcuts.
 

--- a/docs/11-upgrading/01-upgrade-to-four.md
+++ b/docs/11-upgrading/01-upgrade-to-four.md
@@ -223,7 +223,7 @@ Copy the updated Dockerfile from the [4.0 framework template](https://github.com
 
 ## What's new in 4.0
 
-- **`serverpod start` TUI**: hot reload on save, **R** to hot restart, **M** to create a migration, **A** to apply migrations, **P** to apply a repair migration.
+- **`serverpod start` TUI**: hot reload on save, **R** to hot restart, **M** to create and apply a migration, **P** to create and apply a repair migration.
 - **Flutter app spawning** from `serverpod start` so the Flutter app runs alongside the server in the same TUI.
 - **AI agent skills and MCP servers** scaffolded during `serverpod create`; existing projects opt in by running `serverpod create .`.
 - **Embedded Postgres**: zero-Docker development via `dataPath`.


### PR DESCRIPTION
Since serverpod/serverpod#5481, **M** creates the migration and applies it in one step, and the same holds for **P**. The **A** shortcut remains as a retry when applying fails.

Updates the six places that still tell the reader to press **M** then **A**.