### PR TITLE
docs: Fix broken framework links in Cloud documentation

### DIFF
--- a/cloud_docs/concepts/cdn.md
+++ b/cloud_docs/concepts/cdn.md
@@ -62,7 +62,7 @@ cacheControlFactory: StaticRoute.public(maxAge: const Duration(minutes: 1)),
 Flutter's build uses fixed file names with no content hashes, so a long browser `max-age` can leave a visitor on an old build after you deploy. Keep the browser lifetime short and let the deploy purge handle the edge.
 :::
 
-Caching more aggressively takes cache busting, where each asset URL includes a hash of the file's content, so a new build gets new URLs and old cached copies are never requested again. The web server supports this for static files, and hashed assets can use `publicImmutable` with a long lifetime, because a file at a hashed URL never changes. Flutter's build does not produce hashed names, so for a Flutter build that means post-processing the build output yourself, and the short browser lifetime above is the simpler choice. See the framework [Static files](https://docs.serverpod.dev/concepts/web-server/static-files) guide for the full `cacheControlFactory` and cache-busting reference.
+Caching more aggressively takes cache busting, where each asset URL includes a hash of the file's content, so a new build gets new URLs and old cached copies are never requested again. The web server supports this for static files, and hashed assets can use `publicImmutable` with a long lifetime, because a file at a hashed URL never changes. Flutter's build does not produce hashed names, so for a Flutter build that means post-processing the build output yourself, and the short browser lifetime above is the simpler choice. See the framework [Static files](/concepts/webserver/static-files) guide for the full `cacheControlFactory` and cache-busting reference.
 
 ## Verify caching is working
 
@@ -99,6 +99,6 @@ How to read the responses:
 
 - [Deployments](/cloud/concepts/deployments): the deploy that clears the cache.
 - [Custom domains](/cloud/concepts/custom-domains): the CDN covers your custom domains too.
-- [Static files](https://docs.serverpod.dev/concepts/web-server/static-files): the framework reference for `cacheControlFactory` and cache busting.
-- [Single-page apps](https://docs.serverpod.dev/concepts/web-server/single-page-apps): serving another framework's single-page app with `SpaRoute`.
-- [Flutter web apps](https://docs.serverpod.dev/concepts/web-server/flutter-web): serving a Flutter build from the framework web server.
+- [Static files](/concepts/webserver/static-files): the framework reference for `cacheControlFactory` and cache busting.
+- [Single-page apps](/concepts/webserver/single-page-apps): serving another framework's single-page app with `SpaRoute`.
+- [Flutter web apps](/concepts/webserver/flutter-web): serving a Flutter build from the framework web server.

--- a/cloud_docs/concepts/logs.md
+++ b/cloud_docs/concepts/logs.md
@@ -132,7 +132,7 @@ Two environment variables control session logging. With a database enabled (the 
 
 To change either default, set the value with `scloud variable set`. See [Passwords, secrets, and environment variables](/cloud/concepts/passwords-secrets-env-vars) for variable management.
 
-For what the server records, which tables it writes to, and how retention works, see [Logging](https://docs.serverpod.dev/concepts/operations/logging) in the framework documentation.
+For what the server records, which tables it writes to, and how retention works, see [Logging](/concepts/logging) in the framework documentation.
 
 ## Troubleshooting
 

--- a/cloud_docs/getting-started/launch.md
+++ b/cloud_docs/getting-started/launch.md
@@ -14,7 +14,7 @@ Get your Serverpod app live on Cloud in a few minutes.
 You need:
 
 - `scloud`, Serverpod Cloud's command-line tool, installed and signed in. See [Install scloud](/cloud/getting-started/installation).
-- A Serverpod project on your machine. See the Serverpod [Quickstart](https://docs.serverpod.dev/get-started/quickstart) to create one.
+- A Serverpod project on your machine. See [Creating a new project](/#creating-a-new-project) in the Serverpod installation guide.
 
 ## Launch your project
 

--- a/cloud_docs/guides/redis.md
+++ b/cloud_docs/guides/redis.md
@@ -73,8 +73,8 @@ After a successful deploy, your server will use Upstash for Redis-backed caching
 
 ## Related
 
-- [Redis](https://docs.serverpod.dev/next/concepts/server-fundamentals/redis) for enabling Redis, the password, and connecting a GUI.
-- [Serverpod configuration](https://docs.serverpod.dev/concepts/server-fundamentals/configuration) for Redis options and environment variables.
-- [Serverpod caching](https://docs.serverpod.dev/concepts/endpoints-and-apis/caching) for local and Redis-backed caches.
+- [Redis](/next/concepts/server-fundamentals/redis) for enabling Redis, the password, and connecting a GUI.
+- [Serverpod configuration](/concepts/configuration) for Redis options and environment variables.
+- [Serverpod caching](/concepts/caching) for local and Redis-backed caches.
 - [Upstash: Connect your client](https://upstash.com/docs/redis/howto/connectclient) for connection details and TLS.
 - [Passwords, secrets, and environment variables](/cloud/concepts/passwords-secrets-env-vars) for how Serverpod Cloud injects passwords and variables.


### PR DESCRIPTION
Eight links from four Cloud pages pointed at framework paths that only exist in the 4.0 prerelease. Readers on the released version hit 404s while following the deploy, logging, caching, and web-hosting paths.

They were all written as absolute `https://docs.serverpod.dev/...` URLs. Docusaurus treats those as external and skips them, so the broken-link check never saw them. Each one now points at the equivalent page in the served version, written as a root-relative path like the rest of our cloud-to-framework links, so the build checks it from here on.
