### PR TITLE
docs: Fix includeList nested include parameter name

### DIFF
--- a/docs/06-concepts/03-data-and-the-database/02-database/07-relation-queries.md
+++ b/docs/06-concepts/03-data-and-the-database/02-database/07-relation-queries.md
@@ -75,7 +75,7 @@ The example above returns a company with all related employees included.
 
 ### Nested includes
 
-The `includeList` method works slightly differently from a normal `include` and to include nested objects the `includes` field must be used. When including something on a list it means that every entry in the list will each have access to the nested object.
+The `includeList` method works slightly differently from a normal `include`. To include nested objects, use its `include` parameter. When including something on a list it means that every entry in the list will each have access to the nested object.
 
 ```dart
 var company = await Company.db.findById(
@@ -83,7 +83,7 @@ var company = await Company.db.findById(
   companyId,
   include: Company.include(
     employees: Employee.includeList(
-      includes: Employee.include(
+      include: Employee.include(
         address: Address.include(),
       ),
     ),
@@ -101,7 +101,7 @@ var company = await Company.db.findById(
   companyId,
   include: Company.include(
     employees: Employee.includeList(
-      includes: Employee.include(
+      include: Employee.include(
         tools: Tool.includeList(),
       ),
     ),

--- a/docs/06-concepts/03-data-and-the-database/02-database/07-relation-queries.md
+++ b/docs/06-concepts/03-data-and-the-database/02-database/07-relation-queries.md
@@ -75,7 +75,7 @@ The example above returns a company with all related employees included.
 
 ### Nested includes
 
-The `includeList` method works slightly differently from a normal `include`. To include nested objects, use its `include` parameter. When including something on a list it means that every entry in the list will each have access to the nested object.
+The `includeList` method takes its nested includes through an `include` parameter, the same name used on `findById`. When including something on a list it means that every entry in the list will each have access to the nested object.
 
 ```dart
 var company = await Company.db.findById(


### PR DESCRIPTION
The nested include on `includeList` is documented as `includes`. The generated
parameter is `include`, the same name used on `findById`, so both examples on
the page fail to compile as written.

Verified against 4.0.0-rc.2, which emits `where`, `limit`, `offset`, `orderBy`,
`orderByList`, and `include`. The `versioned_docs` copies carry the same error
back to 1.2.0 and are left for a separate pass, since they are frozen release
snapshots. Closes #798.