### PR TITLE
docs: Add heading and intro to scloud context CLI page

### DIFF
--- a/cloud_docs/reference/cli/commands/context/_context.md
+++ b/cloud_docs/reference/cli/commands/context/_context.md
@@ -1,0 +1,5 @@
+# scloud context
+
+`scloud context` manages the global project context: a locally stored project ID that `scloud` uses when a command doesn't get a project from `-p` / `--project`, `SERVERPOD_CLOUD_PROJECT_ID`, or `scloud.yaml`. The setting is a last-resort default and applies across directories.
+
+To pin a specific codebase to a Cloud project, run [`scloud project link`](/cloud/reference/cli/commands/project). That writes `scloud.yaml` in the project directory, which takes precedence over the global context.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes [CLD-1314](https://linear.app/serverpod/issue/CLD-1314/context-cli-reference-page-has-no-title).

The `scloud context` reference page imported an empty `_context.md`, so it rendered with no `<h1>` and no intro prose. Sibling command pages (for example `deploy`) all start with `# scloud <command>` plus a short description.

This adds the missing heading and two intro sentences: what global context is, when `scloud` uses it, and that `scloud project link` is the per-project alternative.

## Walkthrough

The page at `/cloud/reference/cli/commands/context` now matches every other CLI command page:

1. Heading: `scloud context`
2. Intro explaining last-resort project selection
3. Auto-generated `--help` dump below that

Please verify the page in a docs preview; this repo asks agents not to run `npm run build`.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [CLD-1314](https://linear.app/serverpod/issue/CLD-1314/context-cli-reference-page-has-no-title)

<div><a href="https://cursor.com/agents/bc-05fc5bc0-f27a-4601-b47e-d813a5aaa325?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05fc5bc0-f27a-4601-b47e-d813a5aaa325&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

