### PR TITLE
docs: Update SDK minimums, require .spy.yaml model files, and cover remaining 4.0 breaking changes

### DIFF
--- a/docs/04-get-started/01-installation.md
+++ b/docs/04-get-started/01-installation.md
@@ -8,7 +8,7 @@ slug: /installation
 
 ### Prerequisites
 
-Serverpod is tested on Mac, Windows, and Linux. Before you can install Serverpod, you need to have **[Flutter](https://flutter.dev/docs/get-started/install)** installed.
+Serverpod is tested on Mac, Windows, and Linux. Before you can install Serverpod, you need to have **[Flutter](https://flutter.dev/docs/get-started/install)** installed. Serverpod 4 requires Flutter 3.44.4 or later, which includes Dart 3.12.2.
 
 :::info
 Check your Flutter installation by running the following command in your terminal:

--- a/docs/06-concepts/03-data-and-the-database/01-models/01-working-with-models.md
+++ b/docs/06-concepts/03-data-and-the-database/01-models/01-working-with-models.md
@@ -8,7 +8,7 @@ description: Serverpod model files define serializable classes, exceptions, and 
 
 A data model is a YAML definition that becomes a typed Dart class on both the server and the client, and, with a [table](./database/tables) key, a database table as well. Models are the unit of data your endpoints pass and your database stores. You can also [define models that you only use in Flutter](#using-models-on-the-client-only).
 
-The recommended file extension is `.spy.yaml` (.spy stands for "Serverpod YAML"), with `.spy` and `.spy.yml` accepted as well. These files can be placed anywhere in your server's `lib` directory, and the extension enables syntax highlighting through the [Serverpod Extension](https://marketplace.visualstudio.com/items?itemName=serverpod.serverpod) for VS Code. Regular `.yaml` files are also supported, but only within `lib/src/models` (or the legacy `lib/src/protocol` directory).
+The recommended file extension is `.spy.yaml` (.spy stands for "Serverpod YAML"), with `.spy` and `.spy.yml` accepted as well. These files can be placed anywhere in your server's `lib` directory, and the extension enables syntax highlighting through the [Serverpod Extension](https://marketplace.visualstudio.com/items?itemName=serverpod.serverpod) for VS Code. Files with a plain `.yaml` or `.yml` extension are not model files. Serverpod 4 ignores them in `lib/src/models` and `lib/src/protocol` and reports an error asking you to rename them.
 
 The Serverpod CLI reads the model files when generating code and creating migrations. With `serverpod start` running, saving a model file regenerates the code. Outside a session, run `serverpod generate`.
 

--- a/docs/06-concepts/03-data-and-the-database/01-models/06-shared-packages.md
+++ b/docs/06-concepts/03-data-and-the-database/01-models/06-shared-packages.md
@@ -21,7 +21,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.10.3
+  sdk: ^3.12.2
 
 dependencies:
   serverpod_serialization: SERVERPOD_VERSION

--- a/docs/06-concepts/03-data-and-the-database/02-database/06-relations/01-one-to-one.md
+++ b/docs/06-concepts/03-data-and-the-database/02-database/06-relations/01-one-to-one.md
@@ -15,13 +15,13 @@ In the following examples we show how to configure a 1:1 relationship between `U
 In the most simple case, all we have to do is add an `id` field on one of the models.
 
 ```yaml
-# address.yaml
+# address.spy.yaml
 class: Address
 table: address
 fields:
   street: String
 
-# user.yaml
+# user.spy.yaml
 class: User
 table: user
 fields:
@@ -44,13 +44,13 @@ When fetching a `User` from the database the `addressId` field will automaticall
 While the previous example highlights manual handling of data, there's an alternative approach that simplifies data access using automated handling. By directly specifying the Address type in the User class, Serverpod can automatically handle the relation for you.
 
 ```yaml
-# address.yaml
+# address.spy.yaml
 class: Address
 table: address
 fields:
   street: String
 
-# user.yaml
+# user.spy.yaml
 class: User
 table: user
 fields:
@@ -75,7 +75,7 @@ No `parent` keyword is needed here because the relational table is inferred from
 ### Optional relation
 
 ```yaml
-# user.yaml
+# user.spy.yaml
 class: User
 table: user
 fields:
@@ -93,7 +93,7 @@ With the introduction of the `optional` keyword in the relation, the automatical
 The `field` parameter names the foreign key field used by an object relation.
 
 ```yaml
-# user.yaml
+# user.spy.yaml
 class: User
 table: user
 fields:
@@ -114,7 +114,7 @@ fields:
 Declare the field yourself when you need control over it, for example to give it a [column name override](../tables#column-name-override) or a [scope](../../models#limiting-visibility-of-a-generated-class). A declared field must be nullable if the relation is `optional`:
 
 ```yaml
-# user.yaml
+# user.spy.yaml
 class: User
 table: user
 fields:
@@ -159,7 +159,7 @@ The `ON DELETE` and `ON UPDATE` clauses come from the relation's referential act
 You are able to define as many independent relations as you wish on each side of the relation. This is useful when you want to have multiple relations between two entities.
 
 ```yaml
-# user.yaml
+# user.spy.yaml
 class: User
 table: user
 fields:
@@ -169,7 +169,7 @@ indexes:
     fields: friendsAddressId
     unique: true
 
-# address.yaml
+# address.spy.yaml
 class: Address
 table: address
 fields:
@@ -188,7 +188,7 @@ Both relations operate independently of each other, resulting in two distinct re
 If access to the same relation is desired from both sides, a bidirectional relation can be defined.
 
 ```yaml
-# user.yaml
+# user.spy.yaml
 class: User
 table: user
 fields:
@@ -198,7 +198,7 @@ indexes:
     fields: addressId
     unique: true
 
-# address.yaml
+# address.spy.yaml
 class: Address
 table: address
 fields:

--- a/docs/06-concepts/03-data-and-the-database/02-database/06-relations/02-one-to-many.md
+++ b/docs/06-concepts/03-data-and-the-database/02-database/06-relations/02-one-to-many.md
@@ -17,14 +17,14 @@ In the following examples we show how to configure a 1:n relationship between `C
 With an implicit setup, Serverpod determines and establishes the relationship based on the table and class structures.
 
 ```yaml
-# company.yaml
+# company.spy.yaml
 class: Company
 table: company
 fields:
   name: String
   employees: List<Employee>?, relation
 
-# employee.yaml
+# employee.spy.yaml
 class: Employee
 table: employee
 fields:
@@ -44,13 +44,13 @@ In an explicit definition, you directly specify the relationship in a one-to-man
 This can be done through an [object relation](one-to-one#with-an-object):
 
 ```yaml
-# company.yaml
+# company.spy.yaml
 class: Company
 table: company
 fields:
   name: String
 
-# employee.yaml
+# employee.spy.yaml
 class: Employee
 table: employee
 fields:
@@ -61,13 +61,13 @@ fields:
 Or through a [foreign key field](one-to-one#with-an-id-field):
 
 ```yaml
-# company.yaml
+# company.spy.yaml
 class: Company
 table: company
 fields:
   name: String
 
-# employee.yaml
+# employee.spy.yaml
 class: Employee
 table: employee
 fields:
@@ -84,14 +84,14 @@ For a more comprehensive representation, you can define the relationship from bo
 Either through an [object relation](one-to-one#with-an-object) on the many side:
 
 ```yaml
-# company.yaml
+# company.spy.yaml
 class: Company
 table: company
 fields:
   name: String
   employees: List<Employee>?, relation(name=company_employees)
 
-# employee.yaml
+# employee.spy.yaml
 class: Employee
 table: employee
 fields:
@@ -102,14 +102,14 @@ fields:
 Or through a [foreign key field](one-to-one#with-an-id-field) on the many side:
 
 ```yaml
-# company.yaml
+# company.spy.yaml
 class: Company
 table: company
 fields:
   name: String
   employees: List<Employee>?, relation(name=company_employees)
 
-# employee.yaml
+# employee.spy.yaml
 class: Employee
 table: employee
 fields:

--- a/docs/06-concepts/03-data-and-the-database/02-database/06-relations/03-many-to-many.md
+++ b/docs/06-concepts/03-data-and-the-database/02-database/06-relations/03-many-to-many.md
@@ -23,7 +23,7 @@ In the following examples we show how to configure an n:m relationship between `
 Both the `Course` and `Student` tables have a direct relationship with the `Enrollment` table but no direct relationship with each other.
 
 ```yaml
-# course.yaml
+# course.spy.yaml
 class: Course
 table: course
 fields:
@@ -32,7 +32,7 @@ fields:
 ```
 
 ```yaml
-# student.yaml
+# student.spy.yaml
 class: Student
 table: student
 fields:
@@ -47,7 +47,7 @@ Note that the `name` argument is different, `course_enrollments` and `student_en
 The `Enrollment` table acts as the bridge between `Course` and `Student`. It contains foreign keys from both tables, representing the many-to-many relationship.
 
 ```yaml
-# enrollment.yaml
+# enrollment.spy.yaml
 class: Enrollment
 table: enrollment
 fields:

--- a/docs/06-concepts/03-data-and-the-database/02-database/06-relations/06-deferrable-constraints.md
+++ b/docs/06-concepts/03-data-and-the-database/02-database/06-relations/06-deferrable-constraints.md
@@ -13,7 +13,7 @@ This is what makes circular references between two tables writable: with a per-s
 Add `deferrable` or `deferred` to the relation on the side that holds the foreign key:
 
 ```yaml
-# employee.yaml
+# employee.spy.yaml
 class: Employee
 table: employee
 fields:
@@ -31,7 +31,7 @@ The two keywords are mutually exclusive. A relation declared with neither keywor
 Both work on [id relations](one-to-one#with-an-id-field) and [object relations](one-to-one#with-an-object). Like `onUpdate` and `onDelete`, they can only be set on the side holding the foreign key:
 
 ```yaml
-# employee.yaml
+# employee.spy.yaml
 class: Employee
 table: employee
 fields:

--- a/docs/11-upgrading/01-upgrade-to-four.md
+++ b/docs/11-upgrading/01-upgrade-to-four.md
@@ -46,7 +46,7 @@ Also bump the Dart SDK constraint in the root `pubspec.yaml` and `<project>_serv
 
 ```yaml
 environment:
-  sdk: '^3.10.3'
+  sdk: '^3.12.2'
 ```
 
 ### If you use the legacy auth module
@@ -254,7 +254,7 @@ Replace `cursor` with the editor you use: `antigravity`, `claude`, `cline`, `cod
 
 Your production build needs to switch from `dart compile exe` to `dart build cli`. The 4.0 server includes native build hooks that `dart compile` doesn't support, and produces a bundle (executable plus its native libraries) rather than a single static binary, so your Dockerfile needs a few updates.
 
-Copy the updated Dockerfile from the [4.0 framework template](https://github.com/serverpod/serverpod/blob/main/templates/serverpod_templates/projectname_server/Dockerfile) or a fresh 4.0 project's `<project>_server/Dockerfile`. The key changes vs. the 3.4 pattern: build from the project root (not the server directory), copy the bundle directory, update `ENTRYPOINT` to point at the bundled binary, and bump the Dart SDK base image to 3.10.x or newer.
+Copy the updated Dockerfile from the [4.0 framework template](https://github.com/serverpod/serverpod/blob/main/templates/serverpod_templates/projectname_server/Dockerfile) or a fresh 4.0 project's `<project>_server/Dockerfile`. The key changes vs. the 3.4 pattern: build from the project root (not the server directory), copy the bundle directory, update `ENTRYPOINT` to point at the bundled binary, and build from the `dart:3.12.2` base image or newer.
 
 ## Authentication changes
 

--- a/docs/11-upgrading/01-upgrade-to-four.md
+++ b/docs/11-upgrading/01-upgrade-to-four.md
@@ -102,6 +102,18 @@ Then refresh the generated server and client code:
 $ serverpod generate
 ```
 
+### If your model files use the `.yaml` extension
+
+Model files must use the `.spy.yaml` extension in 4.0 (`.spy.yml` and `.spy` are also accepted). Files with a plain `.yaml` or `.yml` extension in `lib/src/models` or `lib/src/protocol` are ignored, and `serverpod generate` and `serverpod start` stop with an error listing them:
+
+```text
+Model files must use the .spy.yaml extension. The following files are ignored:
+  lib/src/models/company.yaml
+Rename the files to use the .spy.yaml extension and run the command again.
+```
+
+Rename the files and run `serverpod generate` again. The contents do not change.
+
 ### If you use the legacy streaming endpoints API
 
 Serverpod's legacy streaming endpoints API was deprecated in 3.0 and is removed in 4.0. Endpoints that use the `StreamingSession` type no longer compile, and all the related server and client methods (e.g. `streamOpened`, `streamClosed`, `handleStreamMessage`, `sendStreamMessage`, `getUserObject`, `setUserObject`, `openStreamingConnection`) are gone.

--- a/docs/11-upgrading/01-upgrade-to-four.md
+++ b/docs/11-upgrading/01-upgrade-to-four.md
@@ -163,7 +163,7 @@ The `*WithOptions` variants on `CloudStorage` are merged into the base methods: 
 
 - The deprecated future call methods on `Serverpod` are gone; use the generated `pod.futureCalls` API. See [Future calls](../concepts/scheduling/future-calls).
 - The `orderDescending` parameter on ORM methods is removed, and `Order` can no longer be constructed directly. Use `column.asc()` and `column.desc()`. See [Sorting](../concepts/data-and-the-database/database/sorting).
-- The `ignoreEndpoint` annotation is removed; use `@doNotGenerate`. See [Exclude an endpoint from generation](../concepts/endpoints-and-apis/working-with-endpoints#exclude-an-endpoint-from-generation).
+- The `ignoreEndpoint` annotation is removed; use `@doNotGenerate`. See [Exclude an endpoint from generation](../concepts/endpoints-and-apis#exclude-an-endpoint-from-generation).
 - `SerializationManagerServer` is removed. The generated `Protocol` class now extends `DatabaseSerializationManager` from `serverpod_database`; code that referenced the old class can use `Protocol` instead.
 - The legacy web-server widgets and static directory classes (`Widget`, `WidgetJson`, `WidgetRedirect`, `RouteStaticDirectory`, and friends) are removed in favor of `WebWidget`, `JsonWidget`, `RedirectWidget`, and `StaticRoute`. `WidgetRoute.build` now returns `WebWidget?`, where `null` yields a 404. See [Web server](../concepts/web-server/overview).
 - The `--mini` flag on `serverpod create` is removed. Create a project without a database with `--no-database`, or without a Flutter app with `--template server`.

--- a/docs/11-upgrading/01-upgrade-to-four.md
+++ b/docs/11-upgrading/01-upgrade-to-four.md
@@ -135,9 +135,46 @@ insightsServer:
 
 The `hotReload`, `getOpenSessionLog`, and `shutdown` Insights methods are removed. See [Insights](../tools/insights#database-access) for details.
 
+## Other breaking changes
+
+Each of these compiles or behaves differently in 4.0. Skim the headings for the ones your project uses.
+
+### Message central delivers globally by default
+
+`session.messages.postMessage` now defaults to `MessageScope.auto`: the message goes through Redis to every server instance when Redis is enabled, and stays local otherwise. Code that relied on local-only delivery must pass `scope: MessageScope.local`, and the removed `global: true` argument becomes `scope: MessageScope.global`. See [Message scope](../concepts/endpoints-and-apis/server-events#message-scope).
+
+### Client exceptions are a sealed hierarchy
+
+`ServerpodClientException` is sealed and carries only `message`. Failures to reach the server throw `ServerpodClientNetworkException`; error responses throw a subclass of the sealed `ServerpodClientHttpException`, which owns `statusCode`. The `statusCode == -1` check for connection failures no longer compiles. See [Error handling and exceptions](../concepts/endpoints-and-apis/error-handling-and-exceptions#handle-errors-in-your-app).
+
+### Database exceptions are typed
+
+`DatabaseInsertRowException`, `DatabaseUpdateRowException`, `DatabaseDeleteRowException`, and `DatabaseUpsertRowException` are replaced by `DatabaseUnexpectedResultException`. Constraint failures throw `DatabaseUniqueViolationException` and `DatabaseForeignKeyViolationException`, and SQLite lock failures throw `SqliteDatabaseLockedException`, all subclasses of `DatabaseQueryException`. See [Database exceptions](../concepts/data-and-the-database/database/exceptions).
+
+### `CloudStorage` methods take an options parameter
+
+The `*WithOptions` variants on `CloudStorage` are merged into the base methods: `storeFile`, `temporaryDownloadUrl`, and `createUploadDescription` now take an `options` parameter. Custom `CloudStorage` implementations must fold the two overrides into one. See [Custom cloud storage](../concepts/endpoints-and-apis/custom-cloud-storage#implement-the-cloudstorage-methods).
+
+### Google sign-in on the web uses the OAuth2 redirect flow
+
+`serverpod_auth_idp_flutter` no longer ships the native Google Sign-In web implementation. On the web, `initializeGoogleSignIn` requires `clientId` and `redirectUri`, and the server needs a `FlutterWebAuth2CallbackRoute`. The legacy `serverpod_auth` module is unaffected. See [Google web setup](../concepts/authentication/providers/google/setup#web).
+
+### Removed deprecated APIs
+
+- The deprecated future call methods on `Serverpod` are gone; use the generated `pod.futureCalls` API. See [Future calls](../concepts/scheduling/future-calls).
+- The `orderDescending` parameter on ORM methods is removed, and `Order` can no longer be constructed directly. Use `column.asc()` and `column.desc()`. See [Sorting](../concepts/data-and-the-database/database/sorting).
+- The `ignoreEndpoint` annotation is removed; use `@doNotGenerate`. See [Exclude an endpoint from generation](../concepts/endpoints-and-apis/working-with-endpoints#exclude-an-endpoint-from-generation).
+- `SerializationManagerServer` is removed. The generated `Protocol` class now extends `DatabaseSerializationManager` from `serverpod_database`; code that referenced the old class can use `Protocol` instead.
+- The legacy web-server widgets and static directory classes (`Widget`, `WidgetJson`, `WidgetRedirect`, `RouteStaticDirectory`, and friends) are removed in favor of `WebWidget`, `JsonWidget`, `RedirectWidget`, and `StaticRoute`. `WidgetRoute.build` now returns `WebWidget?`, where `null` yields a 404. See [Web server](../concepts/web-server/overview).
+- The `--mini` flag on `serverpod create` is removed. Create a project without a database with `--no-database`, or without a Flutter app with `--template server`.
+
+### PostgreSQL Docker image
+
+New projects use `ghcr.io/serverpod/postgres:16`, which bundles pgvector and PostGIS, instead of `pgvector/pgvector:pg16`. Existing Docker setups keep working; switch the image when you need PostGIS. See [Upgrade to PostGIS](./upgrade-to-postgis).
+
 ## Generate the 4.0 migration
 
-Version 4.0 adds a few new internal Serverpod tables and updates some indexes to greatly improve logs performance on Insights. Create a migration that captures these schema deltas so your database can be brought up to date:
+Version 4.0 adds a few new internal Serverpod tables and updates some indexes to greatly improve logs performance on Insights. The migration reads the protocol you generated above, so run `serverpod generate` first. Create a migration that captures these schema deltas so your database can be brought up to date:
 
 ```bash
 $ serverpod create-migration --tag "upgrade-4.0"
@@ -292,6 +329,7 @@ Copy the updated Dockerfile from the [4.0 framework template](https://github.com
 - **`upsert` and `upsertRow`** on the ORM, and **`asc()` / `desc()`** convenience methods on orderable columns.
 - **Recurring future calls** via the new claim-based scheduling.
 - **OAuth2 PKCE Flutter web redirect** for sign-in flows.
+- **Account merging** in the auth module, so a user can link a second sign-in method to an existing account. See [Merging accounts](../concepts/authentication/working-with-users#merging-accounts).
 - **httpOnly cookie authentication for the web**, keeping browser sign-in tokens out of JavaScript-readable storage. See [web authentication](../concepts/authentication/web-authentication).
 - **Health endpoints** on the built-in webserver.
 - **IDE and agent selection** in `serverpod create`.

--- a/docs/11-upgrading/03-migrate-from-legacy-auth.md
+++ b/docs/11-upgrading/03-migrate-from-legacy-auth.md
@@ -10,8 +10,8 @@ This guide is for apps still running `serverpod_auth_server` on Serverpod 3.4 or
 ## Before you start
 
 - A Serverpod 4.0.x project. If you are on an earlier version, follow [Upgrade to 4.0](./upgrade-to-four) first.
-- Dart SDK 3.10.3 or later.
-- Flutter SDK 3.38.4 or later (only if you are migrating the Flutter app).
+- Dart SDK 3.12.2 or later.
+- Flutter SDK 3.44.4 or later (only if you are migrating the Flutter app).
 - Postgres 14 or later, or SQLite3.
 - The four new auth packages at `4.0.0-beta.1`: `serverpod_auth_core`, `serverpod_auth_idp`, `serverpod_auth_bridge`, and `serverpod_auth_migration`.
 - Back up your production database.

--- a/redirects.js
+++ b/redirects.js
@@ -10,13 +10,13 @@ module.exports = [{
   },
   {
     // Moved in version 1.1.1, 2.1.0 and 2.9.0
-    from: ['/tutorials', '/tutorials/videos', '/tutorials/first-app', '/tutorials/tutorials/fundamentals'],
-    to: '/tutorials/fundamentals',
+    from: ['/tutorials', '/tutorials/videos', '/tutorials/first-app'],
+    to: '/tutorials/tutorials/fundamentals',
   },
   {
     // Moved in version 1.2.0
-    from: ['/concepts/database-communication', '/concepts/database/connection'],
-    to: '/concepts/data-and-the-database/database/connection',
+    from: ['/concepts/database-communication'],
+    to: '/concepts/database/connection',
   },
   {
     // Moved in version 2.1.0
@@ -35,13 +35,13 @@ module.exports = [{
   },
   {
     // Moved when scheduling was reorganized from a single page to a directory
-    from: ['/concepts/scheduling', '/concepts/scheduling/setup'],
-    to: '/concepts/scheduling/overview',
+    from: ['/concepts/scheduling'],
+    to: '/concepts/scheduling/setup',
   },
   {
     // Removed in version 4.0 together with the string-based future call API
     from: ['/concepts/scheduling/legacy'],
-    to: '/concepts/scheduling/overview',
+    to: '/concepts/scheduling/setup',
   },
   {
     from: ['/cloud/reference/cli/commands/secret'],
@@ -94,260 +94,5 @@ module.exports = [{
   {
     from: ['/cloud/reference/project-id'],
     to: '/cloud/reference/project-id-rules',
-  },
-  {
-    // Moved in version 4.0: the docs were regrouped into Concepts sections, the
-    // deployment and tutorial pages were reorganized, and older upgrade guides
-    // and the Serverpod Mini pages moved to the archive.
-    from: ['/concepts/authentication/providers/anonymous/configuration', '/concepts/authentication/providers/anonymous/customizing-the-ui'],
-    to: '/concepts/authentication/providers/anonymous/customizations',
-  },
-  {
-    from: ['/concepts/authentication/providers/apple/configuration', '/concepts/authentication/providers/apple/customizing-the-ui'],
-    to: '/concepts/authentication/providers/apple/customizations',
-  },
-  {
-    from: ['/concepts/authentication/providers/facebook/configuration', '/concepts/authentication/providers/facebook/customizing-the-ui'],
-    to: '/concepts/authentication/providers/facebook/customizations',
-  },
-  {
-    from: ['/concepts/authentication/providers/github/configuration', '/concepts/authentication/providers/github/customizing-the-ui'],
-    to: '/concepts/authentication/providers/github/customizations',
-  },
-  {
-    from: ['/concepts/authentication/providers/google/configuration', '/concepts/authentication/providers/google/customizing-the-ui'],
-    to: '/concepts/authentication/providers/google/customizations',
-  },
-  {
-    from: ['/concepts/authentication/providers/microsoft/configuration', '/concepts/authentication/providers/microsoft/customizing-the-ui'],
-    to: '/concepts/authentication/providers/microsoft/customizations',
-  },
-  {
-    from: ['/concepts/authentication/providers/passkey/customizing-the-ui'],
-    to: '/concepts/authentication/providers/passkey/setup',
-  },
-  {
-    from: ['/concepts/database/crud'],
-    to: '/concepts/data-and-the-database/database/crud',
-  },
-  {
-    from: ['/concepts/database/indexing'],
-    to: '/concepts/data-and-the-database/database/indexing',
-  },
-  {
-    from: ['/concepts/database/migrations'],
-    to: '/concepts/data-and-the-database/database/migrations',
-  },
-  {
-    from: ['/concepts/database/pagination'],
-    to: '/concepts/data-and-the-database/database/pagination',
-  },
-  {
-    from: ['/concepts/database/raw-access'],
-    to: '/concepts/data-and-the-database/database/raw-access',
-  },
-  {
-    from: ['/concepts/database/relation-queries'],
-    to: '/concepts/data-and-the-database/database/relation-queries',
-  },
-  {
-    from: ['/concepts/database/row-locking'],
-    to: '/concepts/data-and-the-database/database/row-locking',
-  },
-  {
-    from: ['/concepts/database/runtime-parameters'],
-    to: '/concepts/data-and-the-database/database/runtime-parameters',
-  },
-  {
-    from: ['/concepts/database/transactions'],
-    to: '/concepts/data-and-the-database/database/transactions',
-  },
-  {
-    from: ['/concepts/database/filter'],
-    to: '/concepts/data-and-the-database/database/filtering',
-  },
-  {
-    from: ['/concepts/database/sort'],
-    to: '/concepts/data-and-the-database/database/sorting',
-  },
-  {
-    from: ['/concepts/database/models'],
-    to: '/concepts/data-and-the-database/database/tables',
-  },
-  {
-    from: ['/concepts/database/relations/many-to-many'],
-    to: '/concepts/data-and-the-database/database/relations/many-to-many',
-  },
-  {
-    from: ['/concepts/database/relations/modules'],
-    to: '/concepts/data-and-the-database/database/relations/modules',
-  },
-  {
-    from: ['/concepts/database/relations/one-to-many'],
-    to: '/concepts/data-and-the-database/database/relations/one-to-many',
-  },
-  {
-    from: ['/concepts/database/relations/one-to-one'],
-    to: '/concepts/data-and-the-database/database/relations/one-to-one',
-  },
-  {
-    from: ['/concepts/database/relations/referential-actions'],
-    to: '/concepts/data-and-the-database/database/relations/referential-actions',
-  },
-  {
-    from: ['/concepts/database/relations/self-relations'],
-    to: '/concepts/data-and-the-database/database/relations/self-relations',
-  },
-  {
-    from: ['/concepts/working-with-endpoints'],
-    to: '/concepts/endpoints-and-apis',
-  },
-  {
-    from: ['/concepts/backward-compatibility'],
-    to: '/concepts/endpoints-and-apis/backward-compatibility',
-  },
-  {
-    from: ['/concepts/caching'],
-    to: '/concepts/endpoints-and-apis/caching',
-  },
-  {
-    from: ['/concepts/file-uploads'],
-    to: '/concepts/endpoints-and-apis/file-uploads',
-  },
-  {
-    from: ['/concepts/server-events'],
-    to: '/concepts/endpoints-and-apis/server-events',
-  },
-  {
-    from: ['/concepts/sessions'],
-    to: '/concepts/endpoints-and-apis/sessions',
-  },
-  {
-    from: ['/concepts/streams'],
-    to: '/concepts/endpoints-and-apis/streaming',
-  },
-  {
-    from: ['/concepts/exceptions'],
-    to: '/concepts/endpoints-and-apis/error-handling-and-exceptions',
-  },
-  {
-    from: ['/concepts/models'],
-    to: '/concepts/data-and-the-database/models',
-  },
-  {
-    from: ['/concepts/serialization'],
-    to: '/concepts/data-and-the-database/models/custom-serialization',
-  },
-  {
-    from: ['/concepts/shared-packages'],
-    to: '/concepts/data-and-the-database/models/shared-packages',
-  },
-  {
-    from: ['/concepts/configuration', '/concepts/experimental'],
-    to: '/concepts/server-fundamentals/configuration',
-  },
-  {
-    from: ['/concepts/modules'],
-    to: '/concepts/server-fundamentals/modules',
-  },
-  {
-    from: ['/concepts/health-checks'],
-    to: '/concepts/operations/health-checks',
-  },
-  {
-    from: ['/concepts/logging'],
-    to: '/concepts/operations/logging',
-  },
-  {
-    from: ['/concepts/security-configuration'],
-    to: '/concepts/operations/security-and-tls',
-  },
-  {
-    from: ['/concepts/scheduling/recurring-task'],
-    to: '/concepts/scheduling/recurring-tasks',
-  },
-  {
-    from: ['/concepts/testing/the-basics'],
-    to: '/concepts/testing/get-started',
-  },
-  {
-    from: ['/concepts/testing/best-practises'],
-    to: '/concepts/testing/best-practices',
-  },
-  {
-    from: ['/concepts/webserver/flutter-web'],
-    to: '/concepts/web-server/flutter-web',
-  },
-  {
-    from: ['/concepts/webserver/overview'],
-    to: '/concepts/web-server/overview',
-  },
-  {
-    from: ['/concepts/webserver/request-data'],
-    to: '/concepts/web-server/request-data',
-  },
-  {
-    from: ['/concepts/webserver/routing'],
-    to: '/concepts/web-server/routing',
-  },
-  {
-    from: ['/concepts/webserver/server-side-html'],
-    to: '/concepts/web-server/server-side-html',
-  },
-  {
-    from: ['/concepts/webserver/single-page-apps'],
-    to: '/concepts/web-server/single-page-apps',
-  },
-  {
-    from: ['/concepts/webserver/static-files'],
-    to: '/concepts/web-server/static-files',
-  },
-  {
-    from: ['/concepts/webserver/middleware'],
-    to: '/concepts/web-server/web-server-middleware',
-  },
-  {
-    from: ['/deployments/deployment-strategy'],
-    to: '/deployments/custom-hosting/choosing-a-strategy',
-  },
-  {
-    from: ['/deployments/general', '/deployments/deploying-to-aws', '/deployments/deploying-to-gce-terraform', '/deployments/deploying-to-gcr-console'],
-    to: '/deployments/custom-hosting/hosting-elsewhere',
-  },
-  {
-    from: ['/deployments/community-supported-deployments'],
-    to: '/deployments/custom-hosting/community-supported',
-  },
-  {
-    from: ['/overview'],
-    to: '/how-it-works',
-  },
-  {
-    from: ['/serverpod-mini'],
-    to: '/upgrading/archive/upgrade-from-mini',
-  },
-  {
-    from: ['/tutorials/academy'],
-    to: '/serverpod-academy',
-  },
-  {
-    from: ['/tutorials/tutorials/ai-and-rag'],
-    to: '/tutorials/ai-and-rag',
-  },
-  {
-    from: ['/tutorials/tutorials/real-time-communication'],
-    to: '/tutorials/real-time-communication',
-  },
-  {
-    from: ['/upgrading/upgrade-from-mini'],
-    to: '/upgrading/archive/upgrade-from-mini',
-  },
-  {
-    from: ['/upgrading/upgrade-to-pgvector'],
-    to: '/upgrading/archive/upgrade-to-pgvector',
-  },
-  {
-    from: ['/upgrading/upgrade-to-three'],
-    to: '/upgrading/archive/upgrade-to-three',
   },
 ];

--- a/redirects.js
+++ b/redirects.js
@@ -10,13 +10,13 @@ module.exports = [{
   },
   {
     // Moved in version 1.1.1, 2.1.0 and 2.9.0
-    from: ['/tutorials', '/tutorials/videos', '/tutorials/first-app'],
-    to: '/tutorials/tutorials/fundamentals',
+    from: ['/tutorials', '/tutorials/videos', '/tutorials/first-app', '/tutorials/tutorials/fundamentals'],
+    to: '/tutorials/fundamentals',
   },
   {
     // Moved in version 1.2.0
-    from: ['/concepts/database-communication'],
-    to: '/concepts/database/connection',
+    from: ['/concepts/database-communication', '/concepts/database/connection'],
+    to: '/concepts/data-and-the-database/database/connection',
   },
   {
     // Moved in version 2.1.0
@@ -35,13 +35,13 @@ module.exports = [{
   },
   {
     // Moved when scheduling was reorganized from a single page to a directory
-    from: ['/concepts/scheduling'],
-    to: '/concepts/scheduling/setup',
+    from: ['/concepts/scheduling', '/concepts/scheduling/setup'],
+    to: '/concepts/scheduling/overview',
   },
   {
     // Removed in version 4.0 together with the string-based future call API
     from: ['/concepts/scheduling/legacy'],
-    to: '/concepts/scheduling/setup',
+    to: '/concepts/scheduling/overview',
   },
   {
     from: ['/cloud/reference/cli/commands/secret'],
@@ -94,5 +94,260 @@ module.exports = [{
   {
     from: ['/cloud/reference/project-id'],
     to: '/cloud/reference/project-id-rules',
+  },
+  {
+    // Moved in version 4.0: the docs were regrouped into Concepts sections, the
+    // deployment and tutorial pages were reorganized, and older upgrade guides
+    // and the Serverpod Mini pages moved to the archive.
+    from: ['/concepts/authentication/providers/anonymous/configuration', '/concepts/authentication/providers/anonymous/customizing-the-ui'],
+    to: '/concepts/authentication/providers/anonymous/customizations',
+  },
+  {
+    from: ['/concepts/authentication/providers/apple/configuration', '/concepts/authentication/providers/apple/customizing-the-ui'],
+    to: '/concepts/authentication/providers/apple/customizations',
+  },
+  {
+    from: ['/concepts/authentication/providers/facebook/configuration', '/concepts/authentication/providers/facebook/customizing-the-ui'],
+    to: '/concepts/authentication/providers/facebook/customizations',
+  },
+  {
+    from: ['/concepts/authentication/providers/github/configuration', '/concepts/authentication/providers/github/customizing-the-ui'],
+    to: '/concepts/authentication/providers/github/customizations',
+  },
+  {
+    from: ['/concepts/authentication/providers/google/configuration', '/concepts/authentication/providers/google/customizing-the-ui'],
+    to: '/concepts/authentication/providers/google/customizations',
+  },
+  {
+    from: ['/concepts/authentication/providers/microsoft/configuration', '/concepts/authentication/providers/microsoft/customizing-the-ui'],
+    to: '/concepts/authentication/providers/microsoft/customizations',
+  },
+  {
+    from: ['/concepts/authentication/providers/passkey/customizing-the-ui'],
+    to: '/concepts/authentication/providers/passkey/setup',
+  },
+  {
+    from: ['/concepts/database/crud'],
+    to: '/concepts/data-and-the-database/database/crud',
+  },
+  {
+    from: ['/concepts/database/indexing'],
+    to: '/concepts/data-and-the-database/database/indexing',
+  },
+  {
+    from: ['/concepts/database/migrations'],
+    to: '/concepts/data-and-the-database/database/migrations',
+  },
+  {
+    from: ['/concepts/database/pagination'],
+    to: '/concepts/data-and-the-database/database/pagination',
+  },
+  {
+    from: ['/concepts/database/raw-access'],
+    to: '/concepts/data-and-the-database/database/raw-access',
+  },
+  {
+    from: ['/concepts/database/relation-queries'],
+    to: '/concepts/data-and-the-database/database/relation-queries',
+  },
+  {
+    from: ['/concepts/database/row-locking'],
+    to: '/concepts/data-and-the-database/database/row-locking',
+  },
+  {
+    from: ['/concepts/database/runtime-parameters'],
+    to: '/concepts/data-and-the-database/database/runtime-parameters',
+  },
+  {
+    from: ['/concepts/database/transactions'],
+    to: '/concepts/data-and-the-database/database/transactions',
+  },
+  {
+    from: ['/concepts/database/filter'],
+    to: '/concepts/data-and-the-database/database/filtering',
+  },
+  {
+    from: ['/concepts/database/sort'],
+    to: '/concepts/data-and-the-database/database/sorting',
+  },
+  {
+    from: ['/concepts/database/models'],
+    to: '/concepts/data-and-the-database/database/tables',
+  },
+  {
+    from: ['/concepts/database/relations/many-to-many'],
+    to: '/concepts/data-and-the-database/database/relations/many-to-many',
+  },
+  {
+    from: ['/concepts/database/relations/modules'],
+    to: '/concepts/data-and-the-database/database/relations/modules',
+  },
+  {
+    from: ['/concepts/database/relations/one-to-many'],
+    to: '/concepts/data-and-the-database/database/relations/one-to-many',
+  },
+  {
+    from: ['/concepts/database/relations/one-to-one'],
+    to: '/concepts/data-and-the-database/database/relations/one-to-one',
+  },
+  {
+    from: ['/concepts/database/relations/referential-actions'],
+    to: '/concepts/data-and-the-database/database/relations/referential-actions',
+  },
+  {
+    from: ['/concepts/database/relations/self-relations'],
+    to: '/concepts/data-and-the-database/database/relations/self-relations',
+  },
+  {
+    from: ['/concepts/working-with-endpoints'],
+    to: '/concepts/endpoints-and-apis',
+  },
+  {
+    from: ['/concepts/backward-compatibility'],
+    to: '/concepts/endpoints-and-apis/backward-compatibility',
+  },
+  {
+    from: ['/concepts/caching'],
+    to: '/concepts/endpoints-and-apis/caching',
+  },
+  {
+    from: ['/concepts/file-uploads'],
+    to: '/concepts/endpoints-and-apis/file-uploads',
+  },
+  {
+    from: ['/concepts/server-events'],
+    to: '/concepts/endpoints-and-apis/server-events',
+  },
+  {
+    from: ['/concepts/sessions'],
+    to: '/concepts/endpoints-and-apis/sessions',
+  },
+  {
+    from: ['/concepts/streams'],
+    to: '/concepts/endpoints-and-apis/streaming',
+  },
+  {
+    from: ['/concepts/exceptions'],
+    to: '/concepts/endpoints-and-apis/error-handling-and-exceptions',
+  },
+  {
+    from: ['/concepts/models'],
+    to: '/concepts/data-and-the-database/models',
+  },
+  {
+    from: ['/concepts/serialization'],
+    to: '/concepts/data-and-the-database/models/custom-serialization',
+  },
+  {
+    from: ['/concepts/shared-packages'],
+    to: '/concepts/data-and-the-database/models/shared-packages',
+  },
+  {
+    from: ['/concepts/configuration', '/concepts/experimental'],
+    to: '/concepts/server-fundamentals/configuration',
+  },
+  {
+    from: ['/concepts/modules'],
+    to: '/concepts/server-fundamentals/modules',
+  },
+  {
+    from: ['/concepts/health-checks'],
+    to: '/concepts/operations/health-checks',
+  },
+  {
+    from: ['/concepts/logging'],
+    to: '/concepts/operations/logging',
+  },
+  {
+    from: ['/concepts/security-configuration'],
+    to: '/concepts/operations/security-and-tls',
+  },
+  {
+    from: ['/concepts/scheduling/recurring-task'],
+    to: '/concepts/scheduling/recurring-tasks',
+  },
+  {
+    from: ['/concepts/testing/the-basics'],
+    to: '/concepts/testing/get-started',
+  },
+  {
+    from: ['/concepts/testing/best-practises'],
+    to: '/concepts/testing/best-practices',
+  },
+  {
+    from: ['/concepts/webserver/flutter-web'],
+    to: '/concepts/web-server/flutter-web',
+  },
+  {
+    from: ['/concepts/webserver/overview'],
+    to: '/concepts/web-server/overview',
+  },
+  {
+    from: ['/concepts/webserver/request-data'],
+    to: '/concepts/web-server/request-data',
+  },
+  {
+    from: ['/concepts/webserver/routing'],
+    to: '/concepts/web-server/routing',
+  },
+  {
+    from: ['/concepts/webserver/server-side-html'],
+    to: '/concepts/web-server/server-side-html',
+  },
+  {
+    from: ['/concepts/webserver/single-page-apps'],
+    to: '/concepts/web-server/single-page-apps',
+  },
+  {
+    from: ['/concepts/webserver/static-files'],
+    to: '/concepts/web-server/static-files',
+  },
+  {
+    from: ['/concepts/webserver/middleware'],
+    to: '/concepts/web-server/web-server-middleware',
+  },
+  {
+    from: ['/deployments/deployment-strategy'],
+    to: '/deployments/custom-hosting/choosing-a-strategy',
+  },
+  {
+    from: ['/deployments/general', '/deployments/deploying-to-aws', '/deployments/deploying-to-gce-terraform', '/deployments/deploying-to-gcr-console'],
+    to: '/deployments/custom-hosting/hosting-elsewhere',
+  },
+  {
+    from: ['/deployments/community-supported-deployments'],
+    to: '/deployments/custom-hosting/community-supported',
+  },
+  {
+    from: ['/overview'],
+    to: '/how-it-works',
+  },
+  {
+    from: ['/serverpod-mini'],
+    to: '/upgrading/archive/upgrade-from-mini',
+  },
+  {
+    from: ['/tutorials/academy'],
+    to: '/serverpod-academy',
+  },
+  {
+    from: ['/tutorials/tutorials/ai-and-rag'],
+    to: '/tutorials/ai-and-rag',
+  },
+  {
+    from: ['/tutorials/tutorials/real-time-communication'],
+    to: '/tutorials/real-time-communication',
+  },
+  {
+    from: ['/upgrading/upgrade-from-mini'],
+    to: '/upgrading/archive/upgrade-from-mini',
+  },
+  {
+    from: ['/upgrading/upgrade-to-pgvector'],
+    to: '/upgrading/archive/upgrade-to-pgvector',
+  },
+  {
+    from: ['/upgrading/upgrade-to-three'],
+    to: '/upgrading/archive/upgrade-to-three',
   },
 ];


### PR DESCRIPTION
- **SDK minimums** (#802): the upgrade guide, legacy-auth migration guide, and shared-packages page said Dart 3.10.3; 4.0 packages require `^3.12.2` and Flutter `^3.44.4` (confirmed on pub.dev). The Dockerfile note names the `dart:3.12.2` base image and the installation page now states the minimum.
- **`.spy.yaml` requirement** (#801): the models page claimed plain `.yaml` model files were supported; they are ignored with an error in 4.0. Renamed the 26 `# name.yaml` header comments in the relations pages and added an upgrade-guide subsection quoting the CLI error.
- **Remaining breaking changes** (#803): the upgrade guide covered 4 of 16. Added an "Other breaking changes" section for the message-central default, both exception hierarchies, the `CloudStorage` options merge, Google web sign-in, the removed deprecated APIs, and the Postgres image, each linking to its concept page. Also notes that `serverpod generate` must precede the migration step, and lists account merging under "What's new".

Markdownlint passes on all changed Markdown files.

Fixes #801, fixes #802, fixes #803.