### PR TITLE
docs: Document secrets via scloud variable --secret

### DIFF
--- a/cloud_docs/concepts/passwords-secrets-env-vars.md
+++ b/cloud_docs/concepts/passwords-secrets-env-vars.md
@@ -10,18 +10,18 @@ Your server needs sensitive values (database passwords, third-party API keys, OA
 
 |                       | Passwords                                              | Secrets                                                    | Variables                                               |
 | --------------------- | ------------------------------------------------------ | ---------------------------------------------------------- | ------------------------------------------------------- |
-| **CLI**               | `scloud password`                                      | `scloud secret`                                            | `scloud variable`                                       |
+| **CLI**               | `scloud password`                                      | `scloud variable set --secret`                             | `scloud variable`                                       |
 | **Stored as**         | Env var with `SERVERPOD_PASSWORD_` prefix              | Env var (any name)                                         | Env var (any name)                                      |
-| **Encrypted**         | Yes                                                    | Yes                                                        | No (values visible in CLI and dashboard)                |
+| **Encrypted**         | Yes                                                    | Yes                                                        | No (values visible in CLI and Cloud console)                |
 | **Access in code**    | `session.serverpod.getPassword('name')`                | `Platform.environment['NAME']`                             | `Platform.environment['NAME']`                          |
-| **Use when**          | Serverpod code reads the value (preferred for secrets) | A dependency reads env vars and cannot use `getPassword()` | Non-sensitive config (URLs, feature flags)              |
+| **Use when**          | Serverpod code reads the value (preferred for sensitive values) | A dependency reads env vars and cannot use `getPassword()` | Non-sensitive config (URLs, feature flags)              |
 
-All three commands follow the same shape:
+Both `scloud password` and `scloud variable` follow the same shape:
 
 - **`--name`** (mandatory): positional or as a flag
 - **Value**: positional, `--value`, or `--from-file`
-- **`-p, --project`**: required only when the project isn't linked
-- **`set` is create-or-update**: running it again with the same name overwrites the value
+- **`-p, --project`**: required only when the project isn't linked and no project context is set
+- **`set` is create-or-update**: running it again with the same name overwrites the value. The name stays in the tier it was created in
 
 ## Manage passwords
 
@@ -63,12 +63,12 @@ scloud password unset myApiKey
 
 ## Manage secrets
 
-Secrets are the right tier when a library or dependency reads a value from `Platform.environment['SOMETHING']` and can't use the Serverpod API. They're encrypted at rest and never shown in the CLI after creation.
+Secrets are the right tier when a library or dependency reads a value from `Platform.environment['SOMETHING']` and can't use the Serverpod API. They're encrypted at rest, and the CLI shows their values masked after creation. Secrets share the `scloud variable` command with plaintext variables. The `--secret` flag on `set` stores the value in the secret tier.
 
 Set a secret by name and value:
 
 ```bash
-scloud secret set API_KEY "your_secret_value"
+scloud variable set --secret API_KEY "your_secret_value"
 ```
 
 Read the value in code:
@@ -80,20 +80,22 @@ final apiKey = Platform.environment['API_KEY'];
 Pass `--from-file` for long, multi-line, or sensitive values you don't want in shell history:
 
 ```bash
-scloud secret set API_KEY --from-file path/to/file.txt
+scloud variable set --secret API_KEY --from-file path/to/file.txt
 ```
 
-List configured secrets:
+List variables and secrets together, with secret values masked (passwords are listed by `scloud password list` instead):
 
 ```bash
-scloud secret list
+scloud variable list
 ```
 
 Remove a secret:
 
 ```bash
-scloud secret unset API_KEY
+scloud variable unset API_KEY
 ```
+
+A name keeps the tier it was created in. Running `set` again updates the value in place. Turning a variable into a secret, or a secret back into a variable, is refused with an error. To switch tiers, `unset` the name and recreate it.
 
 ## Manage environment variables
 
@@ -117,7 +119,7 @@ Pass `--from-file` to load the value from a file:
 scloud variable set LOG_LEVEL --from-file path/to/file.txt
 ```
 
-List configured variables:
+List configured variables and secrets:
 
 ```bash
 scloud variable list
@@ -145,4 +147,4 @@ The same naming and size rules apply across all three tiers:
 
 ## Related
 
-- CLI reference: [`password`](/cloud/reference/cli/commands/password), [`secret`](/cloud/reference/cli/commands/secret), [`variable`](/cloud/reference/cli/commands/variable)
+- CLI reference: [`password`](/cloud/reference/cli/commands/password), [`variable`](/cloud/reference/cli/commands/variable)

--- a/cloud_docs/reference/cli/commands/variable/_variable.md
+++ b/cloud_docs/reference/cli/commands/variable/_variable.md
@@ -1,5 +1,5 @@
 # scloud variable
 
-`scloud variable` manages plaintext environment variables for non-sensitive configuration (URLs, feature flags, log levels). Variables are visible in the CLI and the Cloud console; for sensitive values, use `scloud secret` or `scloud password` instead.
+`scloud variable` manages environment variables in two tiers: plaintext variables for non-sensitive configuration (URLs, feature flags, log levels), and secrets, which are encrypted and shown masked. The `--secret` flag on `set` stores a value in the secret tier. For values your Serverpod code reads through `getPassword()`, use `scloud password` instead.
 
 See [Passwords, secrets, and environment variables](/cloud/concepts/passwords-secrets-env-vars) for the tier comparison, naming rules, and size limits.


### PR DESCRIPTION
CLI 0.38.0 removed the standalone `scloud secret` command and merged it into `scloud variable` behind a `--secret` flag (serverpod/serverpod_cloud#2443). The sync PR #772 mirrors that by deleting the secret reference pages, but its build check is red because these pages on main still point at the removed command.

- Reworks the secrets parts of the passwords/secrets/variables concept page around `scloud variable set --secret`: the tier table, the Manage secrets examples, list and unset behavior (secrets listed masked, no flag needed on unset), and the rule that a name keeps its tier (changing tier is refused; unset and recreate).
- Rewrites the `scloud variable` reference intro, which called variables plaintext-only and pointed at `scloud secret`.
- Drops the Related link to the deleted secret page.

The tier model itself is unchanged: secrets and variables remain separate stores with separate 64,000-byte budgets, and secrets created with the old command appear in `scloud variable list`.

Unblocks #772: the build passes both against current main and against the state after #772 merges. A follow-up once #772 lands will add a redirect from the old secret command URL and write the intro for the new status command page.
