### PR TITLE
docs: State that authenticationKeyManager is removed in 4.0

### DIFF
--- a/docs/11-upgrading/01-upgrade-to-four.md
+++ b/docs/11-upgrading/01-upgrade-to-four.md
@@ -60,7 +60,7 @@ dependencies:
   serverpod_auth_shared_flutter: 4.0.0-beta.1  # in the Flutter package
 ```
 
-The `authenticationKeyManager` parameter on the generated `Client` is gone in 4.0. Assign the key manager to the `authKeyProvider` field instead:
+The `authenticationKeyManager` parameter on the generated `Client` was removed in 4.0. Assign the key manager to the `authKeyProvider` field instead:
 
 ```dart
 client = Client('http://$ipAddress:8080/')

--- a/docs/11-upgrading/01-upgrade-to-four.md
+++ b/docs/11-upgrading/01-upgrade-to-four.md
@@ -60,7 +60,7 @@ dependencies:
   serverpod_auth_shared_flutter: 4.0.0-beta.1  # in the Flutter package
 ```
 
-The `authenticationKeyManager` parameter on the generated `Client` is deprecated in 4.0 and will be removed in an upcoming release. Assign the key manager to the `authKeyProvider` field instead:
+The `authenticationKeyManager` parameter on the generated `Client` is gone in 4.0. Assign the key manager to the `authKeyProvider` field instead:
 
 ```dart
 client = Client('http://$ipAddress:8080/')


### PR DESCRIPTION
The `authenticationKeyManager` constructor parameter was removed in serverpod/serverpod#5546, so the upgrade guide should not describe it as deprecated with removal still ahead.