### PR TITLE
docs: Update chat model name to 'gemini-3.5-flash-lite'

### DIFF
--- a/docs/05-build-your-first-app/01-creating-endpoints.md
+++ b/docs/05-build-your-first-app/01-creating-endpoints.md
@@ -87,7 +87,7 @@ class RecipeEndpoint extends Endpoint {
     // Configure the Dartantic AI agent for Gemini before sending the prompt.
     final agent = Agent.forProvider(
       GoogleProvider(apiKey: geminiApiKey),
-      chatModelName: 'gemini-2.5-flash-lite',
+      chatModelName: 'gemini-3.5-flash-lite',
     );
 
     final prompt =


### PR DESCRIPTION
This fixes the following error:

ERROR: ApiException(404): This model models/gemini-2.5-flash-lite is no longer available to new users. Please update your code to use models/gemini-3.5-flash-lite for the latest features and improvements. We recommend you to use the Interactions API.