### PR TITLE
docs: Describe when serverpod start launches Docker Compose services

### DIFF
--- a/docs/06-concepts/01-server-fundamentals/02-running-your-server.md
+++ b/docs/06-concepts/01-server-fundamentals/02-running-your-server.md
@@ -56,7 +56,7 @@ serverpod start --no-flutter
 
 You can still launch an app on demand: press **Ctrl+R** in the terminal to open the app launch panel.
 
-If your project runs auxiliary services from a `docker-compose.yaml`, such as Redis, pass `--docker` to start them with the session.
+If your project has a `docker-compose.yaml` and its database is a Postgres on localhost without a [`dataPath`](../data-and-the-database/database/embedded-postgres), `serverpod start` starts the Compose services with the session. Otherwise it leaves them alone. Pass `--docker` or `--no-docker` to decide yourself.
 
 To run without the interactive terminal, pass `--no-tui`. When the output is not a terminal, for example in CI, `serverpod start` falls back to plain output on its own.
 

--- a/docs/06-concepts/01-server-fundamentals/02-running-your-server.md
+++ b/docs/06-concepts/01-server-fundamentals/02-running-your-server.md
@@ -56,11 +56,7 @@ serverpod start --no-flutter
 
 You can still launch an app on demand: press **Ctrl+R** in the terminal to open the app launch panel.
 
-If your project runs auxiliary services from a `docker-compose.yaml`, such as Redis, pass `--docker` to start them with the session.
-
-:::info
-Passing the `--docker` flag is not needed if using PostgreSQL from a Docker Compose stack (no `dataPath` in the config). In such cases, `serverpod start` will automatically start and teardown the existing `docker-compose.yaml`, in case it was not already running.
-:::
+If your project has a `docker-compose.yaml`, `serverpod start` brings it up automatically when your database is a Postgres on `localhost` with no `dataPath`, and tears it down on exit if it was the one that started it. When that does not apply, for example an embedded or remote database with Redis in Compose, pass `--docker` to start the stack anyway, or `--no-docker` to keep it off.
 
 To run without the interactive terminal, pass `--no-tui`. When the output is not a terminal, for example in CI, `serverpod start` falls back to plain output on its own.
 

--- a/docs/06-concepts/01-server-fundamentals/02-running-your-server.md
+++ b/docs/06-concepts/01-server-fundamentals/02-running-your-server.md
@@ -56,7 +56,11 @@ serverpod start --no-flutter
 
 You can still launch an app on demand: press **Ctrl+R** in the terminal to open the app launch panel.
 
-If your project has a `docker-compose.yaml` and its database is a Postgres on localhost without a [`dataPath`](../data-and-the-database/database/embedded-postgres), `serverpod start` starts the Compose services with the session. Otherwise it leaves them alone. Pass `--docker` or `--no-docker` to decide yourself.
+If your project runs auxiliary services from a `docker-compose.yaml`, such as Redis, pass `--docker` to start them with the session.
+
+:::info
+Passing the `--docker` flag is not needed if using PostgreSQL from a Docker Compose stack (no `dataPath` in the config). In such cases, `serverpod start` will automatically start and teardown the existing `docker-compose.yaml`, in case it was not already running.
+:::
 
 To run without the interactive terminal, pass `--no-tui`. When the output is not a terminal, for example in CI, `serverpod start` falls back to plain output on its own.
 

--- a/docs/11-upgrading/01-upgrade-to-four.md
+++ b/docs/11-upgrading/01-upgrade-to-four.md
@@ -106,13 +106,9 @@ You have two paths. Pick the one that fits where you are today; both work with `
 
 #### Keep your Docker Postgres (easiest upgrade)
 
-If you've been developing against a Docker Postgres on 3.4, you can keep it without changing your config. Pass `--docker` to `serverpod start` so it uses your existing `docker-compose.yaml`:
+If you've been developing against a Docker Postgres on 3.4, you can keep it without changing your config.
 
-```bash
-$ serverpod start --docker
-```
-
-With `--docker`, `serverpod start` brings up Docker if it isn't running, and tears down the compose stack on exit if the command brought it up.
+On projects configured to use a regular PostgreSQL (no `dataPath` in the config), `serverpod start` brings up Docker if it isn't running, and tears down the compose stack on exit if the command brought it up.
 
 #### Switch to the embedded Postgres (recommended for new development)
 

--- a/docs/11-upgrading/01-upgrade-to-four.md
+++ b/docs/11-upgrading/01-upgrade-to-four.md
@@ -108,7 +108,7 @@ You have two paths. Pick the one that fits where you are today; both work with `
 
 If you've been developing against a Docker Postgres on 3.4, you can keep it without changing your config.
 
-On projects configured to use a regular PostgreSQL (no `dataPath` in the config), `serverpod start` brings up Docker if it isn't running, and tears down the compose stack on exit if the command brought it up.
+On projects whose config points at a Postgres on `localhost` with no `dataPath`, `serverpod start` brings up the `docker-compose` stack if it isn't running, and tears it down on exit if the command brought it up.
 
 #### Switch to the embedded Postgres (recommended for new development)
 


### PR DESCRIPTION
Since serverpod/serverpod#5482 and serverpod/serverpod#5522, `--docker` defaults to on when the project has a Compose file and the database is a local Postgres without a `dataPath`, instead of being an opt-in flag.