### PR TITLE
docs: Use the Serverpod PostgreSQL image for PostGIS support

### DIFF
--- a/docs/11-upgrading/02-archive/05-upgrade-to-pgvector.md
+++ b/docs/11-upgrading/02-archive/05-upgrade-to-pgvector.md
@@ -1,6 +1,6 @@
 # Upgrade to pgvector
 
-New Serverpod projects automatically include pgvector support through the `pgvector/pgvector` PostgreSQL Docker image. However, existing projects need to be upgraded to use vector functionality.
+New Serverpod projects automatically included pgvector support through the `pgvector/pgvector` PostgreSQL Docker image. From 4.0.0-beta.2, the compose file uses `ghcr.io/serverpod/postgres:16` instead, which is that image plus PostGIS. Existing projects need to be upgraded to use vector functionality.
 
 :::info
 This upgrade is only necessary if you want to use vector fields in your models. If you do not plan to use vector fields, you can skip this upgrade.

--- a/docs/11-upgrading/04-upgrade-to-postgis.md
+++ b/docs/11-upgrading/04-upgrade-to-postgis.md
@@ -16,12 +16,12 @@ If trying to use geography fields without upgrading, you will encounter an error
 
 ## For Docker-based environments
 
-1. Update your `docker-compose.yml` to use a PostgreSQL image with PostGIS (e.g., `postgis/postgis:16-3.5`):
+1. Update your `docker-compose.yml` to use `ghcr.io/serverpod/postgres:16`, the Serverpod PostgreSQL image. It ships with [PostGIS and pgvector](../concepts/data-and-the-database/database/vector-and-geography-fields) already installed:
 
 ```yaml
 services:
   postgres:
-    image: postgis/postgis:16-3.5  # <-- Change from postgres image here
+    image: ghcr.io/serverpod/postgres:16  # <-- Change from postgres image here
     ports:
       - '8090:5432'
     environment:
@@ -34,7 +34,7 @@ services:
 # Other services...
 
   postgres_test:
-    image: postgis/postgis:16-3.5  # <-- Change from postgres image here
+    image: ghcr.io/serverpod/postgres:16  # <-- Change from postgres image here
     ports:
       - '9090:5432'
     environment:
@@ -45,32 +45,7 @@ services:
       - <projectname>_test_data:/var/lib/postgresql/data
 ```
 
-If your project also uses [vector fields](../concepts/data-and-the-database/database/vector-and-geography-fields), you need both pgvector and PostGIS. Create a custom `Dockerfile` instead:
-
-```dockerfile
-FROM pgvector/pgvector:pg16
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-16-postgis-3 \
-    && rm -rf /var/lib/apt/lists/*
-```
-
-Then reference it in your `docker-compose.yml`:
-
-```yaml
-services:
-  postgres:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    ports:
-      - '8090:5432'
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_DB: <projectname>
-      POSTGRES_PASSWORD: <DB_PASSWORD>
-    volumes:
-      - <projectname>_data:/var/lib/postgresql/data
-```
+Projects created with Serverpod 4.0 already reference this image, so there is nothing to change for them.
 
 <!-- markdownlint-disable-next-line MD029-->
 2. Recreate your containers to use the new image:

--- a/docs/11-upgrading/04-upgrade-to-postgis.md
+++ b/docs/11-upgrading/04-upgrade-to-postgis.md
@@ -45,7 +45,7 @@ services:
       - <projectname>_test_data:/var/lib/postgresql/data
 ```
 
-Projects created with Serverpod 4.0 already reference this image, so there is nothing to change for them.
+If your `docker-compose.yaml` came from Serverpod 4.0.0-beta.2 or later, it already references this image and needs no change.
 
 <!-- markdownlint-disable-next-line MD029-->
 2. Recreate your containers to use the new image:


### PR DESCRIPTION
serverpod/serverpod#5563 publishes `ghcr.io/serverpod/postgres:16` with both PostGIS and pgvector installed, and new projects reference it in their `docker-compose.yaml`.

Replaces the `postgis/postgis` image and the hand-built Dockerfile for projects that need both extensions.