### PR TITLE
docs: Document defaultPersist=serial on int fields

### DIFF
--- a/docs/06-concepts/03-data-and-the-database/01-models/01-working-with-models.md
+++ b/docs/06-concepts/03-data-and-the-database/01-models/01-working-with-models.md
@@ -233,13 +233,13 @@ For `UuidValue`, `random` generates a UUID v4 (`Uuid().v4obj()` in Dart, `gen_ra
 
 For enums, the persisted value follows the enum's serialization mode. A `byName` enum default is stored as the value's name, and a `byIndex` enum default is stored as its index, e.g. `0` for the first value.
 
-On an `int` field, `defaultPersist=serial` hands the value over to a database sequence (same used by an `int` `id` column). Because only the database can produce it, `serial` is rejected with `default` and `defaultModel`. On SQLite, it is only supported on the `id` column due to dialect limitations.
+On an `int` field, `defaultPersist=serial` hands the value over to a database sequence, the same mechanism behind an `int` `id` column, though each serial column gets its own sequence. Because only the database can produce it, `serial` is rejected with `default` and `defaultModel`. On SQLite, it is only supported on the `id` column due to dialect limitations.
 
 ```yaml
 class: Invoice
 table: invoice
 fields:
-  invoiceNumber: int, defaultPersist=serial
+  invoiceNumber: int?, defaultPersist=serial
 ```
 
 :::info
@@ -259,7 +259,7 @@ fields:
   boolDefault: bool, defaultModel=false, defaultPersist=true
 
   ### Sets the database-side default value for an integer field.
-  intDefault: int, defaultPersist=20
+  intDefault: int?, defaultPersist=20
 
   ### Defaults to 10.5 in code, with a separate database default.
   doubleDefault: double, default=10.5, defaultPersist=20.5

--- a/docs/06-concepts/03-data-and-the-database/01-models/01-working-with-models.md
+++ b/docs/06-concepts/03-data-and-the-database/01-models/01-working-with-models.md
@@ -233,6 +233,15 @@ For `UuidValue`, `random` generates a UUID v4 (`Uuid().v4obj()` in Dart, `gen_ra
 
 For enums, the persisted value follows the enum's serialization mode. A `byName` enum default is stored as the value's name, and a `byIndex` enum default is stored as its index, e.g. `0` for the first value.
 
+On an `int` field, `defaultPersist=serial` hands the value over to a database sequence (same used by an `int` `id` column). Because only the database can produce it, `serial` is rejected with `default` and `defaultModel`. On SQLite, it is only supported on the `id` column due to dialect limitations.
+
+```yaml
+class: Invoice
+table: invoice
+fields:
+  invoiceNumber: int, defaultPersist=serial
+```
+
 :::info
 On an [immutable class](#immutable-classes), or a class extending one, `default` and `defaultModel` cannot use the non-constant values `now`, `random`, or `random_v7`. On a persisted model, use `defaultPersist` for those instead.
 :::


### PR DESCRIPTION
serverpod/serverpod#5556 allows `serial` on any `int` column, not only `id`. The default values section did not mention `serial` at all.