### PR TITLE
docs: Add cloud secret redirect and status/context intros

### DIFF
--- a/cloud_docs/reference/cli/commands/context/_context.md
+++ b/cloud_docs/reference/cli/commands/context/_context.md
@@ -1,0 +1,5 @@
+# scloud context
+
+`scloud context` manages a locally stored default project. Project-scoped commands fall back to it when no `--project` flag, environment variable, or `scloud.yaml` selects one, so set it once to work on a project from any directory.
+
+For a per-repository default, link the directory instead with [`scloud project link`](/cloud/reference/cli/commands/project).

--- a/cloud_docs/reference/cli/commands/status/_status.md
+++ b/cloud_docs/reference/cli/commands/status/_status.md
@@ -1,0 +1,5 @@
+# scloud status
+
+`scloud status` shows the live state of your deployed project: whether the service is up, how many podlets (the server instances running your deployment) are ready, which deployment is serving, and whether a new one is rolling in. Use it as the first check after a deploy or when the service misbehaves.
+
+To follow a deploy attempt in detail, use [`scloud deployment`](/cloud/reference/cli/commands/deployment); to read runtime output, use [`scloud log`](/cloud/reference/cli/commands/log).

--- a/redirects.js
+++ b/redirects.js
@@ -44,6 +44,10 @@ module.exports = [{
     to: '/concepts/scheduling/setup',
   },
   {
+    from: ['/cloud/reference/cli/commands/secret'],
+    to: '/cloud/reference/cli/commands/variable',
+  },
+  {
     from: ['/cloud/reference/deployment/deploying-your-application'],
     to: '/cloud/concepts/deployments',
   },


### PR DESCRIPTION
Follow-up to #772, which removed the `scloud secret` reference pages after CLI 0.38.0 merged the command into `scloud variable --secret`.

- Redirects `/cloud/reference/cli/commands/secret` to the variable page. Released CLIs up to 0.37.x print the old URL in their help output, so the link keeps working for users on those versions. The redirect could only land once #772 deleted the page, since the plugin rejects redirects whose source path still exists.
- Writes the curated intro for the new `scloud status` page, which shipped with an empty scaffold and rendered without a heading or title. The intro defines podlets in passing, since the generated help uses the term and no other page does.
- Fills in the `scloud context` intro, which had the same gap since the page was created, and points readers choosing between context and per-directory linking at `scloud project link`.
