### PR TITLE
docs: Add scalability and optimization guidance

### DIFF
--- a/docs/06-concepts/07-operations/01-overview.md
+++ b/docs/06-concepts/07-operations/01-overview.md
@@ -1,10 +1,10 @@
 ---
-description: Operations covers running a Serverpod server in production, seeing what it is doing through logs, proving it is healthy, securing its traffic, and catching exceptions.
+description: Operations covers running Serverpod in production through logs, health checks, TLS, exception monitoring, and scaling past a single process.
 ---
 
 # Overview
 
-Once your server is written, the work shifts from building features to running them. This section covers what you need after deployment: seeing what the server is doing, proving to a host that it is healthy, securing the traffic it accepts, and finding out when something breaks.
+Once your server is written, the work shifts from building features to running them. This section covers what you need after deployment: seeing what the server is doing, proving to a host that it is healthy, securing the traffic it accepts, finding out when something breaks, and scaling past a single process.
 
 Everything here works the same whether you deploy to [Serverpod Cloud](../../deployments/deploy-to-serverpod-cloud) or [host it yourself](../../deployments/custom-hosting/choosing-a-strategy), though the two differ in how much is set up for you.
 
@@ -14,6 +14,7 @@ Everything here works the same whether you deploy to [Serverpod Cloud](../../dep
 - **[Health checks](health-checks)**: the HTTP endpoints a host calls to decide whether your server is alive and ready for traffic, plus the metrics Serverpod collects about itself.
 - **[Security and TLS](security-and-tls)**: how traffic to your server is encrypted, and when you need to configure that yourself.
 - **[Exception monitoring](exception-monitoring)**: reporting exceptions to a monitoring service as they happen. This one is an experimental API.
+- **[Scalability](scalability)**: roles for scale-out, isolates for CPU work, Postgres and connection pools, Redis, JWT auth, and streaming tradeoffs.
 
 ## Related
 

--- a/docs/06-concepts/07-operations/06-scalability.md
+++ b/docs/06-concepts/07-operations/06-scalability.md
@@ -1,0 +1,131 @@
+---
+description: Scale Serverpod beyond a single process with server roles, isolates, Postgres indexes and pools, Redis, JWT auth, and when short RPCs beat long-lived streams.
+---
+
+# Scalability
+
+When traffic jumps, the first bottlenecks are usually a blocked Dart event loop, an undersized database pool across many nodes, or shared state that only lives in one process. This page covers how Serverpod scales out request-serving instances, and what to change so CPU work, Postgres, auth, caching, and long-lived connections keep up.
+
+Elastic scale-out of request handlers is already covered by [server roles](../server-fundamentals/running-your-server#choose-a-server-role). The sections below cover what still bites at high daily active users. Built-in read replicas and a Serverpod-owned Postgres tuning recipe are not available today; use cloud provider guides and the escape hatches noted here.
+
+## How Serverpod scales
+
+Each Serverpod process runs on one Dart isolate and one event loop. CPU-heavy work on that isolate delays request handling for every concurrent call on the same process.
+
+HTTPS APIs with JWT auth are largely stateless and scale behind a load balancer. Features that keep in-process state (local caches, local server events, long-lived streams without a shared bus) need either sticky routing, Redis, or a redesign so state lives outside the process.
+
+For serverless or auto-scaled fleets, run request nodes in the `serverless` role (or `monolith` if you accept in-process maintenance), and run `maintenance` on a schedule for future calls and health metric collection. See [Hosting elsewhere](../../deployments/custom-hosting/hosting-elsewhere#server-roles) and [Scheduling overview](../scheduling/overview).
+
+## Split request and maintenance work
+
+Use roles so request capacity and background work do not share the same scaling curve:
+
+| Role | Serves requests | Runs future calls and health metrics |
+| --- | --- | --- |
+| `monolith` | Yes | Yes (continuous) |
+| `serverless` | Yes | No |
+| `maintenance` | No | Once, then exit |
+
+```bash
+dart run bin/main.dart --mode production --role serverless
+```
+
+Schedule a separate process in the `maintenance` role (for example once per minute) when request nodes run as `serverless`. On pure request nodes you can also set `futureCallExecutionEnabled` to `false`; see [Future call configuration](../scheduling/configuration).
+
+## Offload CPU work to isolates
+
+Image decoding, password hashing, and other CPU-bound work should not run on the request isolate. Use Dart's `Isolate.run` with plain data only:
+
+```dart
+Future<List<int>> buildThumbnail(List<int> bytes) async {
+  return Isolate.run(() {
+    // CPU-heavy decode, resize, and encode.
+    // Pass only serializable data in and out.
+    return processImage(bytes);
+  });
+}
+```
+
+Do not pass a `Session`, database connection, or Redis client into the isolate. Do I/O on the main isolate after the isolate returns.
+
+There is no first-party Serverpod helper for this pattern. For sustained background workloads, raise `futureCall.concurrencyLimit` carefully (default `1`), or plan for a dedicated worker model as your product grows.
+
+## Optimize Postgres queries
+
+Declare indexes in your models for columns you filter and sort on. Without an index that covers an `ORDER BY`, Postgres may sort the full result set before applying `OFFSET` / `LIMIT`. See [Indexing](../data-and-the-database/database/indexing).
+
+Prefer [cursor-based pagination](../data-and-the-database/database/pagination#cursor-based-pagination) over deep `offset` pages on large tables: filter with `where: (t) => t.id > lastId`, `orderBy` on `id`, and a `limit`.
+
+At high scale, treat wide `OR` / `inSet` filters carefully, especially expressions like `(A OR B) AND (C OR D)`. Those shapes can explode into many indexed paths. Prefer a denormalized flag, a `UNION` of simpler indexed queries, or a narrower filter design when those queries dominate load.
+
+## Size the connection pool
+
+Each Serverpod process opens its own pool. The default `database.maxConnectionCount` is `10` (override with `SERVERPOD_DATABASE_MAX_CONNECTION_COUNT`). Across a fleet:
+
+`(number of nodes × maxConnectionCount) + headroom ≤ Postgres max_connections`
+
+Leave headroom for Insights, maintenance jobs, migrations, and admin tools. Unlimited pools (`0` or a negative value) are easy to misconfigure under auto-scaling. See [Database connection](../data-and-the-database/database/connection#configure-connection-pool-size).
+
+## Scale Postgres itself
+
+Assigning CPU, memory, and storage to Postgres is owned by your cloud provider (RDS instance class, Cloud SQL machine type, and similar). Point your operators at those guides rather than copying example parameters into Serverpod config.
+
+Serverpod does not ship a read-only query API (there is no `MyTable.dbro`) and does not auto-route reads to replicas. Practical options today:
+
+- Put a proxy or cloud read endpoint in front of the database (PgBouncer, RDS Proxy, or your provider's reader endpoint) when the proxy can classify traffic.
+- Or wrap `session.db` with a [database interceptor](../data-and-the-database/database/database-interceptors) that routes selected reads yourself.
+
+Treat third-party Postgres tuning examples as illustrative for your workload and instance size, not as Serverpod defaults.
+
+## Prefer JWT for auth at scale
+
+Modern projects use the [JWT token manager](../authentication/token-managers/jwt-token-manager). Access-token verification is local and does not query the database on every request. Refresh still hits the database; that path is far less frequent than ordinary API calls.
+
+[Server-side sessions](../authentication/token-managers/managing-tokens) are the opposite tradeoff: a database lookup on validation, with immediate revocation. Prefer JWT when request volume is the constraint. Legacy auth key handlers that load a row per request do not belong on a high-QPS fleet.
+
+## Share state across instances with Redis
+
+Local caches (`session.caches.local` and `localPrio`) stay on one process. For values every instance must see, use the [global cache](../endpoints-and-apis/caching#the-global-cache-and-redis) with Redis enabled.
+
+Cross-instance [server events](../endpoints-and-apis/server-events) need Redis as well. `MessageScope.global` requires Redis; without it, messaging stays local to the process that posted the event.
+
+Enable Redis in production config when you run more than one request node that shares cache entries or broadcast events.
+
+## Choose streams carefully
+
+[Streaming endpoints](../endpoints-and-apis/streaming) keep a WebSocket session open for the life of the stream. That is the right model for chat, multiplayer, and live dashboards. At very high concurrent clients per node, long-lived connections consume file descriptors and complicate load balancing and autoscaling.
+
+When fan-out volume is the problem, prefer short HTTPS RPCs for client-to-server work and an external push service (FCM, APNs, or similar) for server-to-client wakeups. Firebase in Serverpod is an auth identity provider, not a push delivery product; wire push as an integration outside the framework.
+
+Keep `websocketPingInterval` (default 30 seconds) in mind under high connection counts: each open socket pays keepalive cost.
+
+## Configuration cheat sheet
+
+| Setting | Default | Why it matters at scale |
+| --- | --- | --- |
+| `role` / `SERVERPOD_SERVER_ROLE` | `monolith` | Split request nodes from maintenance work. |
+| `database.maxConnectionCount` | `10` | Pool size times node count must fit Postgres. |
+| `redis.enabled` | `false` in templates | Required for shared cache and global events. |
+| `maxRequestSize` | `524288` | Large uploads increase memory pressure. |
+| `websocketPingInterval` | `30` (seconds) | Keepalive cost under many open streams. |
+| `futureCall.concurrencyLimit` | `1` | Caps background CPU and database load. |
+| `sessionLogs.persistentEnabled` | mode-dependent | Extra database writes per request when on. |
+| `healthCheckInterval` | about 1 minute | Metrics write load; aggressive liveness elsewhere can cascade restarts. |
+
+Full keys and environment variables: [Configuration reference](../lookups/configuration-reference).
+
+## Limits
+
+- No first-class read-replica routing or `dbro` API; use a proxy or a database interceptor.
+- No Serverpod-owned production Postgres tuning profile; follow your cloud database guide.
+- Isolate offloading is a Dart convention in your code, not a framework API.
+- Terraform and sample AWS layouts in community examples are starting points, not production scale blueprints.
+
+## Related
+
+- [Server roles](../server-fundamentals/running-your-server#choose-a-server-role): which processes serve traffic versus maintenance.
+- [Hosting elsewhere](../../deployments/custom-hosting/hosting-elsewhere): roles and Docker on your own host.
+- [Indexing](../data-and-the-database/database/indexing): declare indexes for filters and sorts.
+- [Caching](../endpoints-and-apis/caching): local versus Redis-backed global cache.
+- [Health checks](health-checks): probes and metric collection under load.
+- [Configuration reference](../lookups/configuration-reference): every scale-related env var.

--- a/docs/06-concepts/07-operations/06-scalability.md
+++ b/docs/06-concepts/07-operations/06-scalability.md
@@ -64,7 +64,7 @@ Each Serverpod process opens its own pool. The default `database.maxConnectionCo
 
 `(number of nodes × maxConnectionCount) + headroom ≤ Postgres max_connections`
 
-Leave headroom for Insights, maintenance jobs, migrations, and admin tools. Unlimited pools (`0` or a negative value) are easy to misconfigure under auto-scaling. See [Database connection](../data-and-the-database/database/connection#configure-connection-pool-size).
+Leave headroom for Insights, maintenance jobs, migrations, and admin tools. Unlimited pools (a negative value, or omitting the key) are easy to misconfigure under auto-scaling. See [Database connection](../data-and-the-database/database/connection#configure-connection-pool-size).
 
 ## Scale Postgres itself
 
@@ -87,7 +87,7 @@ Modern projects use the [JWT token manager](../authentication/token-managers/jwt
 
 Local caches (`session.caches.local` and `localPrio`) stay on one process. For values every instance must see, use the [global cache](../endpoints-and-apis/caching#the-global-cache-and-redis) with Redis enabled.
 
-Cross-instance [server events](../endpoints-and-apis/server-events) need Redis as well. `MessageScope.global` requires Redis; without it, messaging stays local to the process that posted the event.
+Cross-instance [server events](../endpoints-and-apis/server-events) need Redis as well. `MessageScope.global` throws a `StateError` without Redis, and the default `MessageScope.auto` falls back to local delivery, so without Redis events silently stop reaching other instances.
 
 Enable Redis in production config when you run more than one request node that shares cache entries or broadcast events.
 
@@ -105,12 +105,12 @@ Keep `websocketPingInterval` (default 30 seconds) in mind under high connection 
 | --- | --- | --- |
 | `role` / `SERVERPOD_SERVER_ROLE` | `monolith` | Split request nodes from maintenance work. |
 | `database.maxConnectionCount` | `10` | Pool size times node count must fit Postgres. |
-| `redis.enabled` | `false` in templates | Required for shared cache and global events. |
+| `redis.enabled` | `false` | Required for shared cache and global events. |
 | `maxRequestSize` | `524288` | Large uploads increase memory pressure. |
 | `websocketPingInterval` | `30` (seconds) | Keepalive cost under many open streams. |
 | `futureCall.concurrencyLimit` | `1` | Caps background CPU and database load. |
-| `sessionLogs.persistentEnabled` | mode-dependent | Extra database writes per request when on. |
-| `healthCheckInterval` | about 1 minute | Metrics write load; aggressive liveness elsewhere can cascade restarts. |
+| `sessionLogs.persistentEnabled` | on when a database is configured | Extra database writes per request when on. |
+| `healthCheckInterval` | 1 minute | Metrics write load; aggressive liveness elsewhere can cascade restarts. |
 
 Full keys and environment variables: [Configuration reference](../lookups/configuration-reference).
 

--- a/docs/06-concepts/07-operations/06-scalability.md
+++ b/docs/06-concepts/07-operations/06-scalability.md
@@ -1,5 +1,5 @@
 ---
-description: Scale Serverpod beyond a single process with server roles, isolates, Postgres indexes and pools, Redis, JWT auth, and when short RPCs beat long-lived streams.
+description: "Scaling guidance for Serverpod: server roles, isolates for CPU work, Postgres indexes and pools, Redis, JWT auth, and when short RPCs beat long-lived streams."
 ---
 
 # Scalability

--- a/docs/08-deployments/custom-hosting/02-hosting-elsewhere.md
+++ b/docs/08-deployments/custom-hosting/02-hosting-elsewhere.md
@@ -42,6 +42,8 @@ You can specify the role of your server when you launch it by setting the `--rol
 $ dart bin/main.dart --role serverless
 ```
 
+For connection pools, Redis, isolates, and other production scale concerns beyond roles, see [Scalability](../../concepts/operations/scalability).
+
 ## Docker container
 
 Running Serverpod through a Docker container is often the best option as it provides a well-defined environment. It's also easy to integrate into your build and deployment process and runs well on most platforms.


### PR DESCRIPTION
## Summary
- Adds an Operations concept page on scaling Serverpod beyond a single process: server roles, `Isolate.run` for CPU work, Postgres indexes and query shape, connection pool sizing, Redis for shared cache and events, JWT auth, and streaming tradeoffs.
- States current limits honestly (no first-class read replicas or Serverpod-owned Postgres tuning), and points to database interceptors or an external proxy where needed.
- Links the page from the Operations overview and Hosting elsewhere (server roles).

Closes [serverpod/serverpod#1718](https://github.com/serverpod/serverpod/issues/1718).

## Test plan
- [ ] Open Next → Concepts → Operations → Scalability.
- [ ] Confirm the page appears in the Operations sidebar after Exception monitoring.
- [ ] Follow inbound links from Operations overview and Hosting elsewhere → Server roles.
- [ ] Spot-check outbound links: server roles, indexing, pagination, connection pool, database interceptors, JWT token manager, caching, server events, streaming, configuration reference.
- [ ] Skim for em dashes and marketing wording against STYLE_GUIDE.md.