### PR TITLE
docs: Use serverpod start in the real-time communication tutorial

### DIFF
--- a/docs/07-tutorials/02-real-time-communication.md
+++ b/docs/07-tutorials/02-real-time-communication.md
@@ -387,7 +387,11 @@ To test Pixorama, start the server and the app from the `pixorama_server` direct
 serverpod start
 ```
 
-`serverpod start` runs the server and opens the Flutter app, and hot reloads both as you save changes. To pick the device yourself, keep the server running, change to the `pixorama_flutter` directory, and run `flutter run -d chrome`.
+`serverpod start` runs the server and opens the Flutter app, and hot reloads both as you save changes.
+
+:::info
+To pick the device yourself, run `serverpod start --no-flutter`, then change to the `pixorama_flutter` directory and run `flutter run -d chrome`. Running `flutter run` next to the app `serverpod start` opened also works: each instance is another drawing client.
+:::
 
 You can also start a second instance of the app to see real-time updates reflected across both instances.
 

--- a/docs/07-tutorials/02-real-time-communication.md
+++ b/docs/07-tutorials/02-real-time-communication.md
@@ -381,17 +381,13 @@ class _PixoramaState extends State<Pixorama> {
 
 ## Running Pixorama
 
-To test Pixorama, start the server by navigating to the `pixorama_server` directory and running:
+To test Pixorama, start the server and the app from the `pixorama_server` directory:
 
 ```bash
-dart bin/main.dart
+serverpod start
 ```
 
-Then, launch the Flutter app by changing to the `pixorama_flutter` directory and running:
-
-```bash
-flutter run -d chrome
-```
+`serverpod start` runs the server and opens the Flutter app, and hot reloads both as you save changes. To pick the device yourself, keep the server running, change to the `pixorama_flutter` directory, and run `flutter run -d chrome`.
 
 You can also start a second instance of the app to see real-time updates reflected across both instances.
 


### PR DESCRIPTION
The Pixorama tutorial's run section still used the pre-4.0 triad: a bare `dart bin/main.dart` plus a separate `flutter run`. It now uses `serverpod start`, matching the workflow every other guide teaches, with the `-d chrome` option kept for readers who want to pick the device themselves.

This was the last dev-loop use of `dart bin/main.dart` in the docs; the remaining mentions are deliberate (migrations, maintenance role, production deployment, run scripts, and archived guides). Closes #565.